### PR TITLE
Hide named hostname, server-id and version

### DIFF
--- a/install/ubuntu/18.04/bind/named.conf.options
+++ b/install/ubuntu/18.04/bind/named.conf.options
@@ -1,0 +1,28 @@
+options {
+        directory "/var/cache/bind";
+
+        // If there is a firewall between you and nameservers you want
+        // to talk to, you may need to fix the firewall to allow multiple
+        // ports to talk.  See http://www.kb.cert.org/vuls/id/800113
+
+        // If your ISP provided one or more IP addresses for stable
+        // nameservers, you probably want to use them as forwarders.
+        // Uncomment the following block, and insert the addresses replacing
+        // the all-0's placeholder.
+
+        // forwarders {
+        //      0.0.0.0;
+        // };
+
+        //========================================================================
+        // If BIND logs error messages about the root key being expired,
+        // you will need to update your keys.  See https://www.isc.org/bind-keys
+        //========================================================================
+        dnssec-validation auto;
+        auth-nxdomain no;
+        allow-recursion { 127.0.0.1; ::1; };
+        allow-transfer {"none";};
+        hostname none;
+        server-id none;
+        version none;
+};


### PR DESCRIPTION
Needs to replace /etc/bind/named.conf.options after installation