### PR TITLE
Fix for "Connection to storage server failed." dovecot error

### DIFF
--- a/install/ubuntu/16.04/dovecot/dovecot.conf
+++ b/install/ubuntu/16.04/dovecot/dovecot.conf
@@ -7,7 +7,7 @@ login_greeting = Mail Delivery Agent
 namespace {
     type = private
     separator = /
-    prefix = /mail
+    prefix = mail/
     inbox = yes
     list = no
 

--- a/install/ubuntu/16.04/dovecot/dovecot.conf
+++ b/install/ubuntu/16.04/dovecot/dovecot.conf
@@ -7,8 +7,9 @@ login_greeting = Mail Delivery Agent
 namespace {
     type = private
     separator = /
-    prefix =
+    prefix = /mail
     inbox = yes
+    list = no
 
     mailbox Sent {
         auto = subscribe

--- a/install/ubuntu/18.04/dovecot/dovecot.conf
+++ b/install/ubuntu/18.04/dovecot/dovecot.conf
@@ -7,8 +7,9 @@ login_greeting = Mail Delivery Agent
 namespace {
     type = private
     separator = /
-    prefix =
+    prefix = mail/
     inbox = yes
+    list = no
 
     mailbox Sent {
         auto = subscribe


### PR DESCRIPTION
This pull request contains fix for annoying [**Connection to storage server failed**](https://forum.vestacp.com/viewtopic.php?t=13539) dovecot error,  while user trying to login to Roundcube GUI. This fix is tested under Ubuntu 16.04.5