### PR TITLE
make the command works

### DIFF
--- a/install/debian/8/nginx/nginx.conf
+++ b/install/debian/8/nginx/nginx.conf
@@ -103,7 +103,7 @@ http {
     #set_real_ip_from  2a06:98c0::/29;
     real_ip_header     CF-Connecting-IP;
 
-    #openssl dhparam 4096 -out /etc/ssl/dhparam.pem
+    #openssl dhparam 4096 > /etc/ssl/dhparam.pem
     #ssl_dhparam /etc/ssl/dhparam.pem;
 
     # SSL PCI Compliance

--- a/install/debian/9/nginx/nginx.conf
+++ b/install/debian/9/nginx/nginx.conf
@@ -103,7 +103,7 @@ http {
     #set_real_ip_from  2a06:98c0::/29;
     real_ip_header     CF-Connecting-IP;
 
-    #openssl dhparam 4096 -out /etc/ssl/dhparam.pem
+    #openssl dhparam 4096 > /etc/ssl/dhparam.pem
     #ssl_dhparam /etc/ssl/dhparam.pem;
 
     # SSL PCI Compliance

--- a/install/ubuntu/14.04/nginx/nginx.conf
+++ b/install/ubuntu/14.04/nginx/nginx.conf
@@ -103,7 +103,7 @@ http {
     #set_real_ip_from  2a06:98c0::/29;
     real_ip_header     CF-Connecting-IP;
 
-    #openssl dhparam 4096 -out /etc/ssl/dhparam.pem
+    #openssl dhparam 4096 > /etc/ssl/dhparam.pem
     #ssl_dhparam /etc/ssl/dhparam.pem;
 
     # SSL PCI Compliance

--- a/install/ubuntu/16.04/nginx/nginx.conf
+++ b/install/ubuntu/16.04/nginx/nginx.conf
@@ -103,7 +103,7 @@ http {
     #set_real_ip_from  2a06:98c0::/29;
     real_ip_header     CF-Connecting-IP;
 
-    #openssl dhparam 4096 -out /etc/ssl/dhparam.pem
+    #openssl dhparam 4096 > /etc/ssl/dhparam.pem
     #ssl_dhparam /etc/ssl/dhparam.pem;
 
     # SSL PCI Compliance

--- a/install/ubuntu/18.04/nginx/nginx.conf
+++ b/install/ubuntu/18.04/nginx/nginx.conf
@@ -103,7 +103,7 @@ http {
     #set_real_ip_from  2a06:98c0::/29;
     real_ip_header     CF-Connecting-IP;
 
-    #openssl dhparam 4096 -out /etc/ssl/dhparam.pem
+    #openssl dhparam 4096 > /etc/ssl/dhparam.pem
     #ssl_dhparam /etc/ssl/dhparam.pem;
 
     # SSL PCI Compliance


### PR DESCRIPTION
for an obscure reason I add to replace 
`openssl dhparam 4096 -o /etc/ssl/dhparam.pem` by `openssl dhparam 4096 > /etc/ssl/dhparam.pem`
unless the certificate was ending in the console and not in the file as expected.