### PR TITLE
Bugfix 0504-1 ForceSSL

### DIFF
--- a/bin/v-add-web-domain-ssl-force
+++ b/bin/v-add-web-domain-ssl-force
@@ -43,7 +43,7 @@ if [ "$SSL" != 'yes' ]; then
 fi
 
 # Check if proxy is active
-if [ ! -z "$PROXY_SYSTEM" ] || [ ! -z "$PROXY" ]; then
+if [ ! -z "$PROXY_SYSTEM" ]; then
     if ! grep --quiet "forcessl" $HESTIA/data/templates/web/nginx/default.tpl; then
         $BIN/v-update-web-templates
     fi
@@ -56,7 +56,7 @@ else
 fi
 
 # Insert redirect commands
-if [ ! -z $PROXY ]; then
+if [ ! -z "$PROXY_SYSTEM" ] || [ "$WEB_SYSTEM" = 'nginx' ]; then
     echo 'return 301 https://$host$request_uri;' > $forcessl
 else
     echo 'RewriteEngine On' > $forcessl

--- a/bin/v-add-web-domain-ssl-force
+++ b/bin/v-add-web-domain-ssl-force
@@ -68,6 +68,10 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
+if [ -z "$FORCESSL" ]; then
+    add_object_key "web" 'DOMAIN' "$domain" 'FORCESSL' 'SSL'
+fi
+
 # Set forcessl flag to enabled
 update_object_value 'web' 'DOMAIN' "$domain" '$FORCESSL' 'yes'
 

--- a/bin/v-delete-web-domain-ssl-force
+++ b/bin/v-delete-web-domain-ssl-force
@@ -49,6 +49,10 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
+if [ -z "$FORCESSL" ]; then
+    add_object_key "web" 'DOMAIN' "$domain" 'FORCESSL' 'SSL'
+fi
+
 update_object_value 'web' 'DOMAIN' "$domain" '$FORCESSL' 'no'
 
 # Restart services if requested

--- a/bin/v-delete-web-domain-ssl-force
+++ b/bin/v-delete-web-domain-ssl-force
@@ -38,8 +38,12 @@ is_object_valid 'web' 'DOMAIN' "$domain" "$FORCESSL"
 eval $(grep "DOMAIN='$domain'" $USER_DATA/web.conf)
 
 # Remove forcessl configs
-rm -f $HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.forcessl.conf
-rm -f $HOMEDIR/$user/conf/web/$domain/$PROXY_SYSTEM.forcessl.conf
+if [ -f $HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.forcessl.conf ]; then
+    rm -f $HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.forcessl.conf
+fi
+if [ -f $HOMEDIR/$user/conf/web/$domain/$PROXY_SYSTEM.forcessl.conf ]; then
+    rm -f $HOMEDIR/$user/conf/web/$domain/$PROXY_SYSTEM.forcessl.conf
+fi
 
 #----------------------------------------------------------#
 #                       Hestia                             #


### PR DESCRIPTION
- Forcessl could not be enabled if FORCESSl was missing from domain web.conf
- Nginx webserver was not detected.  
Fixes issue #282