### PR TITLE
Bugfix webmail alias

### DIFF
--- a/install/deb/templates/mail/nginx/default.stpl
+++ b/install/deb/templates/mail/nginx/default.stpl
@@ -5,7 +5,7 @@ server {
     ssl_certificate_key  %ssl_key%;
     root        /var/lib/roundcube;
     index       index.php;
-    
+
     location ~ /(config|temp|logs) {
         deny all;
         return 404;
@@ -21,7 +21,7 @@ server {
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
             alias /var/lib/roundcube/;
             expires 1h;
-            try_files $uri @fallback;
+            try_files $uri $uri/ index.php?$args @fallback;
         }
     }
 

--- a/install/deb/templates/mail/nginx/default.tpl
+++ b/install/deb/templates/mail/nginx/default.tpl
@@ -5,7 +5,7 @@ server {
     index       index.php;
 
     include %home%/%user%/conf/mail/%root_domain%/nginx.forcessl.conf*;
-    
+
     location ~ /(config|temp|logs) {
         deny all;
         return 404;
@@ -21,7 +21,7 @@ server {
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
             alias /var/lib/roundcube/;
             expires 1h;
-            try_files $uri @fallback;
+            try_files $uri $uri/ index.php?$args @fallback;
         }
     }
 

--- a/install/deb/templates/mail/nginx/web_system.stpl
+++ b/install/deb/templates/mail/nginx/web_system.stpl
@@ -5,7 +5,7 @@ server {
     ssl_certificate_key  %ssl_key%;
     root        /var/lib/roundcube;
     index       index.php;
-   
+
     location ~ /(config|temp|logs) {
         deny all;
         return 404;
@@ -21,6 +21,7 @@ server {
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
             expires 1h;
             fastcgi_hide_header "Set-Cookie";
+            try_files $uri $uri/ index.php?$args @fallback;
         }
     }
 

--- a/install/deb/templates/mail/nginx/web_system.stpl
+++ b/install/deb/templates/mail/nginx/web_system.stpl
@@ -21,9 +21,9 @@ location =/ {
         }
     
 	location / {
-        try_files $uri $uri/ /index.php?$args;
-        location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-            expires 90h;
+            
+	    location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
+            expires 90d;
             fastcgi_hide_header "Set-Cookie";
         }
     

--- a/install/deb/templates/mail/nginx/web_system.stpl
+++ b/install/deb/templates/mail/nginx/web_system.stpl
@@ -16,13 +16,17 @@ server {
         return 404;
     }
 
-    location / {
+location =/ {
+        try_files $uri $uri/ /index.php?$args;
+        }
+    
+	location / {
         try_files $uri $uri/ /index.php?$args;
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-            expires 1h;
+            expires 90h;
             fastcgi_hide_header "Set-Cookie";
-            try_files $uri $uri/ index.php?$args @fallback;
         }
+    
     }
 
     location ~ ^/(.*\.php)$ {

--- a/install/deb/templates/mail/nginx/web_system.tpl
+++ b/install/deb/templates/mail/nginx/web_system.tpl
@@ -15,13 +15,15 @@ server {
         deny all;
         return 404;
     }
-
-    location / {
+	
+	location =/ {
         try_files $uri $uri/ /index.php?$args;
+        }
+    
+	location / {
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-            expires 1h;
+            expires 90h;
             fastcgi_hide_header "Set-Cookie";
-            try_files $uri $uri/ index.php?$args @fallback;
         }
     }
 
@@ -32,15 +34,13 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $request_filename;
     }
+    location /error/ {
+        alias   %home%/%user%/web/%root_domain%/document_errors/;
+    }
 }
 
     error_page 403 /error/404.html;
     error_page 404 /error/404.html;
     error_page 500 502 503 504 /error/50x.html;
     
-    location /error/ {
-        alias   %home%/%user%/web/%root_domain%/document_errors/;
-    }
-
-    include %home%/%user%/conf/mail/%root_domain%/%web_system%.conf_*;
-}
+   include %home%/%user%/conf/mail/%root_domain%/%web_system%.conf_*;

--- a/install/deb/templates/mail/nginx/web_system.tpl
+++ b/install/deb/templates/mail/nginx/web_system.tpl
@@ -21,6 +21,7 @@ server {
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
             expires 1h;
             fastcgi_hide_header "Set-Cookie";
+            try_files $uri $uri/ index.php?$args @fallback;
         }
     }
 
@@ -31,7 +32,8 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $request_filename;
     }
-    
+}
+
     error_page 403 /error/404.html;
     error_page 404 /error/404.html;
     error_page 500 502 503 504 /error/50x.html;

--- a/install/deb/templates/mail/nginx/web_system.tpl
+++ b/install/deb/templates/mail/nginx/web_system.tpl
@@ -22,7 +22,7 @@ server {
     
 	location / {
         location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-            expires 90h;
+            expires 90d;
             fastcgi_hide_header "Set-Cookie";
         }
     }


### PR DESCRIPTION
Bugfix of nginx configuration for **nginx+PHP-FPM** webstack including increased browser caching time and web-alias bugfix. Works correctly on **nginx+PHP-FPM** now.