### PR TITLE
Fix infinite redirect loop

### DIFF
--- a/install/deb/templates/mail/nginx/web_system.stpl
+++ b/install/deb/templates/mail/nginx/web_system.stpl
@@ -61,8 +61,7 @@ server {
     error_page 500 502 503 504 505 /error/50x.html;
 
     location /error/ {
-        root        /var/www/document_errors/;
-        try_files   $uri $uri/;
+        alias        /var/www/document_errors/;
     }
 
     include %home%/%user%/conf/mail/%root_domain%/%web_system%.conf_*;

--- a/install/deb/templates/mail/nginx/web_system.tpl
+++ b/install/deb/templates/mail/nginx/web_system.tpl
@@ -61,8 +61,7 @@ server {
     error_page 500 502 503 504 505 /error/50x.html;
 
     location /error/ {
-        root        /var/www/document_errors/;
-        try_files   $uri $uri/;
+        alias       /var/www/document_errors/;
     }
 
     include %home%/%user%/conf/mail/%root_domain%/%web_system%.conf_*;


### PR DESCRIPTION
Remove `try_files   $uri $uri/; ` which caused redirect loop and #500 HTTP error finally.
Revert `root` statement to `alias`