### PR TITLE
Bugfix 0515

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -294,27 +294,27 @@ replace_web_config() {
 # Delete web configuration
 del_web_config() {
     conf="$HOMEDIR/$user/conf/web/$domain/$1.conf"
+    local confname="$domain.conf"
     if [[ "$2" =~ stpl$ ]]; then
         conf="$HOMEDIR/$user/conf/web/$domain/$1.ssl.conf"
+        confname="$domain.ssl.conf"
     fi
 
     # Remove domain configuration files and clean up symbolic links
-    if [ ! -z "$WEB_SYSTEM" ]; then
-        rm -f /etc/$WEB_SYSTEM/conf.d/domains/$domain.conf
-        rm -f /etc/$WEB_SYSTEM/conf.d/domains/$domain.ssl.conf
+    if [ ! -z "$WEB_SYSTEM" ] && [ "$WEB_SYSTEM" = "$1" ]; then
+        rm -f "/etc/$WEB_SYSTEM/conf.d/domains/$confname"
     fi
-    if [ ! -z "$PROXY_SYSTEM" ]; then
-        rm -f /etc/$PROXY_SYSTEM/conf.d/domains/$domain.conf 
-        rm -f /etc/$PROXY_SYSTEM/conf.d/domains/$domain.ssl.conf 
+    if [ ! -z "$PROXY_SYSTEM" ] && [ "$PROXY_SYSTEM" = "$1" ]; then
+        rm -f "/etc/$PROXY_SYSTEM/conf.d/domains/$confname"
     fi
 
     # Clean up legacy configuration files
     if [ ! -e "$conf" ]; then
-        conf="$HOMEDIR/$user/conf/web/$1.conf"
+        local legacyconf="$HOMEDIR/$user/conf/web/$1.conf"
         if [[ "$2" =~ stpl$ ]]; then
-            conf="$HOMEDIR/$user/conf/web/s$1.conf"
+            legacyconf="$HOMEDIR/$user/conf/web/s$1.conf"
         fi
-        rm -f $conf
+        rm -f $legacyconf
 
         # Remove old global includes file
         rm -f /etc/$1/conf.d/hestia.conf

--- a/install/deb/multiphp/apache2/PHP-56.sh
+++ b/install/deb/multiphp/apache2/PHP-56.sh
@@ -10,7 +10,7 @@ pool_conf="[$2]
 
 listen = /run/php/php5.6-fpm-$2.sock
 listen.owner = $1
-listen.group = $1
+listen.group = www-data
 listen.mode = 0660
 
 user = $1

--- a/install/deb/multiphp/apache2/PHP-70.sh
+++ b/install/deb/multiphp/apache2/PHP-70.sh
@@ -10,7 +10,7 @@ pool_conf="[$2]
 
 listen = /run/php/php7.0-fpm-$2.sock
 listen.owner = $1
-listen.group = $1
+listen.group = www-data
 listen.mode = 0660
 
 user = $1

--- a/install/deb/multiphp/apache2/PHP-71.sh
+++ b/install/deb/multiphp/apache2/PHP-71.sh
@@ -10,7 +10,7 @@ pool_conf="[$2]
 
 listen = /run/php/php7.1-fpm-$2.sock
 listen.owner = $1
-listen.group = $1
+listen.group = www-data
 listen.mode = 0660
 
 user = $1

--- a/install/deb/multiphp/apache2/PHP-72.sh
+++ b/install/deb/multiphp/apache2/PHP-72.sh
@@ -10,7 +10,7 @@ pool_conf="[$2]
 
 listen = /run/php/php7.2-fpm-$2.sock
 listen.owner = $1
-listen.group = $1
+listen.group = www-data
 listen.mode = 0660
 
 user = $1

--- a/install/deb/multiphp/apache2/PHP-73.sh
+++ b/install/deb/multiphp/apache2/PHP-73.sh
@@ -10,7 +10,7 @@ pool_conf="[$2]
 
 listen = /run/php/php7.3-fpm-$2.sock
 listen.owner = $1
-listen.group = $1
+listen.group = www-data
 listen.mode = 0660
 
 user = $1


### PR DESCRIPTION
- [apache+multiphp] php-fpm webserver permissions for apache templates
- [apache+nginx proxy] Apache symlink (/etc/apache2/conf.d/domains/example.tld.conf) is removed when adding/removing webalias 