### PR TITLE
Comply with HELO/EHLO standards

### DIFF
--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -324,7 +324,7 @@ begin transports
 
 remote_smtp:
   driver = smtp
-  helo_data = ${sender_address_domain}
+  helo_data = ${primary_hostname}
   dkim_domain = DKIM_DOMAIN
   dkim_selector = mail
   dkim_private_key = DKIM_PRIVATE_KEY


### PR DESCRIPTION
The name that a mail server announces in an outgoing email should also match the server it's being sent from and not the domain it's being sent from.

Some information on, as well as a way to find out if you have a correctly configured HELO/EHLO can be verified using this link:

https://www.abuseat.org/helocheck.html