### PR TITLE
Apache and PHP-FPM cause conflicts

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -263,6 +263,7 @@ set_default_lang 'en'
 # Checking software conflicts
 if [ "$multiphp" = 'yes' ]; then
     phpfpm='yes'
+    apache = 'no'
 fi
 if [ "$proftpd" = 'yes' ]; then
     vsftpd='no'


### PR DESCRIPTION
when you choose to install MultiPHP which depends on PHP-FPM, Apache can't be installed because Apache and PHP-FPM cause conflicts and there can only be one backend to Nginx either Apache or PHP-FPM.