### PR TITLE
Fix detection of Debian 10

### DIFF
--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -49,7 +49,7 @@ if [ -e "/etc/os-release" ]; then
             exit 1
         fi
     elif [ "$type" = "debian" ]; then
-        release=$(cat /etc/debian_version|grep -o [0-9]|head -n1)
+        release=$(cat /etc/debian_version|grep -o "[0-9]\{1,2\}"|head -n1)
         VERSION='debian'
     fi
 else


### PR DESCRIPTION
The Install script fails to detect Debian version 10, because grep only get one number which is 1 not 10, so using grep -o "[0-9]\{1,2\}"
should fix that problem.