### PR TITLE
Installation script fails on Debian 10

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -51,7 +51,7 @@ elif [ "$release" -eq 9 ]; then
         e2fslibs bsdutils e2fsprogs curl imagemagick fail2ban dnsutils
         bsdmainutils cron hestia hestia-nginx hestia-php expect libmail-dkim-perl
         unrar-free vim-common acl sysstat rsyslog setpriv"
-else
+elif [ "$release" -eq 10 ]; then
     software="nginx apache2 apache2-utils apache2-suexec-custom
         apache2-suexec-pristine libapache2-mod-fcgid libapache2-mod-php php
         php-common php-cgi php-mysql php-curl php-pgsql php-imap php-ldap php-apcu
@@ -62,7 +62,7 @@ else
         flex whois git idn zip sudo bc ftp lsof ntpdate rrdtool quota
         e2fslibs bsdutils e2fsprogs curl imagemagick fail2ban dnsutils
         bsdmainutils cron hestia hestia-nginx hestia-php expect libmail-dkim-perl
-        unrar-free vim-common acl sysstat rsyslog setpriv"
+        unrar-free vim-common acl sysstat rsyslog util-linux"
 fi
 
 # Defining help function


### PR DESCRIPTION
The installation script fails on Debian 10 because the packages list assigned to the variable "software" include "setpriv" which is not available in Debian 10 it was replaced with the package "util-linux", 
so the following line " 856  apt-get -y install $software > /dev/null 2>&1 &" fails quietly without any errors or warnings. it wasn't easy to figure out what the issue.