### PR TITLE
open_basedir amendments

### DIFF
--- a/install/deb/php-fpm/multiphp.tpl
+++ b/install/deb/php-fpm/multiphp.tpl
@@ -17,7 +17,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
-php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail
+php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 env[PATH] = /usr/local/bin:/usr/bin:/bin

--- a/install/deb/templates/web/php-fpm/default.tpl
+++ b/install/deb/templates/web/php-fpm/default.tpl
@@ -17,7 +17,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
-php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail
+php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 env[HOSTNAME] = $HOSTNAME

--- a/install/deb/templates/web/php-fpm/no-php.tpl
+++ b/install/deb/templates/web/php-fpm/no-php.tpl
@@ -1,17 +1,24 @@
+; origin-src: deb/templates/web/php-fpm/no-php.tpl
+
 ;[%backend%]
-;listen = /dev/null
+;listen = /var/run/php/%backend%.sock
+;listen.owner = %user%
+;listen.group = www-data
+;listen.mode = 0660
 
 ;user = %user%
 ;group = %user%
-
-;listen.owner = %user%
-;listen.group = www-data
 
 ;pm = ondemand
 ;pm.max_children = 8
 ;pm.max_requests = 4000
 ;pm.process_idle_timeout = 10s
 ;pm.status_path = /status
+
+;php_admin_value[upload_tmp_dir] = /home/%user%/tmp
+;php_admin_value[session.save_path] = /home/%user%/tmp
+;php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 ;env[HOSTNAME] = $HOSTNAME
 ;env[PATH] = /usr/local/bin:/usr/bin:/bin

--- a/install/deb/templates/web/php-fpm/socket.tpl
+++ b/install/deb/templates/web/php-fpm/socket.tpl
@@ -17,7 +17,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
-php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail
+php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 env[HOSTNAME] = $HOSTNAME


### PR DESCRIPTION
- Removed /etc/phpMyAdmin (kept /etc/phpmyadmin which is the one used in Ubuntu/Debian).
- Renamed /etc/roundcubemail to /etc/roundcube (dir used by Ubuntu/Debian)
- Added /var/lib/roundcube
- Added /opt (common dir for third party application installations)