### PR TITLE
Mail quota show

### DIFF
--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -62,7 +62,7 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
     if [ "$quota" = 'unlimited' ]; then
         quota='0'
     fi
-    str="$account:$md5:$user:mail::$HOMEDIR/$user:$quota"
+    str="$account:$md5:$user:mail::$HOMEDIR/$user::userdb_quota_rule=*:storage=${quota}M"
     echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 fi
 

--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -56,7 +56,7 @@ md5="{MD5}$($BIN/v-generate-password-hash md5 $salt <<<$password)"
 
 if [[ "$MAIL_SYSTEM" =~ exim ]]; then
     sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
-    str="$account:$md5:$user:mail::$HOMEDIR/$user:$quota"
+    str="$account:$md5:$user:mail::$HOMEDIR/$user::userdb_quota_rule=*:storage=${quota}M"
     echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 fi
 

--- a/bin/v-change-mail-account-quota
+++ b/bin/v-change-mail-account-quota
@@ -58,7 +58,7 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
         quota=0
     fi
     sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
-    str="$account:$md5:$user:mail::$HOMEDIR/$user:$quota"
+    str="$account:$md5:$user:mail::$HOMEDIR/$user::userdb_quota_rule=*:storage=${quota}M"
     echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 fi
 

--- a/install/deb/dovecot/conf.d/20-imap.conf
+++ b/install/deb/dovecot/conf.d/20-imap.conf
@@ -14,7 +14,7 @@ protocol imap {
 
   # Space separated list of plugins to load (default is global mail_plugins).
   #mail_plugins = $mail_plugins
-mail_plugins = quota imap_quota
+  mail_plugins = quota imap_quota
 
   # IMAP logout format string:
   #  %i - total number of bytes read from client

--- a/install/deb/dovecot/conf.d/20-imap.conf
+++ b/install/deb/dovecot/conf.d/20-imap.conf
@@ -14,6 +14,7 @@ protocol imap {
 
   # Space separated list of plugins to load (default is global mail_plugins).
   #mail_plugins = $mail_plugins
+mail_plugins = quota imap_quota
 
   # IMAP logout format string:
   #  %i - total number of bytes read from client

--- a/install/deb/dovecot/conf.d/20-pop3.conf
+++ b/install/deb/dovecot/conf.d/20-pop3.conf
@@ -78,6 +78,7 @@ protocol pop3 {
 
   # Space separated list of plugins to load (default is global mail_plugins).
   #mail_plugins = $mail_plugins
+mail_plugins = quota
 
   # Workarounds for various client bugs:
   #   outlook-no-nuls:

--- a/install/deb/dovecot/conf.d/20-pop3.conf
+++ b/install/deb/dovecot/conf.d/20-pop3.conf
@@ -78,7 +78,7 @@ protocol pop3 {
 
   # Space separated list of plugins to load (default is global mail_plugins).
   #mail_plugins = $mail_plugins
-mail_plugins = quota
+  mail_plugins = quota
 
   # Workarounds for various client bugs:
   #   outlook-no-nuls:

--- a/install/deb/dovecot/conf.d/90-quota.conf
+++ b/install/deb/dovecot/conf.d/90-quota.conf
@@ -1,0 +1,84 @@
+##
+## Quota configuration.
+##
+
+# Note that you also have to enable quota plugin in mail_plugins setting.
+# <doc/wiki/Quota.txt>
+
+##
+## Quota limits
+##
+
+# Quota limits are set using "quota_rule" parameters. To get per-user quota
+# limits, you can set/override them by returning "quota_rule" extra field
+# from userdb. It's also possible to give mailbox-specific limits, for example
+# to give additional 100 MB when saving to Trash:
+
+plugin {
+  #quota_rule = *:storage=1G
+  #quota_rule2 = Trash:storage=+100M
+
+  # LDA/LMTP allows saving the last mail to bring user from under quota to
+  # over quota, if the quota doesn't grow too high. Default is to allow as
+  # long as quota will stay under 10% above the limit. Also allowed e.g. 10M.
+  #quota_grace = 10%%
+
+  # Quota plugin can also limit the maximum accepted mail size.
+  #quota_max_mail_size = 100M
+}
+
+##
+## Quota warnings
+##
+
+# You can execute a given command when user exceeds a specified quota limit.
+# Each quota root has separate limits. Only the command for the first
+# exceeded limit is excecuted, so put the highest limit first.
+# The commands are executed via script service by connecting to the named
+# UNIX socket (quota-warning below).
+# Note that % needs to be escaped as %%, otherwise "% " expands to empty.
+
+plugin {
+  #quota_warning = storage=95%% quota-warning 95 %u
+  #quota_warning2 = storage=80%% quota-warning 80 %u
+}
+
+# Example quota-warning service. The unix listener's permissions should be
+# set in a way that mail processes can connect to it. Below example assumes
+# that mail processes run as vmail user. If you use mode=0666, all system users
+# can generate quota warnings to anyone.
+#service quota-warning {
+#  executable = script /usr/local/bin/quota-warning.sh
+#  user = dovecot
+#  unix_listener quota-warning {
+#    user = vmail
+#  }
+#}
+
+##
+## Quota backends
+##
+
+# Multiple backends are supported:
+#   dirsize: Find and sum all the files found from mail directory.
+#            Extremely SLOW with Maildir. It'll eat your CPU and disk I/O.
+#   dict: Keep quota stored in dictionary (eg. SQL)
+#   maildir: Maildir++ quota
+#   fs: Read-only support for filesystem quota
+
+plugin {
+  #quota = dirsize:User quota
+  quota = maildir:User quota
+  #quota = dict:User quota::proxy::quota
+  #quota = fs:User quota
+}
+
+# Multiple quota roots are also possible, for example this gives each user
+# their own 100MB quota and one shared 1GB quota within the domain:
+plugin {
+  #quota = dict:user::proxy::quota
+  #quota2 = dict:domain:%d:proxy::quota_domain
+  #quota_rule = *:storage=102400
+  #quota2_rule = *:storage=1048576
+}
+


### PR DESCRIPTION
This is one of the "corrections" I usually do an my Hestia installations. It allows me to view  in Roundcube and/or IMAP clients, a percentage of the mailbox used quota.

I found the proposed changes at [Vesta Forum](https://forum.vestacp.com/viewtopic.php?f=16&t=9197) and thought it might be useful to other people if I created this pull request.

About the new file `90-quota.conf` I just added the whole file. It may be possible to just add only the fraction of what's needed. For example
```
plugin {
  quota = maildir:User quota
}
```
P.S. This is my first pull request. I hope I understood correctly the project's Guidelines and Github's Help on how to create one. If I did something wrong, please don't hesitate to point it out to me.