### PR TITLE
Detect if it's LXC to bypass the netplan requirement

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -395,7 +395,7 @@ if [ ! -z "$conflicts" ] && [ -z "$force" ]; then
 fi
 
 # Check network configuration
-if [ -d /etc/netplan ] && [ -z "$force" ]; then
+if [ -d /etc/netplan ] && [ -z "$force" ] && [ $(systemd-detect-virt) == lxc ]; then
     if [ -z "$(ls -A /etc/netplan)" ]; then
         echo '!!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!'
         echo

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -362,7 +362,7 @@ if [ ! -z "$conflicts" ] && [ -z "$force" ]; then
 fi
 
 # Check network configuration
-if [ -d /etc/netplan ] && [ -z "$force" ]; then
+if [ -d /etc/netplan ] && [ -z "$force" ] && [ $(systemd-detect-virt) == lxc ]; then
     if [ -z "$(ls -A /etc/netplan)" ]; then
         echo '!!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!'
         echo


### PR DESCRIPTION
since proxmox don't use netplan it would be nice to simply detect if it's run inside a LXC and bypass this potential issue since hestia works perfectly inside a LXC container when you force the installation.
related to https://github.com/hestiacp/hestiacp/issues/175