### PR TITLE
Set cron to use root to run v-add-sys-sftp-jail

### DIFF
--- a/bin/v-add-sys-sftp-jail
+++ b/bin/v-add-sys-sftp-jail
@@ -73,7 +73,7 @@ done
 
 # Add v-add-sys-sftp-jail to startup
 if [ ! -e "/etc/cron.d/hestia-sftp" ]; then
-    echo "@reboot admin /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
+    echo "@reboot root /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
 fi
 
 #----------------------------------------------------------#

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1377,7 +1377,7 @@ if [ "$named" = 'yes' ]; then
     check_result $? "bind9 start failed"
 
     # Workaround for OpenVZ/Virtuozzo
-    if [ -e "/proc/vz/veinfo" ]; then
+    if [ -e "/proc/vz/veinfo" ] && [ -e "/etc/rc.local" ]; then
         sed -i "s/^exit 0/service bind9 restart\nexit 0/" /etc/rc.local
     fi
 fi

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1354,7 +1354,7 @@ if [ "$named" = 'yes' ]; then
     check_result $? "bind9 start failed"
 
     # Workaround for OpenVZ/Virtuozzo
-    if [ -e "/proc/vz/veinfo" ]; then
+    if [ -e "/proc/vz/veinfo" ] && [ -e "/etc/rc.local" ]; then
         sed -i "s/^exit 0/service bind9 restart\nexit 0/" /etc/rc.local
     fi
 fi

--- a/install/upgrade/versions/latest.sh
+++ b/install/upgrade/versions/latest.sh
@@ -71,8 +71,8 @@ fi
 
 # Fix sftp jail cronjob
 if [ -e "/etc/cron.d/hestia-sftp" ]; then
-    if ! cat /etc/cron.d/hestia-sftp | grep -q 'admin'; then
-        echo "@reboot admin /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
+    if ! cat /etc/cron.d/hestia-sftp | grep -q 'root'; then
+        echo "@reboot root /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
     fi
 fi
 


### PR DESCRIPTION
Fixes #673 

If we want to keep admin user for this command, we could alternatively use this instead:

`@reboot admin /usr/bin/sudo /usr/local/hestia/bin/v-add-sys-sftp-jail`