### PR TITLE
Set cron to use root to run v-add-sys-sftp-jail

### DIFF
--- a/bin/v-add-sys-sftp-jail
+++ b/bin/v-add-sys-sftp-jail
@@ -73,7 +73,7 @@ done
 
 # Add v-add-sys-sftp-jail to startup
 if [ ! -e "/etc/cron.d/hestia-sftp" ]; then
-    echo "@reboot admin /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
+    echo "@reboot root /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
 fi
 
 #----------------------------------------------------------#

--- a/install/upgrade/versions/latest.sh
+++ b/install/upgrade/versions/latest.sh
@@ -71,8 +71,8 @@ fi
 
 # Fix sftp jail cronjob
 if [ -e "/etc/cron.d/hestia-sftp" ]; then
-    if ! cat /etc/cron.d/hestia-sftp | grep -q 'admin'; then
-        echo "@reboot admin /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
+    if ! cat /etc/cron.d/hestia-sftp | grep -q 'root'; then
+        echo "@reboot root /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp
     fi
 fi
 


### PR DESCRIPTION
Resubmitted.

Fixes #673 

Could use the following instead if you want to keep the admin user:

`echo "@reboot admin /usr/bin/sudo /usr/local/hestia/bin/v-add-sys-sftp-jail" > /etc/cron.d/hestia-sftp`