### PR TITLE
fixes lograte bug and cleans up the messed up permissions

### DIFF
--- a/install/deb/logrotate/apache2
+++ b/install/deb/logrotate/apache2
@@ -5,7 +5,7 @@
     notifempty
     compress
     delaycompress
-    create 640 root adm
+    create 640
     sharedscripts
     postrotate
         /etc/init.d/apache2 reload > /dev/null || true

--- a/install/deb/logrotate/nginx
+++ b/install/deb/logrotate/nginx
@@ -5,7 +5,7 @@
     notifempty
     compress
     delaycompress
-    create 640 nginx adm
+    create 640
     sharedscripts
     postrotate
         [ -f /var/run/nginx.pid ] && kill -USR1 `cat /var/run/nginx.pid`


### PR DESCRIPTION
Should fix #666 

- Fixes the logrotate config files for apache and nginx for new installs and upgrades
- Fixes the ownership of all domains, sub-domains, and webmail aliases