### PR TITLE
WebUI tooltip correction when listing Packages

### DIFF
--- a/web/templates/admin/list_packages.html
+++ b/web/templates/admin/list_packages.html
@@ -51,7 +51,7 @@
                 <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-mail-bulk" title="<?php print __('Mail Domains');?>"></i></b></div>
                 <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-inbox" title="<?php print __('Mail Accounts');?>"></i></b></div>
                 <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-database" title="<?php print __('Databases');?>"></i></b></div>
-                <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-clock" title="<?php print __('Backups');?>"></i></b></div>
+                <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-clock" title="<?php print __('Cron Jobs');?>"></i></b></div>
            </div>
         </div>
 


### PR DESCRIPTION
In Hestia Web UI when listing the packages (/list/package/), the last icon (clock) at the top bar has wrong tool-tip text (Backups) instead of Cron Jobs.