### PR TITLE
Set util-linux package instead of setpriv command

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -40,7 +40,7 @@ software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
     php$fpm_v-mbstring php$fpm_v-opcache php$fpm_v-pspell php$fpm_v-readline
     php$fpm_v-xml postgresql postgresql-contrib proftpd-basic quota
     roundcube-core roundcube-mysql roundcube-plugins rrdtool rssh spamassassin
-    sudo hestia hestia-nginx hestia-php vim-common vsftpd whois zip acl sysstat setpriv"
+    sudo hestia hestia-nginx hestia-php vim-common vsftpd whois zip acl sysstat util-linux"
 
 # Defining help function
 help() {


### PR DESCRIPTION
The bug is because setpriv is declared as part of the packages to install (end of line #43), only that this command is not a package by itself, but is part of util-linux.

I corrected by changing the declaration to util-linux, instead of setpriv.