### PR TITLE
Fix: Infinite restart loop when server restart is invoked from the UI

### DIFF
--- a/web/restart/system/index.php
+++ b/web/restart/system/index.php
@@ -11,13 +11,29 @@ if ((!isset($_GET['token'])) || ($_SESSION['token'] != $_GET['token'])) {
     exit();
 }
 
-if ($_SESSION['user'] == 'admin') {
-    if (!empty($_GET['hostname'])) {
-        exec (HESTIA_CMD."v-restart-system yes", $output, $return_var);
-        $_SESSION['error_msg'] = 'The system is going down for reboot NOW!';
+// If the session has the same reset token as the current request prevent restarting again.
+// This happens when the server is restarted, the admin panel goes down and the browser reloads
+// the /restart/index.php page once the server goes online causing restart loop.
+$reset_token_dir = '/var/tmp/';
+if (isset($_GET['system_reset_token']) && is_numeric($_GET['system_reset_token'])) {
+    clearstatcache();
+    $reset_token_file = $reset_token_dir . 'hst_reset_' . $_GET['system_reset_token'];
+    if (file_exists($reset_token_file)) {
+        unlink($reset_token_file);
+        sleep(5);
+        header('location: /list/server/');
+        exit();
     }
-    unset($output);
+    if ($_SESSION['user'] == 'admin') {
+        if (!empty($_GET['hostname'])) {
+            touch($reset_token_file);
+            $_SESSION['error_msg'] = 'The system is going down for reboot NOW!';
+            touch($reset_token_file . '_persistent');
+            exec(HESTIA_CMD . "v-restart-system yes", $output, $return_var);
+        }
+        unset($output);
+    }
 }
 
 header("Location: /list/server/");
-exit;
+exit();

--- a/web/restart/system/index.php
+++ b/web/restart/system/index.php
@@ -11,9 +11,9 @@ if ((!isset($_GET['token'])) || ($_SESSION['token'] != $_GET['token'])) {
     exit();
 }
 
-// If the session has the same reset token as the current request prevent restarting again.
-// This happens when the server is restarted, the admin panel goes down and the browser reloads
-// the /restart/index.php page once the server goes online causing restart loop.
+// If the stored reset token matches the current request one it means that we need 
+// to prevent the action because the browser automatically reloaded the page when 
+// the server turned on. This will prevent duplicate restarts.
 $reset_token_dir = '/var/tmp/';
 if (isset($_GET['system_reset_token']) && is_numeric($_GET['system_reset_token'])) {
     clearstatcache();
@@ -28,7 +28,6 @@ if (isset($_GET['system_reset_token']) && is_numeric($_GET['system_reset_token']
         if (!empty($_GET['hostname'])) {
             touch($reset_token_file);
             $_SESSION['error_msg'] = 'The system is going down for reboot NOW!';
-            touch($reset_token_file . '_persistent');
             exec(HESTIA_CMD . "v-restart-system yes", $output, $return_var);
         }
         unset($output);

--- a/web/templates/admin/list_services.html
+++ b/web/templates/admin/list_services.html
@@ -10,7 +10,7 @@
               <a class="data-controls do_servicerestart ui-button danger cancel" title="<?=__('Restart')?>">
                 <i class="do_servicerestart fas fa-undo status-icon red"></i>
                 <?=__('Restart')?>
-                <input type="hidden" name="servicerestart_url" value="/restart/system/?hostname=<?php echo $sys['sysinfo']['HOSTNAME'] ?>&token=<?=$_SESSION['token']?>" />
+                <input type="hidden" name="servicerestart_url" value="/restart/system/?hostname=<?php echo $sys['sysinfo']['HOSTNAME'] ?>&token=<?=$_SESSION['token']?>&system_reset_token=<?php echo time(); ?>" />
                   <div class="confirmation-text-servicerestart hidden" title="<?=__('Confirmation')?>">
                     <p class="confirmation"><?=__('RESTART_CONFIRMATION', 'Server')?></p>
                   </div>


### PR DESCRIPTION
This fixes issue #454

The problem is caused when you hit "Restart" button then the server and the page go offline as expected. Once the server is back again the browser attempts to reload the /restart/index.php... url and that way it causes another restart. If you keep the tab open this will repeat.