### PR TITLE
Feature DNS TTL #494

### DIFF
--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add dns record
-# options: USER DOMAIN RECORD TYPE VALUE [PRIORITY] [ID] [RESTART]
+# options: USER DOMAIN RECORD TYPE VALUE [PRIORITY] [ID] [RESTART] [TTL]
 #
 # The call is used for adding new DNS record. Complex records of TXT, MX and
 # SRV types can be used by a filling in the 'value' argument. The function also
@@ -23,6 +23,10 @@ dvalue=$(idn -t --quiet -u "$5" )
 priority=$6
 id=$7
 restart=$8
+ttl=$9
+
+echo "$8 $7 $9"
+
 if [ -z "$priority" ]; then
     priority=10
 fi
@@ -99,7 +103,7 @@ date=$(echo "$time_n_date" |cut -f 2 -d \ )
 # Adding record
 zone="$USER_DATA/dns/$domain.conf"
 dns_rec="ID='$id' RECORD='$record' TYPE='$rtype' PRIORITY='$priority'"
-dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date'"
+dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date' TTL='$ttl'"
 echo "$dns_rec" >> $zone
 chmod 660 $zone
 

--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -25,8 +25,6 @@ id=$7
 restart=$8
 ttl=$9
 
-echo "$8 $7 $9"
-
 if [ -z "$priority" ]; then
     priority=10
 fi

--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -101,9 +101,15 @@ date=$(echo "$time_n_date" |cut -f 2 -d \ )
 
 # Adding record
 zone="$USER_DATA/dns/$domain.conf"
-dns_rec="ID='$id' RECORD='$record' TYPE='$rtype' PRIORITY='$priority'"
-dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date' TTL='$ttl'"
-echo "$dns_rec" >> $zone
+if [ "$ttl" == '' ]; then
+    dns_rec="ID='$id' RECORD='$record' TYPE='$rtype' PRIORITY='$priority'"
+    dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date'"
+    echo "$dns_rec" >> $zone;
+    else
+    dns_rec="ID='$id' RECORD='$record' TYPE='$rtype' PRIORITY='$priority'"
+    dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date' TTL='$ttl'"
+    echo "$dns_rec" >> $zone
+fi 
 chmod 660 $zone
 
 # Sorting records

--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -73,7 +73,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '5' "$#" 'USER DOMAIN RECORD TYPE VALUE [PRIORITY] [ID] [RESTART]'
+check_args '5' "$#" 'USER DOMAIN RECORD TYPE VALUE [PRIORITY] [ID] [RESTART] [TTL]'
 is_format_valid 'user' 'domain' 'record' 'rtype' 'dvalue'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
@@ -86,6 +86,7 @@ is_format_valid 'id'
 is_object_new "dns/$domain" 'ID' "$id"
 is_dns_fqnd "$rtype" "$dvalue"
 is_dns_nameserver_valid "$domain" "$rtype" "$dvalue"
+is_format_valid 'ttl'
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-change-dns-record
+++ b/bin/v-change-dns-record
@@ -36,7 +36,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '6' "$#" 'USER DOMAIN ID RECORD TYPE VALUE [PRIORITY] [RESTART]'
+check_args '6' "$#" 'USER DOMAIN ID RECORD TYPE VALUE [PRIORITY] [RESTART] [TTL]'
 is_format_valid 'user' 'domain' 'id' 'record' 'type' 'dvalue'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
@@ -44,6 +44,7 @@ is_object_unsuspended 'user' 'USER' "$user"
 is_object_valid 'dns' 'DOMAIN' "$domain"
 is_object_unsuspended 'dns' 'DOMAIN' "$domain"
 is_object_valid "dns/$domain" 'ID' "$id"
+is_format_valid 'ttl'
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-change-dns-record
+++ b/bin/v-change-dns-record
@@ -84,9 +84,16 @@ time=$(echo "$time_n_date" |cut -f 1 -d \ )
 date=$(echo "$time_n_date" |cut -f 2 -d \ )
 
 # Adding record
-dns_rec="ID='$id' RECORD='$record' TYPE='$type' PRIORITY='$priority'"
-dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date' TTL='$ttl'"
-echo "$dns_rec" >> $USER_DATA/dns/$domain.conf
+zone="$USER_DATA/dns/$domain.conf"
+if [ "$ttl" == '' ]; then
+    dns_rec="ID='$id' RECORD='$record' TYPE='$rtype' PRIORITY='$priority'"
+    dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date'"
+    echo "$dns_rec" >> $zone;
+    else
+    dns_rec="ID='$id' RECORD='$record' TYPE='$rtype' PRIORITY='$priority'"
+    dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date' TTL='$ttl'"
+    echo "$dns_rec" >> $zone
+fi 
 
 # Sorting records
 sort_dns_records

--- a/bin/v-change-dns-record
+++ b/bin/v-change-dns-record
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change dns domain record
-# options: USER DOMAIN ID VALUE [PRIORITY] [RESTART]
+# options: USER DOMAIN ID VALUE [PRIORITY] [RESTART] [TTL]
 #
 # The function for changing DNS record.
 
@@ -19,6 +19,7 @@ type=$5
 dvalue=$(idn -t --quiet -u "$6" )
 priority=$7
 restart=$8
+ttl=$9
 
 # Includes
 source $HESTIA/func/main.sh
@@ -83,7 +84,7 @@ date=$(echo "$time_n_date" |cut -f 2 -d \ )
 
 # Adding record
 dns_rec="ID='$id' RECORD='$record' TYPE='$type' PRIORITY='$priority'"
-dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date'"
+dns_rec="$dns_rec VALUE='$dvalue' SUSPENDED='no' TIME='$time' DATE='$date' TTL='$ttl'"
 echo "$dns_rec" >> $USER_DATA/dns/$domain.conf
 
 # Sorting records

--- a/bin/v-list-dns-records
+++ b/bin/v-list-dns-records
@@ -34,7 +34,8 @@ json_list() {
         "ID": "'$ID'",
         "SUSPENDED": "'$SUSPENDED'",
         "TIME": "'$TIME'",
-        "DATE": "'$DATE'"
+        "DATE": "'$DATE'",
+        "TTL": "'$TTL'"
     }'
         if [ "$i" -lt "$objects" ]; then
             echo ','
@@ -49,11 +50,11 @@ json_list() {
 # SHELL list function
 shell_list() {
     IFS=$'\n'
-    echo "ID^RECORD^TYPE^VALUE^DATE"
-    echo "--^------^----^-----^----"
+    echo "ID^RECORD^TYPE^VALUE^DATE^TTL"
+    echo "--^------^----^-----^----^----"
     while read str; do
         parse_object_kv_list "$str"
-        echo "$ID^$RECORD^$TYPE^${VALUE:0:30}^$DATE"
+        echo "$ID^$RECORD^$TYPE^${VALUE:0:30}^$DATE^$TTL"
     done < <(cat $USER_DATA/dns/$domain.conf)
 }
 
@@ -64,19 +65,19 @@ plain_list() {
         parse_object_kv_list "$str"
         VALUE=$(echo "$VALUE" |sed -e "s/%quote%/\\'/g")
         echo -ne "$ID\t$RECORD\t$TYPE\t$PRIORITY\t$VALUE\t"
-        echo -e "$SUSPENDED\t$TIME\t$DATE"
+        echo -e "$SUSPENDED\t$TIME\t$DATE\t$TTL"
     done < <(cat $USER_DATA/dns/$domain.conf)
 }
 
 # CSV list function
 csv_list() {
     IFS=$'\n'
-    echo "ID,RECORD,TYPE,PRIORITY,VALUE,SUSPENDED,TIME,DATE"
+    echo "ID,RECORD,TYPE,PRIORITY,VALUE,SUSPENDED,TIME,DATE,TTL"
     while read str; do
         parse_object_kv_list "$str"
         VALUE=$(echo "$VALUE" |sed -e "s/%quote%/\\'/g")
         echo -n "$ID,$RECORD,$TYPE,$PRIORITY,\"$VALUE\","
-        echo "$SUSPENDED,$TIME,$DATE"
+        echo "$SUSPENDED,$TIME,$DATE,$TTL"
     done < <(cat $USER_DATA/dns/$domain.conf)
 }
 

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -115,7 +115,6 @@ if (!empty($_POST['ok_rec'])) {
         }
         $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
     }
-    
 
     // Protect input
     $v_domain = escapeshellarg($_POST['v_domain']);
@@ -124,7 +123,6 @@ if (!empty($_POST['ok_rec'])) {
     $v_val = escapeshellarg($_POST['v_val']);
     $v_priority = escapeshellarg($_POST['v_priority']);
     $v_ttl = escapeshellarg($_POST['v_ttl']);
-    
 
     // Add dns record
     if (empty($_SESSION['error_msg'])) {

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -115,6 +115,7 @@ if (!empty($_POST['ok_rec'])) {
         }
         $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
     }
+    
 
     // Protect input
     $v_domain = escapeshellarg($_POST['v_domain']);
@@ -122,10 +123,12 @@ if (!empty($_POST['ok_rec'])) {
     $v_type = escapeshellarg($_POST['v_type']);
     $v_val = escapeshellarg($_POST['v_val']);
     $v_priority = escapeshellarg($_POST['v_priority']);
+    $v_ttl = escapeshellarg($_POST['v_ttl']);
+    
 
     // Add dns record
     if (empty($_SESSION['error_msg'])) {
-        exec (HESTIA_CMD."v-add-dns-record ".$user." ".$v_domain." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority, $output, $return_var);
+        exec (HESTIA_CMD."v-add-dns-record ".$user." ".$v_domain." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority." '' false ".$v_ttl, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
         $v_type = $_POST['v_type'];

--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -161,12 +161,14 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['reco
     $v_record_id = escapeshellarg($_POST['v_record_id']);
 
     // Change dns record
-    if (($v_rec != $_POST['v_rec']) || ($v_type != $_POST['v_type']) || ($v_val != $_POST['v_val']) || ($v_priority != $_POST['v_priority']) && (empty($_SESSION['error_msg']))) {
+    if (($v_rec != $_POST['v_rec']) || ($v_type != $_POST['v_type']) || ($v_val != $_POST['v_val']) || ($v_priority != $_POST['v_priority']) || ($v_ttl != $_POST['v_ttl']) && (empty($_SESSION['error_msg']))) {
         $v_rec = escapeshellarg($_POST['v_rec']);
         $v_type = escapeshellarg($_POST['v_type']);
         $v_val = escapeshellarg($_POST['v_val']);
         $v_priority = escapeshellarg($_POST['v_priority']);
-        exec (HESTIA_CMD."v-change-dns-record ".$v_username." ".$v_domain." ".$v_record_id." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority, $output, $return_var);
+        $v_ttl = escapeshellarg($_POST['v_ttl']);
+        
+        exec (HESTIA_CMD."v-change-dns-record ".$v_username." ".$v_domain." ".$v_record_id." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority." false ".$v_ttl, $output, $return_var);
         check_return_code($return_var,$output);
         $v_rec = $_POST['v_rec'];
         $v_type = $_POST['v_type'];

--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -79,7 +79,6 @@ if ((!empty($_GET['domain'])) && (!empty($_GET['record_id'])))  {
     $v_date = $data[$v_record_id]['DATE'];
     $v_time = $data[$v_record_id]['TIME'];
     $v_ttl = $data[$v_record_id]['TTL'];
-    
 }
 
 // Check POST request for dns domain

--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -169,7 +169,6 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['reco
         $v_val = escapeshellarg($_POST['v_val']);
         $v_priority = escapeshellarg($_POST['v_priority']);
         $v_ttl = escapeshellarg($_POST['v_ttl']);
-        
         exec (HESTIA_CMD."v-change-dns-record ".$v_username." ".$v_domain." ".$v_record_id." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority." false ".$v_ttl, $output, $return_var);
         check_return_code($return_var,$output);
         $v_rec = $_POST['v_rec'];

--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -78,6 +78,8 @@ if ((!empty($_GET['domain'])) && (!empty($_GET['record_id'])))  {
     }
     $v_date = $data[$v_record_id]['DATE'];
     $v_time = $data[$v_record_id]['TIME'];
+    $v_ttl = $data[$v_record_id]['TTL'];
+    
 }
 
 // Check POST request for dns domain

--- a/web/templates/admin/add_dns_rec.html
+++ b/web/templates/admin/add_dns_rec.html
@@ -120,6 +120,16 @@
                                     <input type="text" size="20" class="vst-input" name="v_priority" value="<?=htmlentities(trim($v_priority, "'"))?>">
                                 </td>
                             </tr>
+                            <tr>
+                                <td class="vst-text input-label">
+                                    <?php print __('TTL');?> <span class="optional">(<?php print __('optional');?>)</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <input type="text" size="20" class="vst-input" name="v_ttl" value="<?=htmlentities(trim($v_ttl, "'"))?>">
+                                </td>
+                            </tr>                            
                         </table>
                         <table class="data-col2">
                         </table>

--- a/web/templates/admin/edit_dns_rec.html
+++ b/web/templates/admin/edit_dns_rec.html
@@ -132,6 +132,16 @@
                             </tr>
                             <tr>
                                 <td class="vst-text input-label">
+                                    <?php print __('TTL');?> <span class="optional">(<?=__('optional');?>)</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <input type="text" size="20" class="vst-input" name="v_ttl" value="<?=htmlentities(trim($v_ttl, "'"))?>">
+                                </td>
+                            </tr>                            
+                            <tr>
+                                <td class="vst-text input-label">
                                     <?php print __('Record Number');?> <span class="optional">(<?=__('internal');?>)</span>
                                 </td>
                             </tr>

--- a/web/templates/admin/list_dns_rec.html
+++ b/web/templates/admin/list_dns_rec.html
@@ -47,7 +47,8 @@
           <div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
           <div class="clearfix l-unit__stat-col--left compact text-center"><b><?php print __('Type');?></b></div>
           <div class="clearfix l-unit__stat-col--left compact"><b><?php print __('Priority');?></b></div>
-          <div class="clearfix l-unit__stat-col--left wide-7"><b><?php print __('IP or Value');?></b></div>
+          <div class="clearfix l-unit__stat-col--left compact"><b><?php print __('TTL');?></b></div>
+          <div class="clearfix l-unit__stat-col--left wide-6"><b><?php print __('IP or Value');?></b></div>
         </div>
     </div>
 
@@ -92,7 +93,9 @@ v_unit_id="<?=$key?>" v_section="dns_rec">
             <!-- END QUICK ACTION TOOLBAR AREA -->
             <div class="clearfix l-unit__stat-col--left compact text-center"><b><?=$data[$key]['TYPE']?></b></div>
             <div class="clearfix l-unit__stat-col--left compact"><?=$data[$key]['PRIORITY']?>&nbsp;</div>
-            <div class="clearfix l-unit__stat-col--left wide-7"><?=htmlspecialchars($data[$key]['VALUE'], ENT_QUOTES, 'UTF-8')?></div>
+            <div class="clearfix l-unit__stat-col--left compact"><?php if($data[$key]['TTL'] == ''){ echo __('Default'); }else{ echo $data[$key]['TTL'];} ?></div>
+            
+            <div class="clearfix l-unit__stat-col--left wide-6"><?=htmlspecialchars($data[$key]['VALUE'], ENT_QUOTES, 'UTF-8')?></div>
           </div>
         </div>
       <?}?>


### PR DESCRIPTION
Was checking if it was possible to implement DNS sec. How ever found this issue also open and it was an "easy" fix

Preferred order:
1. User selected value for option (Via v-add-dns-record / v-change-dns-record)
2. Default Settings for Zone file

Due to backward compatibility the command for both add/change are the same as the old one how ever added TTL at the end

./v-add-dns-record  USER DOMAIN RECORD TYPE VALUE [PRIORITY] [ID] [RESTART] [TTL]

Currently don't know a easy fix for (Or creating a new bash file for it) to alter the order

TTL is in seconds same as the default settings