### PR TITLE
Fixes auto logout and 2FA issue when using Cloudflare

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -29,6 +29,11 @@ if(isset($_SERVER['HTTP_X_FORWARDED'])){
 if(isset($_SERVER['HTTP_FORWARDED'])){
     $user_combined_ip .=  '|'. $_SERVER['HTTP_FORWARDED'];
 }
+if(isset($_SERVER['HTTP_CF_CONNECTING_IP'])){
+    if(!empty($_SERVER['HTTP_CF_CONNECTING_IP'])){
+      $user_combined_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+    }
+}
 
 if(!isset($_SESSION['user_combined_ip'])){
     $_SESSION['user_combined_ip'] = $user_combined_ip;
@@ -348,10 +353,10 @@ function list_timezones() {
  * Explaination:
  * $_SESSION['DB_SYSTEM'] has 'mysql' value even if MariaDB is installed, so you can't figure out is it really MySQL or it's MariaDB.
  * So, this function will make it clear.
- * 
+ *
  * If MySQL is installed, function will return 'mysql' as a string.
  * If MariaDB is installed, function will return 'mariadb' as a string.
- * 
+ *
  * Hint: if you want to check if PostgreSQL is installed - check value of $_SESSION['DB_SYSTEM']
  *
  * @return string

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -38,6 +38,11 @@ if (isset($_POST['user']) && isset($_POST['password'])) {
     if(isset($_SESSION['token']) && isset($_POST['token']) && $_POST['token'] == $_SESSION['token']) {
         $v_user = escapeshellarg($_POST['user']);
         $v_ip = escapeshellarg($_SERVER['REMOTE_ADDR']);
+        if(isset($_SERVER['HTTP_CF_CONNECTING_IP'])){
+          if(!empty($_SERVER['HTTP_CF_CONNECTING_IP'])){
+            $v_ip = escapeshellarg($_SERVER['HTTP_CF_CONNECTING_IP']);
+          }
+        }
         if (isset($_POST['twofa'])) {
             $v_twofa = escapeshellarg($_POST['twofa']);
         }

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -8,28 +8,8 @@
                                     <a href="/"><img border=0 src="/images/logo.png" alt="Hestia Control Panel" style="margin: 20px; margin-top: 40px;" /></a>
                                 </td>
                                 <td style="padding: 40px 60px 0 0;">
-                                    <form method="post" action="/login/" >
+                                    <form method="post" action="/login/" id="form_login">
                                     <input type="hidden" name="token" value="<?php echo $_SESSION['token']; ?>">
-                                    <script>
-                                    function show2FA(str) {
-                                        if (str.length == 0) {
-                                            $('.twofa').fadeOut();
-                                            return;
-                                        } else {
-                                            var xmlhttp = new XMLHttpRequest();
-                                            xmlhttp.onreadystatechange = function() {
-                                                if (this.readyState == 4 && this.status == 200) {
-                                                    var x = document.getElementById("twofa");
-                                                    $('.twofa').fadeIn();
-                                                } else {
-                                                    $('.twofa').fadeOut();
-                                                }
-                                            };
-                                            xmlhttp.open("GET", "/inc/2fa/active.php?user=" + str, true);
-                                            xmlhttp.send();
-                                        }
-                                    }
-                                    </script>
                                     <table class="login-box">
                                         <tr>
                                             <td syle="padding: 12px 0 0 2px;" class="login-welcome">
@@ -43,7 +23,7 @@
                                         </tr>
                                         <tr>
                                             <td>
-                                                <input tabindex="1" type="text" size="20px" style="width:240px;" name="user" class="vst-input" onfocusout="show2FA(this.value)">
+                                                <input tabindex="1" type="text" size="20px" style="width:240px;" name="user" class="vst-input">
                                             </td>
                                         </tr>
                                         <tr>
@@ -100,5 +80,23 @@
                 </tr>
             </table>
         </center>
+        <script type="text/javascript">
+          $(document).ready(function () {
+          $('#form_login').on('input', 'input[name="user"]', function() {
+            var username = this.value;
+              $.ajax({
+                type: 'GET',
+                url: '/inc/2fa/active.php?user=' + username,
+                complete: function(xhr) {
+                  if(xhr.status == '200'){
+                    $('.twofa').show();
+                  }else if(xhr.status == '404'){
+                    $('.twofa').hide();
+                  }
+                }
+              });
+            });
+          });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
This commit fixes auto logout and 2FA issue when using Cloudflare as reported [here](https://forum.hestiacp.com/t/macos-safari-login-with-2fa-bug/791/1) and confirmed by OP to be fixed [here](https://forum.hestiacp.com/t/macos-safari-login-with-2fa-bug/791/23?u=rmjtechnologies) with the following changes:
1. Changed Javascript `onFocus` and `xmlhttp` request code with jQuery `on input` so that it is more reliable with auto-fill extensions.
2. Changed method of detecting user IP when Cloudflare is being used, this overwrites the `$user_combined_ip`  with `$_SERVER['HTTP_CF_CONNECTING_IP']` if it exists and is not empty.