### PR TITLE
Allow creating custom backend templates that still work with specific PHP versions

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -90,7 +90,7 @@ prepare_web_backend() {
     pool=$(find -L /etc/php/ -name "$domain.conf" -exec dirname {} \;)
     # Check if multiple-PHP installed
     regex="socket-(\d+)_(\d+)"
-    if [[ $backend_template =~ ^PHP-([0-9])\_([0-9])$ ]]; then
+    if [[ $backend_template =~ ^.*PHP-([0-9])\_([0-9])$ ]]; then
         backend_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
         pool=$(find -L /etc/php/$backend_version -type d \( -name "pool.d" -o -name "*fpm.d" \))
     else


### PR DESCRIPTION
Currently there is no way to create custom backend templates for specific PHP versions in the multi PHP configuration as it decides what PHP version to use based on the backend profile name (Currently its "PHP-7_0", "PHP-7_1", "PHP-7_2".. and so on). Any profile that is not exactly named as the examples before will always default to the latest PHP version, which is not always desired. (For example "MyBTemplate") 

This patch allows to set custom backend templates, while still allowing to use specific PHP versions for those backend templates in the form of "MyBTemplate-PHP-7_0" for PHP 7.0, "MyBTemplate-PHP-7_1" for PHP 7.1.