### PR TITLE
Feature: Extend firewall with support for ipset

### DIFF
--- a/bin/v-add-firewall-ipset
+++ b/bin/v-add-firewall-ipset
@@ -1,0 +1,171 @@
+#!/bin/bash
+# info: add firewall ipset
+# options: NAME [SOURCE] [IPVERSION] [AUTOUPDATE] [FORCE]
+#
+# The function adds new ipset to system firewall
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+ip_name=${1}
+data_source=${2}
+ip_version=${3-v4}
+autoupdate=${4-yes}
+force=${5-no}
+
+# Includes
+source $HESTIA/func/main.sh
+source $HESTIA/conf/hestia.conf
+
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+check_args '1' "$#" 'NAME [SOURCE] [IPVERSION] [AUTOUPDATE] [FORCE]'
+is_format_valid 'ip_name'
+is_boolean_format_valid "$autoupdate" 'bool (yes/no)'
+is_boolean_format_valid "$force" 'bool (yes/no)'
+is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
+
+ipset_hstobject='../../data/firewall/ipset'
+
+IPSET_BIN="$(which ipset)"
+IPSET_PATH="$HESTIA/data/firewall/ipset"
+
+if [ -z "$data_source" ]; then
+    if [ ! -f "${IPSET_PATH}.conf" ] || [[ ! $(grep "LISTNAME='$ip_name'" "${IPSET_PATH}.conf") ]]; then
+        check_args '2' "$#" 'NAME SOURCE [IPVERSION] [AUTOUPDATE] [FORCE]'
+    fi
+
+    data_source="$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ip_name" '$SOURCE')"
+    ip_version="$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ip_name" '$IP_VERSION')"
+else
+    is_object_new "$ipset_hstobject" 'LISTNAME' "$ip_name"
+fi
+
+if [ "$ip_version" != "v4" ] && [ "$ip_version" != "v6" ]; then
+    check_result $E_INVALID "invalid ip version, valid: (v4|v6)"
+fi
+
+if ! echo "$data_source" | egrep -q '^(https?|script|file):'; then
+    check_result $E_INVALID "invalid ipset source, valid: (http[s]://|script:|file:)"
+fi
+
+
+IPSET_FILE="${ip_name}.${ip_version}"
+IPSET_MIN_SIZE=10
+
+# Perform verification if read-only mode is enabled
+check_hestia_demo_mode
+
+# Install ipset package if missing
+if [ -z "$IPSET_BIN" ]; then
+    apt-get --quiet --yes install ipset > /dev/null
+    check_result $? "Installing ipset package"
+
+    IPSET_BIN="$(which ipset)"
+    check_result $? "ipset binary not found"
+fi
+
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+mkdir -p "$IPSET_PATH"
+
+# Generate ip lists file if missing or when forced
+if [ ! -f "${IPSET_PATH}/${IPSET_FILE}.iplist" ] || [ "$force" = "yes" ]; then
+
+    iplist_tempfile=$(mktemp)
+
+    if [[ "$data_source" =~ ^https?:// ]]; then
+
+        wget --tries=3 --timeout=15 --read-timeout=15 --waitretry=3 --no-dns-cache --quiet "$data_source" -O "$iplist_tempfile"
+        check_result $? "Downloading ip list"
+
+        # Advanced: execute script with the same basename for aditional pre-processing
+        # ex: 
+        if [ -x "${IPSET_PATH}/${IPSET_FILE}.sh" ]; then 
+            setpriv --clear-groups --reuid nobody --regid nogroup -- ${IPSET_PATH}/${IPSET_FILE}.sh "$ip_name" "$iplist_tempfile"
+        fi
+
+    elif [[ "$data_source" =~ ^script:/ ]]; then
+
+        # Generate the ip list file trough a external script
+        # ex: compiling a ip list from multiple sources on demand
+
+        if [ -x "${data_source#script:}" ]; then
+
+            setpriv --clear-groups --reuid nobody --regid nogroup -- ${data_source#script:} "$ip_name" > "$iplist_tempfile"
+            check_result $? "Running custom ip list update script"
+
+        fi
+
+    elif [[ "$data_source" =~ ^file:/ ]]; then
+
+        # Use a external ip-list file managed by other apps
+        # ex: Using a ip list that is continously updated
+
+        [ -f "${data_source#file:}" ] && cp -f "${data_source#file:}" "$iplist_tempfile"
+
+    fi
+
+    # Validate iplist file size
+    iplist_size=$(sed -r -e '/^#|^$/d' "$iplist_tempfile" | wc -l)
+    [[ "$iplist_size" -le $IPSET_MIN_SIZE ]] && check_result $E_INVALID "iplist file too small (<${IPSET_MIN_SIZE}), ignoring"
+    mv -f "$iplist_tempfile" "${IPSET_PATH}/${IPSET_FILE}.iplist"
+
+fi
+
+# Load ipset in kernel
+inet_ver="inet"
+[ "$ip_version" == "v6" ] && inet_ver="inet6"
+
+$IPSET_BIN create "$ip_name" -exist hash:net family $inet_ver
+$IPSET_BIN create "${ip_name}-tmp" -exist hash:net family $inet_ver
+$IPSET_BIN flush "${ip_name}-tmp"
+
+sed -rn -e '/^#|^$/d'  -e "s/^(.*)/add ${ip_name}-tmp \\1/p" "${IPSET_PATH}/${IPSET_FILE}.iplist" | $IPSET_BIN -quiet restore
+check_result $? "Populating ipset table"
+
+$IPSET_BIN swap "${ip_name}-tmp" "${ip_name}"
+$IPSET_BIN --quiet destroy "${ip_name}-tmp"
+
+
+# Generating timestamp
+time_n_date=$(date +'%T %F')
+time=$(echo "$time_n_date" |cut -f 1 -d \ )
+date=$(echo "$time_n_date" |cut -f 2 -d \ )
+
+if [ ! -f "${IPSET_PATH}.conf" ] || [ -z "$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ip_name" '$LISTNAME')" ]; then
+
+    # Concatenating rule
+    str="LISTNAME='$ip_name' IP_VERSION='$ip_version' SOURCE='$data_source'"
+    str="$str AUTOUPDATE='$autoupdate' SUSPENDED='no'"
+    str="$str TIME='$time' DATE='$date'"
+    echo "$str" >> $HESTIA/data/firewall/ipset.conf
+
+elif [ "$force" = "yes" ]; then
+
+    # update iplist last regen time
+    update_object_value "$ipset_hstobject" 'LISTNAME' "$ip_name" '$TIME' "$time"
+    update_object_value "$ipset_hstobject" 'LISTNAME' "$ip_name" '$DATE' "$date"
+
+fi
+
+# Changing permissions
+chmod 660 $HESTIA/data/firewall/ipset.conf
+chmod 660 "${IPSET_PATH}/${IPSET_FILE}.iplist"
+
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Logging
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/bin/v-add-firewall-ipset
+++ b/bin/v-add-firewall-ipset
@@ -125,14 +125,15 @@ inet_ver="inet"
 [ "$ip_version" == "v6" ] && inet_ver="inet6"
 
 $IPSET_BIN create "$ip_name" -exist hash:net family $inet_ver
-$IPSET_BIN create "${ip_name}-tmp" -exist hash:net family $inet_ver
+$IPSET_BIN -quiet destroy "${ip_name}-tmp"
+$IPSET_BIN create "${ip_name}-tmp" -exist hash:net family $inet_ver maxelem 1048576
 $IPSET_BIN flush "${ip_name}-tmp"
 
 sed -rn -e '/^#|^$/d'  -e "s/^(.*)/add ${ip_name}-tmp \\1/p" "${IPSET_PATH}/${IPSET_FILE}.iplist" | $IPSET_BIN -quiet restore
 check_result $? "Populating ipset table"
 
 $IPSET_BIN swap "${ip_name}-tmp" "${ip_name}"
-$IPSET_BIN --quiet destroy "${ip_name}-tmp"
+$IPSET_BIN -quiet destroy "${ip_name}-tmp"
 
 
 # Generating timestamp

--- a/bin/v-add-firewall-ipset
+++ b/bin/v-add-firewall-ipset
@@ -10,9 +10,9 @@
 
 ip_name=${1}
 data_source=${2}
-ip_version=${3-v4}
-autoupdate=${4-yes}
-force=${5-no}
+ip_version=${3:-v4}
+autoupdate=${4:-yes}
+force=${5:-no}
 
 # Includes
 source $HESTIA/func/main.sh
@@ -124,7 +124,7 @@ fi
 inet_ver="inet"
 [ "$ip_version" == "v6" ] && inet_ver="inet6"
 
-$IPSET_BIN create "$ip_name" -exist hash:net family $inet_ver
+$IPSET_BIN -quiet create -exist "$ip_name" hash:net family $inet_ver
 $IPSET_BIN -quiet destroy "${ip_name}-tmp"
 $IPSET_BIN create "${ip_name}-tmp" -exist hash:net family $inet_ver maxelem 1048576
 $IPSET_BIN flush "${ip_name}-tmp"

--- a/bin/v-add-firewall-rule
+++ b/bin/v-add-firewall-rule
@@ -47,13 +47,20 @@ sort_fw_rules() {
 #----------------------------------------------------------#
 
 check_args '3' "$#" 'ACTION IP PORT [PROTOCOL] [COMMENT] [RULE]'
-is_format_valid 'action' 'protocol' 'port_ext' 'ip'
+is_format_valid 'action' 'protocol' 'port_ext'
 is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
 get_next_fw_rule
 is_format_valid 'rule'
 is_object_new '../../data/firewall/rules' 'RULE' "$rule"
 if [ ! -z "$comment" ]; then
     is_format_valid 'comment'
+fi
+if [[ "$ip" =~ ^ipset: ]]; then
+    ipset_name="${ip#ipset:}"
+    v-list-firewall-ipset plain | grep "^$ipset_name\s" >/dev/null
+    check_result $? 'ipset object not found' $E_NOTEXIST
+else
+    is_format_valid 'ip'
 fi
 
 # Perform verification if read-only mode is enabled

--- a/bin/v-change-firewall-rule
+++ b/bin/v-change-firewall-rule
@@ -40,12 +40,20 @@ sort_fw_rules() {
 #----------------------------------------------------------#
 
 check_args '5' "$#" 'RULE ACTION IP  PORT [PROTOCOL] [COMMENT]'
-is_format_valid 'rule' 'action' 'protocol' 'port_ext' 'ip'
+is_format_valid 'rule' 'action' 'protocol' 'port_ext'
 if [ ! -z "$comment" ]; then
     is_format_valid 'comment'
 fi
 is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
 is_object_valid '../../data/firewall/rules' 'RULE' "$rule"
+
+if [[ "$ip" =~ ^ipset: ]]; then
+    ipset_name="${ip#ipset:}"
+    v-list-firewall-ipset plain | grep "^$ipset_name\s" >/dev/null
+    check_result $? 'ipset object not found' $E_NOTEXIST
+else
+    is_format_valid 'ip'
+fi
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-delete-firewall-ipset
+++ b/bin/v-delete-firewall-ipset
@@ -50,11 +50,11 @@ fi
 #                       Action                             #
 #----------------------------------------------------------#
 
-if $IPSET_BIN --quiet list "${ip_name}-tmp"; then
+if $IPSET_BIN --quiet list "${ip_name}-tmp" >/dev/null; then
     $IPSET_BIN --quiet destroy "${ip_name}-tmp"
 fi
 
-if $IPSET_BIN --quiet list "${ip_name}"; then
+if $IPSET_BIN --quiet list "${ip_name}" >/dev/null; then
     $IPSET_BIN --quiet destroy "${ip_name}"
     check_result $? "ipset ${ip_name} still used by iptables. Cannot remove"
 fi

--- a/bin/v-delete-firewall-ipset
+++ b/bin/v-delete-firewall-ipset
@@ -1,0 +1,72 @@
+#!/bin/bash
+# info: delete firewall ipset
+# options: NAME
+#
+# The function removes ipset from system and from hestia
+
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+ip_name=${1}
+
+# Includes
+source $HESTIA/func/main.sh
+source $HESTIA/conf/hestia.conf
+
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+ipset_hstobject='../../data/firewall/ipset'
+
+check_args '1' "$#" 'NAME'
+is_format_valid 'ip_name'
+is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
+is_object_valid "$ipset_hstobject" 'LISTNAME' "$ip_name"
+
+ip_version="$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ip_name" '$IP_VERSION')"
+
+IPSET_BIN="$(which ipset)"
+IPSET_PATH="$HESTIA/data/firewall/ipset"
+IPSET_FILE="${ip_name}.${ip_version}"
+
+# Perform verification if read-only mode is enabled
+check_hestia_demo_mode
+
+# Install ipset package if missing
+if [ -z "$IPSET_BIN" ]; then
+    apt-get --quiet --yes install ipset > /dev/null
+    check_result $? "Installing ipset package"
+
+    IPSET_BIN="$(which ipset)"
+    check_result $? "ipset binary not found"
+fi
+
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+if $IPSET_BIN --quiet list "${ip_name}-tmp"; then
+    $IPSET_BIN --quiet destroy "${ip_name}-tmp"
+fi
+
+if $IPSET_BIN --quiet list "${ip_name}"; then
+    $IPSET_BIN --quiet destroy "${ip_name}"
+    check_result $? "ipset ${ip_name} still used by iptables. Cannot remove"
+fi
+
+sed -i "/LISTNAME='$ip_name'/d" "${IPSET_PATH}.conf"
+rm -f "${IPSET_PATH}/${IPSET_FILE}.iplist"
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Logging
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/bin/v-list-firewall-ipset
+++ b/bin/v-list-firewall-ipset
@@ -1,0 +1,102 @@
+#!/bin/bash
+# info: List firewall ipset
+# options: [FORMAT]
+#
+# The function prints defined ipset lists
+
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+# Argument definition
+format=${1-shell}
+
+# Includes
+source $HESTIA/func/main.sh
+source $HESTIA/conf/hestia.conf
+
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
+
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+# JSON list function
+json_list() {
+    IFS=$'\n'
+    i=1
+    objects=$(grep LISTNAME $HESTIA/data/firewall/ipset.conf |wc -l)
+    echo "{"
+    while read str; do
+        [[ -z "$str" ]] && continue;
+        parse_object_kv_list "$str"
+        echo -n '    "'$LISTNAME'": {
+        "IP_VERSION": "'$IP_VERSION'",
+        "AUTOUPDATE": "'$AUTOUPDATE'",
+        "SUSPENDED": "'$SUSPENDED'",
+        "SOURCE": "'$SOURCE'",
+        "TIME": "'$TIME'",
+        "DATE": "'$DATE'"
+    }'
+    [[ "$i" -lt "$objects" ]] && echo ',' || echo
+    ((i++))
+    done < <(cat $HESTIA/data/firewall/ipset.conf)
+    echo '}'
+}
+
+# SHELL list function
+shell_list() {
+    IFS=$'\n'
+    echo "LISTNAME^IP_VERSION^AUTOUPDATE^SUSPENDED^SOURCE^TIME^DATE"
+    echo "----^------^-----^----^--^----^----"
+    while read str; do
+        [[ -z "$str" ]] && continue;
+        parse_object_kv_list "$str"
+        echo "$LISTNAME^$IP_VERSION^$AUTOUPDATE^$SUSPENDED^$SOURCE^$TIME^$DATE"
+    done < <(cat $HESTIA/data/firewall/ipset.conf)
+}
+
+# PLAIN list function
+plain_list() {
+    IFS=$'\n'
+    while read str; do
+        [[ -z "$str" ]] && continue;
+        parse_object_kv_list "$str"
+        echo -ne "$LISTNAME\t$IP_VERSION\t$AUTOUPDATE\t$SUSPENDED\t$SOURCE\t"
+        echo -e "$TIME\t$DATE"
+    done < <(cat $HESTIA/data/firewall/ipset.conf)
+}
+
+# CSV list function
+csv_list() {
+    IFS=$'\n'
+    echo "LISTNAME,IP_VERSION,AUTOUPDATE,SUSPENDED,SOURCE,SUSPENDED,TIME,DATE"
+    while read str; do
+        [[ -z "$str" ]] && continue;
+        parse_object_kv_list "$str"
+        echo -n "$LISTNAME,$IP_VERSION,$AUTOUPDATE,$SUSPENDED,\"$SOURCE\","
+        echo "$TIME,$DATE"
+    done < <(cat $HESTIA/data/firewall/ipset.conf)
+}
+
+# Listing data
+case $format in
+    json)   json_list ;;
+    plain)  plain_list ;;
+    csv)    csv_list ;;
+    shell)  shell_list |column -t -s '^' ;;
+esac
+
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+exit

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -56,6 +56,9 @@ if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22"  ]; then
     sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
 fi
 
+# Load ipset lists before adding Hestia iptables rules
+$BIN/v-update-firewall-ipset
+
 # Creating temporary file
 tmp=$(mktemp)
 
@@ -83,9 +86,16 @@ for line in $(sort -r -n -k 2 -t \' $rules); do
     if [ "$SUSPENDED" = 'no' ]; then
         proto="-p $PROTOCOL"
         port="--dport $PORT"
-        ip="-s $IP"
         state=""
         action="-j $ACTION"
+
+        if [[ "$IP" =~ ^ipset: ]]; then
+            ipset_name="${IP#ipset:}"
+            $(v-list-firewall-ipset plain | grep "^$ipset_name\s" >/dev/null) || log_event $E_NOTEXIST "ipset object ($ipset_name) not found"
+            ip="-m set --match-set '${ipset_name}' src"
+        else
+            ip="-s $IP"
+        fi
 
         # Adding multiport module
         if [[ "$PORT" =~ ,|-|: ]] ; then

--- a/bin/v-update-firewall-ipset
+++ b/bin/v-update-firewall-ipset
@@ -1,0 +1,62 @@
+#!/bin/bash
+# info: update firewall ipset
+# options: [REFRESH]
+#
+# The function creates ipset lists and updates the lists if they are expired or ondemand
+
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+# Force refresh
+force=${1-no}
+
+# Includes
+source $HESTIA/func/main.sh
+source $HESTIA/conf/hestia.conf
+
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+is_boolean_format_valid "$force" 'bool (yes/no)'
+is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
+
+ipset_hstobject='../../data/firewall/ipset'
+
+for ipset_name in $(search_objects "$ipset_hstobject" 'SUSPENDED' 'no' 'LISTNAME'); do
+
+    ipset_time="$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ipset_name" '$TIME')"
+    ipset_date="$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ipset_name" '$DATE')"
+    ipset_au="$(get_object_value "$ipset_hstobject" 'LISTNAME' "$ipset_name" '$AUTOUPDATE')"
+
+    if [ "$ipset_au" = 'no' ] ; then
+        # load existing ip list files in the kernel but don't auto update them
+        $BIN/v-add-firewall-ipset "$ipset_name"
+        continue
+    fi
+
+    last_updated_ts=$(date -d "$ipset_date $ipset_time" +%s)
+    now=$(date +%s)
+    hours_since_update=$(( (now - last_updated_ts) / 60 ))
+
+    if [[ "$hours_since_update" -lt 70 ]] && [ "$force" = 'no' ]; then
+        # load existing ip list files in the kernel but don't auto update them
+        $BIN/v-add-firewall-ipset "$ipset_name"
+        continue
+    fi
+
+    $BIN/v-add-firewall-ipset "$ipset_name" '' '' '' 'yes'
+done
+
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Logging
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/bin/v-update-firewall-ipset
+++ b/bin/v-update-firewall-ipset
@@ -10,7 +10,7 @@
 #----------------------------------------------------------#
 
 # Force refresh
-force=${1-no}
+force=${1:-no}
 
 # Includes
 source $HESTIA/func/main.sh

--- a/install/deb/firewall/ipset/blacklist.sh
+++ b/install/deb/firewall/ipset/blacklist.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script and blacklist urls partially taken from:
+# https://github.com/trick77/ipset-blacklist/blob/master/ipset-blacklist.conf
+#
+
+BLACKLISTS=(
+    "https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1" # Project Honey Pot Directory of Dictionary Attacker IPs
+    "https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"  # TOR Exit Nodes
+    "https://www.maxmind.com/en/high-risk-ip-sample-list" # MaxMind GeoIP Anonymous Proxies
+    "http://danger.rulez.sk/projects/bruteforceblocker/blist.php" # BruteForceBlocker IP List
+    "https://www.spamhaus.org/drop/drop.lasso" # Spamhaus Don't Route Or Peer List (DROP)
+    "https://cinsscore.com/list/ci-badguys.txt" # C.I. Army Malicious IP List
+    "https://lists.blocklist.de/lists/all.txt" # blocklist.de attackers
+    "https://blocklist.greensnow.co/greensnow.txt" # GreenSnow
+    "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset" # Firehol Level 1
+    "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/stopforumspam_7d.ipset" # Stopforumspam via Firehol
+)
+
+
+IP_BLACKLIST_TMP=$(mktemp)
+for i in "${BLACKLISTS[@]}"; do
+    IP_TMP=$(mktemp)
+    (( HTTP_RC=$(curl -L --connect-timeout 10 --max-time 10 -o "$IP_TMP" -s -w "%{http_code}" "$i") ))
+    if (( HTTP_RC == 200 || HTTP_RC == 302 || HTTP_RC == 0 )); then # "0" because file:/// returns 000
+        command grep -Po '^(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?' "$IP_TMP" | sed -r 's/^0*([0-9]+)\.0*([0-9]+)\.0*([0-9]+)\.0*([0-9]+)$/\1.\2.\3.\4/' >> "$IP_BLACKLIST_TMP"
+    elif (( HTTP_RC == 503 )); then
+        echo >&2 -e "\\nUnavailable (${HTTP_RC}): $i"
+    else
+        echo >&2 -e "\\nWarning: curl returned HTTP response code $HTTP_RC for URL $i"
+    fi
+    rm -f "$IP_TMP"
+done
+
+sed -r -e '/^(0\.0\.0\.0|10\.|127\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.|192\.168\.|22[4-9]\.|23[0-9]\.)/d' "$IP_BLACKLIST_TMP"|sort -n|sort -mu
+rm -f "$IP_BLACKLIST_TMP"

--- a/web/add/firewall/index.php
+++ b/web/add/firewall/index.php
@@ -12,6 +12,23 @@ if ($_SESSION['user'] != 'admin') {
     exit;
 }
 
+// Get ipset lists
+exec (HESTIA_CMD."v-list-firewall-ipset 'json'", $output, $return_var);
+check_return_code($return_var,$output);
+$data = json_decode(implode('', $output), true);
+
+$ipset_lists=[];
+foreach($data as $key => $value) {
+    if(isset($value['SUSPENDED']) && $value['SUSPENDED'] === 'yes') {
+        continue;
+    }
+    if(isset($value['IP_VERSION']) && $value['IP_VERSION'] !== 'v4') {
+        continue;
+    }
+    array_push($ipset_lists, ['name'=>$key]);
+}
+$ipset_lists_json=json_encode($ipset_lists);
+
 // Check POST request
 if (!empty($_POST['ok'])) {
 

--- a/web/add/firewall/ipset/index.php
+++ b/web/add/firewall/ipset/index.php
@@ -1,0 +1,64 @@
+<?php
+error_reporting(NULL);
+ob_start();
+$TAB = 'FIREWALL';
+
+// Main include
+include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
+
+// Check user
+if ($_SESSION['user'] != 'admin') {
+    header("Location: /list/user");
+    exit;
+}
+
+// Check POST request
+if (!empty($_POST['ok'])) {
+
+    // Check token
+    if ((!isset($_POST['token'])) || ($_SESSION['token'] != $_POST['token'])) {
+        header('location: /login/');
+        exit();
+    }
+
+    // Check empty fields
+    if (empty($_POST['v_ipname'])) $errors[] = __('Name');
+    if (empty($_POST['v_datasource'])) $errors[] = __('Data Source');
+    if (empty($_POST['v_ipver'])) $errors[] = __('Ip Version');
+    if (empty($_POST['v_autoupdate'])) $errors[] = __('Autoupdate');
+
+    if (!empty($errors[0])) {
+        foreach ($errors as $i => $error) {
+            if ( $i == 0 ) {
+                $error_msg = $error;
+            } else {
+                $error_msg = $error_msg.", ".$error;
+            }
+        }
+        $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
+    }
+
+    $v_ipname = $_POST['v_ipname'];
+    $v_datasource = $_POST['v_datasource'];
+    $v_ipver = $_POST['v_ipver'];
+    $v_autoupdate = $_POST['v_autoupdate'];
+
+    // Add firewall ipset list
+    if (empty($_SESSION['error_msg'])) {
+        exec (HESTIA_CMD."v-add-firewall-ipset ".escapeshellarg($v_ipname)." ".escapeshellarg($v_datasource)." ".escapeshellarg($v_ipver)." ".escapeshellarg($v_autoupdate), $output, $return_var);
+        check_return_code($return_var,$output);
+        unset($output);
+    }
+
+    // Flush field values on success
+    if (empty($_SESSION['error_msg'])) {
+        $_SESSION['ok_msg'] = __('IPSET_CREATED_OK');
+    }
+}
+
+// Render
+render_page($user, $TAB, 'add_firewall_ipset');
+
+// Flush session messages
+unset($_SESSION['error_msg']);
+unset($_SESSION['ok_msg']);

--- a/web/delete/firewall/ipset/index.php
+++ b/web/delete/firewall/ipset/index.php
@@ -1,0 +1,35 @@
+<?php
+error_reporting(NULL);
+ob_start();
+session_start();
+
+// Main include
+include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
+
+// Check user
+if ($_SESSION['user'] != 'admin') {
+    header("Location: /list/user");
+    exit;
+}
+
+// Check token
+if ((!isset($_GET['token'])) || ($_SESSION['token'] != $_GET['token'])) {
+    header('location: /login/');
+    exit();
+}
+
+if (!empty($_GET['listname'])) {
+    $v_listname = $_GET['listname'];
+    exec (HESTIA_CMD."v-delete-firewall-ipset ".escapeshellarg($v_listname), $output, $return_var);
+}
+check_return_code($return_var,$output);
+unset($output);
+
+$back = $_SESSION['back'];
+if (!empty($back)) {
+    header("Location: ".$back);
+    exit;
+}
+
+header("Location: /list/firewall/ipset/");
+exit;

--- a/web/edit/firewall/index.php
+++ b/web/edit/firewall/index.php
@@ -41,6 +41,23 @@ if ( $v_suspended == 'yes' ) {
     $v_status =  'active';
 }
 
+// Get ipset lists
+exec (HESTIA_CMD."v-list-firewall-ipset 'json'", $output, $return_var);
+check_return_code($return_var,$output);
+$data = json_decode(implode('', $output), true);
+
+$ipset_lists=[];
+foreach($data as $key => $value) {
+    if(isset($value['SUSPENDED']) && $value['SUSPENDED'] === 'yes') {
+        continue;
+    }
+    if(isset($value['IP_VERSION']) && $value['IP_VERSION'] !== 'v4') {
+        continue;
+    }
+    array_push($ipset_lists, ['name'=>$key]);
+}
+$ipset_lists_json=json_encode($ipset_lists);
+
 // Check POST request
 if (!empty($_POST['save'])) {
 

--- a/web/list/firewall/ipset/index.php
+++ b/web/list/firewall/ipset/index.php
@@ -1,0 +1,23 @@
+<?php
+error_reporting(NULL);
+$TAB = 'FIREWALL';
+
+// Main include
+include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
+
+// Check user
+if ($_SESSION['user'] != 'admin') {
+    header("Location: /list/user");
+    exit;
+}
+
+// Data
+exec (HESTIA_CMD."v-list-firewall-ipset json", $output, $return_var);
+$data = json_decode(implode('', $output), true);
+ksort($data);
+
+// Render page
+render_page($user, $TAB, 'list_firewall_ipset');
+
+// Back uri
+$_SESSION['back'] = $_SERVER['REQUEST_URI'];

--- a/web/templates/admin/add_firewall.html
+++ b/web/templates/admin/add_firewall.html
@@ -98,7 +98,10 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="text" size="20" class="vst-input" name="v_ip" value="<?=htmlentities(trim($v_ip, "'"))?>">
+                                    <select class="vst-list" id="quickips_list" onchange="this.nextElementSibling.value=this.value">
+                                        <option value="">clear</option>
+                                    </select>
+                                    <input type="text" size="20" class="vst-input vst-list-editor" name="v_ip" value="<?=htmlentities(trim($v_ip, "'"))?>">
                                 </td>
                             </tr>
                             <tr>
@@ -121,3 +124,26 @@
         </from>
 
     </div>
+
+    <script>
+        var iplists = JSON.parse('<?=$ipset_lists_json?>');
+        iplists.sort(function (a, b) {
+            return a.name > b.name;
+        });
+
+        $(function() {
+            var targetelement = document.getElementById('quickips_list');
+
+            var newEl = document.createElement("option");
+            newEl.text = "Ipset Lists";
+            newEl.disabled = true;
+            targetelement.appendChild(newEl);
+
+            iplists.forEach(iplist => {
+                var newEl = document.createElement("option");
+                newEl.text = iplist.name;
+                newEl.value = "ipset:" + iplist.name;
+                targetelement.appendChild(newEl);
+            });
+        });
+    </script>

--- a/web/templates/admin/add_firewall_ipset.html
+++ b/web/templates/admin/add_firewall_ipset.html
@@ -140,12 +140,36 @@
         */
     ];
 
+    var blacklist_iplists = [
+        {name: "[ipv4] Blacklist Script",       source:"script:/usr/local/hestia/install/deb/firewall/ipset/blacklist.sh"},
+        /*
+        {name: "[ipv6] Blacklist Script",       source:"script:/usr/local/hestia/install/deb/firewall/ipset/blacklist.ipv6.sh"},
+        */
+    ];
+
     country_iplists.sort(function (a, b) {
+        return a.name > b.name;
+    });
+
+    blacklist_iplists.sort(function (a, b) {
         return a.name > b.name;
     });
 
     $(function() {
         var targetelement = document.getElementById('datasource_list');
+
+        // Blacklist
+        var newEl = document.createElement("option");
+        newEl.text="BLACKLIST";
+        newEl.disabled=true;
+        targetelement.appendChild(newEl);
+
+        blacklist_iplists.forEach(iplist => {
+            var newEl = document.createElement("option");
+            newEl.text=iplist.name;
+            newEl.value=iplist.source;
+            targetelement.appendChild(newEl);
+        });
 
         // IPVERSE
         var newEl = document.createElement("option");

--- a/web/templates/admin/add_firewall_ipset.html
+++ b/web/templates/admin/add_firewall_ipset.html
@@ -1,0 +1,163 @@
+<div class="l-center edit">
+        <div class="l-sort clearfix">
+          <div class="l-unit-toolbar__buttonstrip">
+            <a class="ui-button cancel" id="btn-back" href="/list/firewall/ipset/"><i class="fas fa-arrow-left status-icon blue"></i> <?=__('Back')?></a>
+          </div>
+          <div class="l-unit-toolbar__buttonstrip float-right">
+            <a href="#" class="ui-button" title="<?=__('Save')?>" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i> <?=__('Save')?></a>
+          </div>
+        </div>
+      </div>
+
+    <div class="l-separator"></div>
+    <!-- /.l-separator -->
+
+    <div class="l-center animated fadeIn">
+        <?php
+          $back = $_SESSION['back'];
+          if (empty($back)) {
+            $back = "location.href='/list/firewall/ipset/'";
+          } else {
+            $back = "location.href='".$back."'";
+          }
+        ?>
+        <form id="vstobjects" name="v_add_ipset" method="post">
+            <input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
+            <input type="hidden" name="ok" value="Add" />
+
+            <table class="data mode-add">
+                <tr class="data-add">
+                    <td class="data-dotted">
+                        <table class="data-col1">
+                            <tr><td></td></tr>
+                        </table>
+                    </td>
+                    <td class="data-dotted">
+                        <table class="data-col2" width="600px">
+                            <tr>
+                                <td class="step-top">
+                                    <span class="page-title"><?=__('Adding Firewall Ipset List')?></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <?php
+                                        if (!empty($_SESSION['error_msg'])) {
+                                            echo "<span class=\"vst-error\"> <i class=\"fas fa-exclamation-circle status-icon red\"></i> ".htmlentities($_SESSION['error_msg'])."</span>";
+                                        } else {
+                                            if (!empty($_SESSION['ok_msg'])) {
+                                                echo "<span class=\"vst-ok\"> <i class=\"fas fa-check-circle status-icon green\"></i> ".$_SESSION['ok_msg']."</span>";
+                                            }
+                                        }
+                                    ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="vst-text step-top">
+                                    <?php print __('Ip List Name') ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <input type="text" size="20" class="vst-input" name="v_ipname" maxlength="255" value="<?=htmlentities(trim($v_ipname, "'"))?>">
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="vst-text step-top">
+                                    <?php print __('Data Source') ?> <span class="optional">(<?php print __('url, script or file');?>)</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <select class="vst-list" id="datasource_list" onchange="this.nextElementSibling.value=this.value">
+                                        <option value="">clear</option>
+                                    </select>
+                                    <input type="text" size="20" class="vst-input vst-list-editor" name="v_datasource" maxlength="255" value="<?=htmlentities(trim($v_datasource, "'"))?>">
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="vst-text step-top">
+                                    <?php print __('Ip Version') ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <select class="vst-list" name="v_ipver">
+                                        <option value="v4" <?php if ((!empty($v_ipver)) && ( $v_ipver == "'v4'" )) echo 'selected'?>><?=__('ip v4')?></option>
+                                        <option value="v6" <?php if ((!empty($v_ipver)) && ( $v_ipver == "'v6'" )) echo 'selected'?>><?=__('ip v6')?></option>
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="vst-text step-top">
+                                    <?php print __('Autoupdate') ?>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <select class="vst-list" name="v_autoupdate">
+                                        <option value="yes" <?php if ((!empty($v_autoupdate)) && ( $v_autoupdate == "'yes'" )) echo 'selected'?>><?=__('yes')?></option>
+                                        <option value="no" <?php if ((!empty($v_autoupdate)) && ( $v_autoupdate == "'no'" )) echo 'selected'?>><?=__('no')?></option>
+                                    </select>
+                                </td>
+                            </tr>
+
+                        </table>
+                        <table class="data-col2">
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </form>
+
+    </div>
+
+    <script>
+    var country_iplists = [
+        {name: "[ipv4] Country Romania",        source:"http://ipverse.net/ipblocks/data/countries/ro.zone"},
+        {name: "[ipv4] Country Germany",        source:"http://ipverse.net/ipblocks/data/countries/de.zone"},
+        {name: "[ipv4] Country Switzerland",    source:"http://ipverse.net/ipblocks/data/countries/ch.zone"},
+        {name: "[ipv4] Country France",         source:"http://ipverse.net/ipblocks/data/countries/fr.zone"},
+        {name: "[ipv4] Country Ukraine",        source:"http://ipverse.net/ipblocks/data/countries/ua.zone"},
+        {name: "[ipv4] Country Russia",         source:"http://ipverse.net/ipblocks/data/countries/ru.zone"},
+        {name: "[ipv4] Country Spain",          source:"http://ipverse.net/ipblocks/data/countries/es.zone"},
+        {name: "[ipv4] Country United Kingdom", source:"http://ipverse.net/ipblocks/data/countries/gb.zone"},
+        {name: "[ipv4] Country United States",  source:"http://ipverse.net/ipblocks/data/countries/us.zone"},
+        {name: "[ipv4] Country China",          source:"http://ipverse.net/ipblocks/data/countries/cn.zone"},
+        {name: "[ipv4] Country India",          source:"http://ipverse.net/ipblocks/data/countries/in.zone"},
+        /*
+        {name: "[ipv6] Country Romania",        source:"http://ipverse.net/ipblocks/data/countries/ro-ipv6.zone"},
+        {name: "[ipv6] Country Germany",        source:"http://ipverse.net/ipblocks/data/countries/de-ipv6.zone"},
+        {name: "[ipv6] Country Switzerland",    source:"http://ipverse.net/ipblocks/data/countries/ch-ipv6.zone"},
+        {name: "[ipv6] Country France",         source:"http://ipverse.net/ipblocks/data/countries/fr-ipv6.zone"},
+        {name: "[ipv6] Country Ukraine",        source:"http://ipverse.net/ipblocks/data/countries/ua-ipv6.zone"},
+        {name: "[ipv6] Country Russia",         source:"http://ipverse.net/ipblocks/data/countries/ru-ipv6.zone"},
+        {name: "[ipv6] Country Spain",          source:"http://ipverse.net/ipblocks/data/countries/es-ipv6.zone"},
+        {name: "[ipv6] Country United Kingdom", source:"http://ipverse.net/ipblocks/data/countries/gb-ipv6.zone"},
+        {name: "[ipv6] Country United States",  source:"http://ipverse.net/ipblocks/data/countries/us-ipv6.zone"},
+        {name: "[ipv6] Country China",          source:"http://ipverse.net/ipblocks/data/countries/cn-ipv6.zone"},
+        {name: "[ipv6] Country India",          source:"http://ipverse.net/ipblocks/data/countries/in-ipv6.zone"},
+        */
+    ];
+
+    country_iplists.sort(function (a, b) {
+        return a.name > b.name;
+    });
+
+    $(function() {
+        var targetelement = document.getElementById('datasource_list');
+
+        // IPVERSE
+        var newEl = document.createElement("option");
+        newEl.text="IPVERSE";
+        newEl.disabled=true;
+        targetelement.appendChild(newEl);
+
+        country_iplists.forEach(iplist => {
+            var newEl = document.createElement("option");
+            newEl.text=iplist.name;
+            newEl.value=iplist.source;
+            targetelement.appendChild(newEl);
+        });
+    });
+    </script>

--- a/web/templates/admin/edit_firewall.html
+++ b/web/templates/admin/edit_firewall.html
@@ -99,7 +99,10 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="text" size="20" class="vst-input" name="v_ip" value="<?=htmlentities(trim($v_ip, "'"))?>">
+                                    <select class="vst-list" id="quickips_list" onchange="this.nextElementSibling.value=this.value">
+                                        <option value="">clear</option>
+                                    </select>
+                                    <input type="text" size="20" class="vst-input vst-list-editor" name="v_ip" value="<?=htmlentities(trim($v_ip, "'"))?>">
                                 </td>
                             </tr>
                             <tr>
@@ -120,3 +123,26 @@
             </table>
         </form>
     </div>
+
+    <script>
+        var iplists = JSON.parse('<?=$ipset_lists_json?>');
+        iplists.sort(function (a, b) {
+            return a.name > b.name;
+        });
+
+        $(function() {
+            var targetelement = document.getElementById('quickips_list');
+
+            var newEl = document.createElement("option");
+            newEl.text = "Ipset Lists";
+            newEl.disabled = true;
+            targetelement.appendChild(newEl);
+
+            iplists.forEach(iplist => {
+                var newEl = document.createElement("option");
+                newEl.text = iplist.name;
+                newEl.value = "ipset:" + iplist.name;
+                targetelement.appendChild(newEl);
+            });
+        });
+    </script>

--- a/web/templates/admin/list_firewall.html
+++ b/web/templates/admin/list_firewall.html
@@ -3,9 +3,10 @@
         <div class="l-unit-toolbar__buttonstrip">
           <a class="ui-button cancel" id="btn-back" href="/list/server/"><i class="fas fa-arrow-left status-icon blue"></i> <?=__('Back')?></a>
           <a href="/add/firewall/" id="btn-create" class="ui-button cancel" title="<?=__('Add Rule')?>"><i class="fas fa-plus-circle status-icon green"></i> <?=__('Add Rule')?></a>
-          <? if(!empty($_SESSION['FIREWALL_EXTENSION'])) {
-            echo '<a class="ui-button cancel" href="/list/firewall/banlist/"><i class="fas fa-eye status-icon red"></i> '.__('list fail2ban').'</a>';
-          } ?>
+          <?php if(!empty($_SESSION['FIREWALL_EXTENSION'])): ?>
+            <a class="ui-button cancel" href="/list/firewall/banlist/"><i class="fas fa-eye status-icon red"></i> <?=__('list fail2ban')?></a>
+            <a class="ui-button cancel" href="/list/firewall/ipset/"><i class="fas fa-list status-icon green"></i> <?=__('list ipset')?></a>
+          <?php endif; ?>
         </div>
         <ul class="context-menu sort-order animated fadeIn" style="display:none;">
           <li entity="sort-action"><span class="name"><?=__('Action')?> <i class="fas fa-sort-amount-down"></i></span><span class="up active"><i class="fas fa-sort-amount-up"></i></span></li>

--- a/web/templates/admin/list_firewall_ipset.html
+++ b/web/templates/admin/list_firewall_ipset.html
@@ -1,0 +1,120 @@
+    <div class="l-center">
+      <div class="l-sort clearfix noselect">
+        <div class="l-unit-toolbar__buttonstrip">
+          <a class="ui-button cancel" id="btn-back" href="/list/firewall/"><i class="fas fa-arrow-left status-icon blue"></i> <?=__('Back')?></a>
+          <a href="/add/firewall/ipset/" id="btn-create" class="ui-button cancel" title="<?=__('Add Ipset List')?>"><i class="fas fa-plus-circle status-icon green"></i> <?=__('Add Ipset List')?></a>
+        </div>
+        <div class="l-sort-toolbar clearfix">
+          <table>
+            <tr>
+              <td>
+                <form action="/bulk/firewall/ipset/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=__('apply to selected')?></option>
+                    <option value="delete"><?php print __('delete') ?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value=""><i class="fas fa-arrow-right"></i></button>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="l-separator"></div>
+  
+    <div class="l-center units animated fadeIn">
+          <div class="header table-header">
+              <div class="l-unit__col l-unit__col--right">
+                    <div class="clearfix l-unit__stat-col--left super-compact">
+                        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" onChange="checkedAll('objects');">
+                    </div>
+                    <div class="clearfix l-unit__stat-col--left wide-3"><b><?php print __('Ipset Name');?></b></div>
+                    <div class="clearfix l-unit__stat-col--left compact-4"><b>&nbsp;</b></div>  
+                    <div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?php print __('Autoupdate');?></b></div>
+                    <div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?php print __('Ip Ver');?></b></div>
+                    <div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?php print __('Date');?></b></div>
+                    <div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?php print __('Time');?></b></div>
+               </div>
+            </div>
+
+      <?php
+        foreach ($data as $key => $value) {
+          ++$i;
+
+          if ($data[$key]['SUSPENDED'] == 'yes') {
+            $status = 'suspended';
+          } else {
+            $status = 'active';
+          }
+
+          list($listname, $chain) = explode(":", $key);
+      ?>
+
+      <div class="l-unit<? if($status == 'suspended') echo ' l-unit--suspended';?>">
+        <div class="l-unit__col l-unit__col--right">
+              <div class="clearfix l-unit__stat-col--left super-compact">
+                  <input id="check<?php echo $i ?>" class="ch-toggle" type="checkbox" name="setname[]" value="<?php echo $listname ?>">
+                </div>
+              <div class="clearfix l-unit__stat-col--left wide-3"><b><?=$listname?></b></div>
+              <!-- START QUICK ACTION TOOLBAR AREA -->
+              <div class="clearfix l-unit__stat-col--left compact-4">
+                <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+                    <div class="actions-panel clearfix">
+
+                      <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                        <a id="delete_link_<?=$i?>" class="data-controls do_delete">
+                          <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                          <input type="hidden" name="delete_url" value="/delete/firewall/ipset/?listname=<?=$listname?>&token=<?=$_SESSION['token']?>" />
+                          <div id="delete_dialog_<?=$i?>" class="confirmation-text-delete hidden" title="<?=__('Confirmation')?>">
+                            <p class="confirmation"><?=__('DELETE_IPSET_CONFIRMATION', $key)?></p>
+                          </div>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <!-- END QUICK ACTION TOOLBAR AREA -->
+                <div class="clearfix l-unit__stat-col--left text-center compact-5"><b>
+                    <? if($data[$key]['AUTOUPDATE'] == 'no'){ ?>
+                        <i class="fas fa-times-circle status-icon red"></i>
+                    <? } else {?>
+                        <i class="fas fa-check-circle status-icon green"></i>
+                    <? } ?>
+                    </b>
+                </div>
+                <div class="clearfix l-unit__stat-col--left text-center compact-4"><?=__($data[$key]['IP_VERSION'])?></div>
+                <div class="clearfix l-unit__stat-col--left text-center compact-4"><?=__($data[$key]['DATE'])?></div>
+                <div class="clearfix l-unit__stat-col--left text-center compact-4"><?=$data[$key]['TIME']?></div>
+            </div>
+      </div>
+      <?}?>
+    </div>
+
+    <div id="vstobjects">
+        <div class="l-separator"></div>
+    <div class="l-center">
+        <div class="l-unit-ft">
+          <table class='data'></table>
+          <div class="data-count l-unit__col l-unit__col--right clearfix">
+            <?php
+              if ( $i == 0) {
+                echo __('There are currently no Ipset lists defined.');
+              }
+              if ( $i == 1) {
+                echo __('1 Ipset list');
+              }
+              if ( $i > 1) {
+                echo __('%s Ipser lists',$i);
+              }
+            ?>
+          </div>
+          <div class="data-count l-unit__col l-unit__col--right back clearfix">
+           
+          </div>
+      </div>
+    </div>
+  </div>


### PR DESCRIPTION
[Ipsets](http://ipset.netfilter.org/index.html) are a very efficient way of handling large ip lists like blacklists or country wide ip's

Example use case:
- Allow / Block acces from a specific country  to ssh or hestiacp port
- Create and keep updated a blacklist that cannot access any service on the server

Usefull ip lists:
- http://iplists.firehol.org/
- http://ipverse.net/

## Add ipset:
`Usage: v-add-firewall-ipset NAME [SOURCE] [IPVERSION] [AUTOUPDATE] [FORCE]`
- NAME:
  Sets a user friendly name for the ip list
- SOURCE: (http,script,file)
Resulting ip list file must contain at least 10 networks
  **http://** or **https://** url
  **script:**/path/to/local/script.sh
  **file:**/path/to/local/ip_list_file.txt
- IPVERSION (default: v4)
v4 or v6
- AUTOUPDATE (default: yes)
ip list will be regenerated when v-update-firewall-ipset is called and the list is expired (24h). Selecting 'no' the update script will never regenerate this list.
- FORCE (default: no)
ip list will be regenerated only when missing. Selecting 'yes' will regenerate the list on demend.

#### Examples:
`v-add-firewall-ipset country-de 'http://ipverse.net/ipblocks/data/countries/de.zone'`
-The command will define country-de in Hestia, download the network lists file and load them in the linux kernel trough ipset
-If a preprocessing script is present at `$HESTIA/data/firewall/ipset/country-de.v4.sh` it will be executed after the file is downloaded, with the following args: NAME and TEMPPATH eg: `country-de.v4.sh country-de /tmp/abcdef1234`

`v-add-firewall-ipset country-de`
-Load in the linux kernel a prev defined ip list, if the list file is missing it will be regenerated.

`v-add-firewall-ipset country-de '' '' '' 'yes'`
-Regenerate the ip list and load in the linux kernel a prev defined ip list.

## Remove ipset:
Remove linux ipset list and hestia
No iptables rules must reference this list name otherwise it will return a error.
`v-delete-firewall-ipset NAME`

## Update ipset
The script runs periodicaly trough cron to update expired ip lists, and at system startup to configure kernel ipset lists

v-update-firewall-ipset [REFRESH]
- REFRESH (default: no)
Regenerates ip lists when expired. Selecting 'yes' will ignore the expire time and the list will be refreshed. Ip lists with autoupdate disabled will still be ignored.

## List ipset
v-list-firewall-ipset [FORMAT]
- FORMAT (json, plain, csv, shell)
