### PR TITLE
Integrate Filegator filemanager in Hestia

### DIFF
--- a/bin/v-add-user-sftp-key
+++ b/bin/v-add-user-sftp-key
@@ -1,0 +1,83 @@
+#!/bin/bash
+# info: add user sftp key
+# options: USER 
+#
+# The script creates and updates ssh key for filemanager usage
+
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+# Argument definition
+user=$1
+
+# Includes
+source $HESTIA/func/main.sh
+source $HESTIA/conf/hestia.conf
+
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+check_args '1' "$#" 'USER'
+is_format_valid 'user'
+is_object_valid 'user' 'USER' "$user"
+
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+PRVKEY_FILE="$HOMEDIR/$user/.ssh/hst-filemanager-key"
+PUBKEY_FILE="$HOMEDIR/$user/.ssh/hst-filemanager-key.pub"
+AUTHKEY_FILE="$HOMEDIR/$user/.ssh/authorized_keys"
+
+[ -L "$PRVKEY_FILE" ]  && check_result $E_FORBIDEN "Private key file cannot be a symlink"
+[ -L "$PUBKEY_FILE" ]  && check_result $E_FORBIDEN "Public key file cannot be a symlink"
+[ -L "$AUTHKEY_FILE" ] && check_result $E_FORBIDEN "Authorized keys file cannot be a symlink"
+
+if [ ! -f "${PRVKEY_FILE}" ]; then
+
+    ssh-keygen -q -b 1024 -t rsa -f "${PRVKEY_FILE}" -N ""
+    new_privkey=true
+
+fi
+
+if [ ! -f "${PUBKEY_FILE}" ] || [ "$new_privkey" = true ]; then
+
+    ssh-keygen -y -f "${PRVKEY_FILE}" > "${PUBKEY_FILE}"
+    new_pubkey=true
+
+fi
+
+if [ ! -f "${AUTHKEY_FILE}" ] || [ "$new_pubkey" = true ]; then
+
+    now=$(date +%s)
+    pubkey_str=$(cat "${PUBKEY_FILE}")
+    pubkey_desc="[${user}]filemanager.ssh.key"
+
+    if grep --quiet -F "[${user}]filemanager.ssh.key" "${AUTHKEY_FILE}"; then
+        echo "remove old pub key from authkeys file"
+        sed -i "/ \[${user}\]filemanager\.ssh\.key\$/d" "${AUTHKEY_FILE}"
+    fi
+
+    echo "from=\"127.0.0.1\",command=\"internal-sftp\",restrict ${pubkey_str} TS:${now} ${pubkey_desc}" >> "${AUTHKEY_FILE}"
+
+fi
+
+# 
+chown ${user}: "${AUTHKEY_FILE}"
+chown ${user}: "${PUBKEY_FILE}"
+chown admin: "${PRVKEY_FILE}"
+
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Logging
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
+++ b/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the FileGator package.
+ *
+ * (c) Milos Stojanovic <alcalbg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ */
+
+namespace Filegator\Services\Auth\Adapters;
+
+use Filegator\Services\Auth\AuthInterface;
+use Filegator\Services\Auth\User;
+use Filegator\Services\Auth\UsersCollection;
+use Filegator\Services\Service;
+
+/**
+ * @codeCoverageIgnore
+ */
+class HestiaAuth implements Service, AuthInterface
+{
+
+    protected $permissions = [];
+
+    protected $private_repos = false;
+
+    protected $hestia_user = '';
+
+    public function init(array $config = [])
+    {
+        if (isset($_SESSION['user'])) {
+            $v_user = $_SESSION['user'];
+        }
+        if (isset($_SESSION['look']) && $_SESSION['look'] != 'admin' && $v_user === 'admin') {
+            $v_user = $_SESSION['look'];
+        }
+        $this->hestia_user = $v_user;
+        $this->permissions = isset($config['permissions']) ? (array)$config['permissions'] : [];
+        $this->private_repos = isset($config['private_repos']) ? (bool)$config['private_repos'] : false;
+    }
+
+    public function user(): ?User
+    {
+
+        $cmd="/usr/bin/sudo /usr/local/hestia/bin/v-list-user";
+        exec ($cmd." ".escapeshellarg($this->hestia_user )." json", $output, $return_var);
+
+        if ($return_var == 0) {
+            $data = json_decode(implode('', $output), true);
+            $hestia_user_info = $data[$this->hestia_user];
+            return $this->transformUser($hestia_user_info);
+        }
+        
+        return $this->getGuest();
+    }
+
+    public function transformUser($hstuser): User
+    {
+        $user = new User();
+        $user->setUsername($this->hestia_user);
+        $user->setName($this->hestia_user . " (" . $hstuser['FNAME'] . " " . $hstuser['LNAME'] . ")");
+        $user->setRole('user');
+        $user->setPermissions($this->permissions);
+        $user->setHomedir('/');
+        return $user;
+    }
+
+    public function authenticate($username, $password): bool
+    {
+        # Auth is handled by Hestia
+        return false;
+    }
+
+    public function forget()
+    {
+        // Logout return to Hestia
+        return $this->getGuest();
+    }
+
+    public function store(User $user)
+    {
+        return null; // not used
+    }
+
+    public function update($username, User $user, $password = ''): User
+    {
+        // Password change is handled by Hestia
+        return $this->user();
+    }
+
+    public function add(User $user, $password): User
+    {
+        return new User(); // not used
+    }
+
+    public function delete(User $user)
+    {
+        return true; // not used
+    }
+
+    public function find($username): ?User
+    {
+        return null; // not used
+    }
+
+    public function allUsers(): UsersCollection
+    {
+        return new UsersCollection(); // not used
+    }
+
+    public function getGuest(): User
+    {
+        $guest = new User();
+
+        $guest->setUsername('guest');
+        $guest->setName('Guest');
+        $guest->setRole('guest');
+        $guest->setHomedir('/');
+        $guest->setPermissions([]);
+
+        return $guest;
+    }
+
+}

--- a/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
+++ b/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the FileGator package.
+ *
+ * (c) Milos Stojanovic <alcalbg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ */
+
+namespace Filegator\Services\Session\Adapters;
+
+use Filegator\Kernel\Request;
+use Filegator\Services\Service;
+use Filegator\Services\Session\Session;
+use Filegator\Services\Session\SessionStorageInterface;
+
+class SessionStorage implements Service, SessionStorageInterface
+{
+    protected $request;
+
+    protected $config;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    public function init(array $config = [])
+    {
+        // we don't have a previous session attached
+        if (! $this->getSession()) {
+            $handler = $config['handler'];
+            $session = new Session($handler());
+            //$session->setName('filegator');
+            $this->setSession($session);
+        }
+    }
+
+    public function save()
+    {
+        $this->getSession()->save();
+    }
+
+    public function set(string $key, $data)
+    {
+        return $this->getSession()->set($key, $data);
+    }
+
+    public function get(string $key, $default = null)
+    {
+        return $this->getSession() ? $this->getSession()->get($key, $default) : $default;
+    }
+
+    public function invalidate()
+    {
+        if (! $this->getSession()->isStarted()) {
+            $this->getSession()->start();
+        }
+
+        $this->getSession()->invalidate();
+    }
+
+    private function setSession(Session $session)
+    {
+        return $this->request->setSession($session);
+    }
+
+    private function getSession(): ?Session
+    {
+        return $this->request->getSession();
+    }
+}

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -1,0 +1,43 @@
+<?php
+
+$dist_config = require __DIR__.'/configuration_sample.php';
+
+$dist_config['frontend_config']['app_name'] = 'Hestia FM';
+$dist_config['frontend_config']['logo'] = 'https://raw.githubusercontent.com/filegator/filegator/master/dist/img/logo.png';
+$dist_config['frontend_config']['editable'] = ['.txt', '.css', '.js', '.ts', '.html', '.php', '.py' ];
+$dist_config['frontend_config']['guest_redirection'] = '/login/' ;
+
+$dist_config['services']['Filegator\Services\Storage\Filesystem']['config']['adapter'] = function () {
+
+        if (isset($_SESSION['user'])) {
+            $v_user = $_SESSION['user'];
+        }
+        if (isset($_SESSION['look']) && $_SESSION['look'] != 'admin' && $v_user === 'admin') {
+            $v_user = $_SESSION['look'];
+        }
+
+        return new \League\Flysystem\Sftp\SftpAdapter([
+            'host' => '127.0.0.1',
+            'port' => 22,
+            'username' => basename($v_user),
+            'privateKey' => '/home/'.basename($v_user).'/.ssh/hst-filemanager-key',
+            'root' => '/',
+            'timeout' => 10,
+        ]);
+    };
+
+$dist_config['services']['Filegator\Services\Auth\AuthInterface'] = [
+        'handler' => '\Filegator\Services\Auth\Adapters\HestiaAuth',
+        'config' => [
+            'permissions' => ['read', 'write', 'upload', 'download', 'batchdownload', 'zip'],
+            'private_repos' => false,
+        ],
+    ];
+
+$dist_config['services']['Filegator\Services\View\ViewInterface']['config'] = [
+        'add_to_head' => '',
+        'add_to_body' => '',
+];
+
+
+return $dist_config;

--- a/install/deb/filemanager/install-fm.sh
+++ b/install/deb/filemanager/install-fm.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [ -z "$HESTIA" ]; then
+    HESTIA="/usr/local/hestia"
+fi
+
+# Hestia php-fpm pool user
+user='admin'
+
+source $HESTIA/func/main.sh
+
+FM_INSTALL_DIR="$HESTIA/web/fm"
+
+FM_V="7.4.1"
+FM_FILE="filegator_v${FM_V}.zip"
+FM_URL="https://github.com/filegator/filegator/releases/download/v${FM_V}/${FM_FILE}"
+
+
+COMPOSER_DIR="$HOMEDIR/$user/.composer"
+COMPOSER_BIN="$COMPOSER_DIR/composer"
+
+if [ ! -f "$COMPOSER_BIN" ]; then
+    mkdir -p "$COMPOSER_DIR"
+    chown $user: "$COMPOSER_DIR"
+
+    COMPOSER_SETUP_FILE=$(mktemp)
+    check_result $? "Create temp file"
+
+    signature="$(curl https://composer.github.io/installer.sig)"
+    check_result $? "Download signature"
+
+    user_exec wget --tries=3 --timeout=15 --read-timeout=15 --waitretry=3 --no-dns-cache https://getcomposer.org/installer --quiet -O "$COMPOSER_SETUP_FILE"
+    check_result $? "Download composer installer"
+
+    [[ "$signature" = $(sha384sum $COMPOSER_SETUP_FILE | cut -f 1 -d " ") ]] || check_result $E_INVALID "Composer signature does not match"
+
+    COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec /usr/bin/php "$COMPOSER_SETUP_FILE"  --install-dir="$COMPOSER_DIR" --filename=composer
+    check_result $? "Composer instal failed"
+
+    [ -f "$COMPOSER_SETUP_FILE" ] && rm -f "$COMPOSER_SETUP_FILE"
+fi
+
+mkdir -p "$FM_INSTALL_DIR"
+cd "$FM_INSTALL_DIR"
+
+[ ! -f "${FM_INSTALL_DIR}/${FM_FILE}" ] && 
+    wget "$FM_URL" --quiet -O "${FM_INSTALL_DIR}/${FM_FILE}"
+
+unzip -qq "${FM_INSTALL_DIR}/${FM_FILE}"
+mv --force ${FM_INSTALL_DIR}/filegator/* "${FM_INSTALL_DIR}"
+rm --recursive --force ${FM_INSTALL_DIR}/filegator
+chown root: "${FM_INSTALL_DIR}"
+
+cp --recursive --force ${HESTIA_INSTALL_DIR}/filemanager/filegator/* "${FM_INSTALL_DIR}"
+
+COMPOSER_HOME="$HOMEDIR/$user/.config/composer" $COMPOSER_BIN require league/flysystem-sftp
+
+chown $user: "${FM_INSTALL_DIR}/private"
+chown $user: "${FM_INSTALL_DIR}/private/logs"
+chown $user: "${FM_INSTALL_DIR}/repository"

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -98,7 +98,7 @@ mkdir -p $DEB_DIR
 mkdir -p $ARCHIVE_DIR
 
 # Set package dependencies for compiling
-SOFTWARE='build-essential libxml2-dev libz-dev libcurl4-gnutls-dev unzip openssl libssl-dev pkg-config libsqlite3-dev libonig-dev'
+SOFTWARE='build-essential libxml2-dev libz-dev libzip-dev libgmp-dev libcurl4-gnutls-dev unzip openssl libssl-dev pkg-config libsqlite3-dev libonig-dev'
 
 # Define a timestamp function
 timestamp() {
@@ -340,6 +340,8 @@ if [ "$PHP_B" = true ] ; then
                 --with-libdir=lib/x86_64-linux-gnu \
                 --with-mysqli \
                 --with-curl \
+                --with-zip \
+                --with-gmp \
                 --enable-mbstring
 
     # Create the files and install them
@@ -397,7 +399,7 @@ if [ "$PHP_B" = true ] ; then
     # clear up the source folder
     rm -r hestia-php_$PHP_V
     rm -rf usr/
-    if [ ! -z "$use_src_folder" ] && [ -d $$BUILD_DIR/hestiacp-$branch ]; then
+    if [ ! -z "$use_src_folder" ] && [ -d $BUILD_DIR/hestiacp-$branch ]; then
       rm -r $BUILD_DIR/hestiacp-$branch
     fi
 fi
@@ -409,7 +411,7 @@ fi
 #
 #################################################################################
 
-if [ "$HESTIA_B" = true ] ; then
+if [ "$HESTIA_B" = true ]; then
     echo "Building Hestia Control Panel package..."
     # Change to build directory
     cd $BUILD_DIR

--- a/web/templates/admin/panel.html
+++ b/web/templates/admin/panel.html
@@ -15,6 +15,7 @@
 			<div class="l-menu__item <?php if($TAB == 'LOG' ) echo 'l-menu__item--active' ?>"><a href="/list/log/"><i class="fas fa-history"></i>&nbsp;&nbsp;&nbsp;<?=__('Log')?></a></div>
 			<div class="l-menu__item <?php if($TAB == 'STATS' ) echo 'l-menu__item--active' ?>"><a href="/list/stats/"><i class="fas fa-chart-line"></i>&nbsp;&nbsp;&nbsp;<?=__('Statistics')?></a></div>
 			<div class="l-menu__item <?php if($TAB == 'SERVER' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'UPDATES' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'IP' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'RRD' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'FIREWALL' ) echo 'l-menu__item--active' ?>"><a href="/list/server/"><i class="fas fa-server"></i>&nbsp;&nbsp;&nbsp;<?=__('Server')?></a></div>
+			<div class="l-menu__item <?php if($TAB == 'FM' ) echo 'l-menu__item--active' ?>"><a href="/fm/"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;&nbsp;<?=__('Fm')?></a></div>
 		</div>
 		<!-- /.l-menu -->
 		<div class="l-profile noselect">

--- a/web/templates/user/panel.html
+++ b/web/templates/user/panel.html
@@ -14,6 +14,7 @@
 			<div class="l-menu__item <?php if($TAB == 'WEB' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'DNS' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'MAIL' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'DB' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'BACKUP' ) echo 'l-menu__item--active' ?> <?php if($TAB == 'CRON' ) echo 'l-menu__item--active' ?>"><a href="/list/web/"><i class="fas fa-tasks"></i>&nbsp;&nbsp;&nbsp;<?=__('Records')?></a></div>
 			<div class="l-menu__item <?php if($TAB == 'LOG' ) echo 'l-menu__item--active' ?>"><a href="/list/log/"><i class="fas fa-history"></i>&nbsp;&nbsp;&nbsp;<?=__('Log')?></a></div>
 			<div class="l-menu__item <?php if($TAB == 'STATS' ) echo 'l-menu__item--active' ?>"><a href="/list/stats/"><i class="fas fa-chart-line"></i>&nbsp;&nbsp;&nbsp;<?=__('Statistics')?></a></div>
+			<div class="l-menu__item <?php if($TAB == 'FM' ) echo 'l-menu__item--active' ?>"><a href="/fm/"><i class="fas fa-folder-open"></i>&nbsp;&nbsp;&nbsp;<?=__('Fm')?></a></div>
 		</div>
 		<!-- /.l-menu -->
 		<div class="l-profile noselect">


### PR DESCRIPTION
### Testing Notes:

After merging the code, filemanager is enabled with 
```bash
/usr/local/hestia/install/deb/filemanager/install-fm.sh
```

To enable a filemanager for a secific user:
```bash
v-add-user-sftp-key user
```

To enable the filemanager for all Hestia users:

```bash
for user in $(v-list-sys-users plain); do v-add-user-sftp-key "$user"; done
```

Also a patch to `/usr/local/hestia/nginx/conf/nginx.conf` is required to include the `/fm/` block
https://github.com/hestiacp/hestiacp/commit/4bcf26c34be227bd51d22e5e991f18d2508cbf3c