### PR TITLE
Prevent from making ip shared if it's not owned by admin

### DIFF
--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -48,6 +48,9 @@ fi
 if [ ! -z "$nat_ip" ] ; then
     is_format_valid 'nat_ip'
 fi
+if [ "$user" != "admin" ]; then
+    ip_status="dedicated"
+fi
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-change-sys-ip-owner
+++ b/bin/v-change-sys-ip-owner
@@ -33,9 +33,6 @@ is_ip_key_empty '$U_SYS_USERS'
 
 ip_status="$(get_ip_value '$STATUS')"
 
-if [ "$user" != "admin" ] && [ "$ip_status" == "shared" ]; then
-        check_result "$E_INVALID" "Only the 'admin' user can have a shared ip"
-fi
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -78,6 +75,11 @@ if [ "$ip_owner" != "$user" ]; then
     fi
 fi
 
+# Set status to dedicated if owner is not admin
+ip_status="$(get_ip_value '$STATUS')"
+if [ "$user" != 'admin' ] && [ "$ip_status" == 'shared' ]; then
+    $HESTIA/bin/v-change-sys-ip-status "$ip" 'dedicated'
+fi
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-change-sys-ip-owner
+++ b/bin/v-change-sys-ip-owner
@@ -31,6 +31,12 @@ is_ip_valid "$ip"
 is_ip_key_empty '$U_WEB_DOMAINS'
 is_ip_key_empty '$U_SYS_USERS'
 
+ip_status="$(get_ip_value '$STATUS')"
+
+if [ "$user" != "admin" ] && [ "$ip_status" == "shared" ]; then
+        check_result "$E_INVALID" "Only the 'admin' user can have a shared ip"
+fi
+
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
 
@@ -42,7 +48,6 @@ check_hestia_demo_mode
 # Changing ip owner
 ip_owner=$(get_ip_value '$OWNER')
 if [ "$ip_owner" != "$user" ]; then
-    ip_status="$(get_ip_value '$STATUS')"
     update_ip_value '$OWNER' "$user"
     decrease_user_value "$ip_owner" '$IP_OWNED'
     if [ "$ip_owner" = 'admin' ]; then

--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -35,7 +35,7 @@ ip_owner=$(get_ip_value '$OWNER')
 if [ "$web_domains" -ne '0' ] && [ "$sys_user" != "$ip_owner" ]; then
     check_result "$E_INUSE" "ip $ip is used"
 fi
-if [ "$ip_owner" != "admin" ]; then
+if [ "$ip_owner" != "admin" ] && [ "$ip_status" == "shared" ]; then
     check_result "$E_INVALID" "Only the 'admin' user can have a shared ip"
 fi
 

--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -35,6 +35,9 @@ ip_owner=$(get_ip_value '$OWNER')
 if [ "$web_domains" -ne '0' ] && [ "$sys_user" != "$ip_owner" ]; then
     check_result "$E_INUSE" "ip $ip is used"
 fi
+if [ "$ip_owner" != "admin" ]; then
+    check_result "$E_INVALID" "Only the 'admin' user can have a shared ip"
+fi
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode


### PR DESCRIPTION
Since users can't share ip's there's no point in allowing the option to even be set.