### PR TITLE
bugfix-#861 Show "read only" fields with a darker bg color (dark theme)

### DIFF
--- a/install/deb/themes/dark.css
+++ b/install/deb/themes/dark.css
@@ -1369,7 +1369,7 @@ label:hover {
 
 .vst-input:disabled,
 .vst-list:disabled {
-  background-color: #454545;
+  background-color: #303030;
   text-shadow: 1px 1px rgba(0,0,0,0.3);
   color: #acacac;
   border-color: #606060;


### PR DESCRIPTION
I used the color from the table tr bg-color. It's darker but not as dark as the body background.

![image](https://user-images.githubusercontent.com/3579830/84594286-7ebb2780-ae51-11ea-98fb-bab6af9ebf64.png)