### PR TITLE
Nginx public_*html permission error fix

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -94,6 +94,7 @@ chown root:$user /var/log/$WEB_SYSTEM/domains/$domain.* $conf
 chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
 chmod 751 $HOMEDIR/$user/web/$domain $HOMEDIR/$user/web/$domain/*
 chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
+chmod 755 $HOMEDIR/$user/web/public_*html
 chmod 644 $HOMEDIR/$user/web/$domain/public_*html/*
 
 # Addding PHP-FPM backend

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -94,7 +94,7 @@ chown root:$user /var/log/$WEB_SYSTEM/domains/$domain.* $conf
 chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
 chmod 751 $HOMEDIR/$user/web/$domain $HOMEDIR/$user/web/$domain/*
 chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
-chmod 755 $HOMEDIR/$user/web/public_*html
+chmod 755 $HOMEDIR/$user/web/$domain/public_*html
 chmod 644 $HOMEDIR/$user/web/$domain/public_*html/*
 
 # Addding PHP-FPM backend

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -98,6 +98,7 @@ rebuild_user_conf() {
         mkdir -p $HOMEDIR/$user/tmp
         chmod 751 $HOMEDIR/$user/conf/web
         chmod 751 $HOMEDIR/$user/web
+        chmod 755 $HOMEDIR/$user/web/public_*html
         chmod 771 $HOMEDIR/$user/tmp
         chown $user:$user $HOMEDIR/$user/web
         if [ -z "$create_user" ]; then

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -379,9 +379,9 @@ rebuild_web_domain_conf() {
                 $HOMEDIR/$user/web/$domain/logs
     chmod 751   $HOMEDIR/$user/web/$domain/private \
                 $HOMEDIR/$user/web/$domain/cgi-bin \
-                $HOMEDIR/$user/web/$domain/public_html \
-                $HOMEDIR/$user/web/$domain/public_shtml \
                 $HOMEDIR/$user/web/$domain/document_errors
+    chmod 755   $HOMEDIR/$user/web/$domain/public_html \
+                $HOMEDIR/$user/web/$domain/public_shtml
     chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
 }
 

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -98,7 +98,6 @@ rebuild_user_conf() {
         mkdir -p $HOMEDIR/$user/tmp
         chmod 751 $HOMEDIR/$user/conf/web
         chmod 751 $HOMEDIR/$user/web
-        chmod 755 $HOMEDIR/$user/web/public_*html
         chmod 771 $HOMEDIR/$user/tmp
         chown $user:$user $HOMEDIR/$user/web
         if [ -z "$create_user" ]; then


### PR DESCRIPTION
The Nginx error logs are getting filled up with:
`2020/06/18 11:41:09 [crit] 12961#12961: *43239 open() "/home/user/web/website.com/public_html/" failed (13: Permission denied), client: 108.61.255.255, server: website.com, request: "GET / HTTP/1.1", host: "website.com"
`

This is caused by too tight permissions on the /home/$user/web/$domain/public_html (and public_shtml) directory for the www-data user. The current permission is 751 for user.user. As www-data is not part of the 'user' group, it cannot access the directory itself. With this pull request I propose to use the 755 permissions for public_*html which means everyone can access the directory including www-data.

Is there a security risk to this? It's not likely. Higher up directories like /home/user/web/website.com are set to no allow other users to read which means they can also not access /home/user/web/website.com/public_html