### PR TITLE
Create mailhelo.conf if it doesnt exist to prevent a error during grep.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 ### Bugfixes
-
+- Create mailhelo.conf if it doesnt exist to prevent a error message during grep.
  
 ## [1.2.1] - Service Release 1 (beta)
 ### Features

--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -101,6 +101,11 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
         echo "$local_ip" > $HOMEDIR/$user/conf/mail/$domain/ip
     fi
 
+    # Touch mailhelo.conf if it doesnt exist
+    if [ ! -f "/etc/exim4/mailhelo.conf" }; then
+        touch /etc/exim4/mailhelo.conf
+    fi
+
     # Setting HELO for mail domain
     if [ ! -z "$local_ip" ]; then
         IP_RDNS=$(is_ip_rdns_valid "$local_ip")

--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -102,7 +102,7 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
     fi
 
     # Touch mailhelo.conf if it doesnt exist
-    if [ ! -f "/etc/exim4/mailhelo.conf" }; then
+    if [ ! -f "/etc/exim4/mailhelo.conf" ]; then
         touch /etc/exim4/mailhelo.conf
     fi
 


### PR DESCRIPTION
This issue fixed #938