### PR TITLE
Default value when PHP-CLI value is missing

### DIFF
--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -58,6 +58,10 @@ if ( $v_suspended == 'yes' ) {
 $v_time = $data[$v_username]['TIME'];
 $v_date = $data[$v_username]['DATE'];
 
+if(empty($v_phpcli)){
+   $v_phpcli = substr(DEFAULT_PHP_VERSION,4);
+}
+
 // List packages
 exec (HESTIA_CMD."v-list-user-packages json", $output, $return_var);
 $packages = json_decode(implode('', $output), true);


### PR DESCRIPTION
Why is the default PHP CLI 5.6 with fresh install (multi-php) when you edit admin user? 

PHP -v gave as default 7.3 

When there was no value the first option was picked.