### PR TITLE
Local ip not defind in ubuntu installer

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1766,6 +1766,7 @@ $HESTIA/bin/v-update-sys-ip > /dev/null 2>&1
 
 # Get main IP
 ip=$(ip addr|grep 'inet '|grep global|head -n1|awk '{print $2}'|cut -f1 -d/)
+local_ip=$ip
 
 # Configuring firewall
 if [ "$iptables" = 'yes' ]; then


### PR DESCRIPTION
Bug in the Ubuntu installer. In line 1811 and beyond, an unassigned $local_ip variable is used. In the Debian installer, this variable is assigned a value in line 1787.

Co-Authored-By: Ernesto Nicolás Carrea <equistango@users.noreply.github.com>