### PR TITLE
Secure the dowload of the nginx signing key

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -622,7 +622,7 @@ echo
 if [ "$nginx" = 'yes' ]; then
     echo "[ * ] NGINX"
     echo "deb [arch=amd64] http://nginx.org/packages/mainline/$VERSION/ $codename nginx" > $apt/nginx.list
-    wget --quiet http://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
+    wget --quiet https://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/nginx_signing.key > /dev/null 2>&1
 fi
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -598,7 +598,7 @@ if [ "$nginx" = 'yes' ]; then
     echo "[ * ] NGINX"
     echo "deb [arch=amd64] http://nginx.org/packages/mainline/$VERSION/ $codename nginx" \
     > $apt/nginx.list
-    wget --quiet http://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
+    wget --quiet https://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/nginx_signing.key > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
I am submitting this single security correction in the Debian install script to avoid delays and discussions on a larger set of corrections.

Getting a public key without ensuring you trust the server you are communicating with is a serious security risk and completely undermines the apt-secure infrastructure.  

Line 618 in https://github.com/hestiacp/hestiacp/blob/main/install/hst-install-debian.sh
`wget --quiet http://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key`

See man apt-key 

> Note that there are no checks performed, so it is easy to completely undermine the apt-secure(8) infrastructure if used without care.

Also refer to http://github.com/hestiacp/hestiacp/issues/949