### PR TITLE
Security suggestions for Debian install script 

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -643,11 +643,11 @@ fi
 # Installing MariaDB repo
 if [ "$mysql" = 'yes' ]; then
     echo "[ * ] MariaDB"
-    echo "deb [arch=amd64] https://ams2.mirrors.digitalocean.com/mariadb/repo/$mariadb_v/$VERSION $codename main" > $apt/mariadb.list
+    echo "deb [arch=amd64] https://mirrors.ukfast.co.uk/sites/mariadb/repo/$mariadb_v/$VERSION $codename main" > $apt/mariadb.list
     if [ "$release" -eq 8 ]; then
         APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com CBCB082A1BB943DB > /dev/null 2>&1
     else
-        APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com F1656F24C74CD1D8 > /dev/null 2>&1
+        APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --fetch-keys 'https://mariadb.org/mariadb_release_signing_key.asc' > /dev/null 2>&1
     fi
 fi
 

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -636,7 +636,7 @@ APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/php_signing.key > /dev/n
 if [ "$apache" = 'yes' ]; then
   echo "[ * ] Apache2"
   if [ "$release" -eq 10 ]; then
-     echo "deb https://deb.debian.org/debian buster-backports main" > $apt/apache2.list
+     echo "deb https://deb.debian.org/debian $codename-backports main" > $apt/apache2.list
   else
     echo "deb https://packages.sury.org/apache2/ $codename main" > $apt/apache2.list
     wget --quiet https://packages.sury.org/apache2/apt.gpg -O /tmp/apache2_signing.key

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -636,7 +636,7 @@ APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/php_signing.key > /dev/n
 if [ "$apache" = 'yes' ]; then
   echo "[ * ] Apache2"
   if [ "$release" -eq 10 ]; then
-     echo "deb http://deb.debian.org/debian buster-backports main" > $apt/apache2.list
+     echo "deb https://deb.debian.org/debian buster-backports main" > $apt/apache2.list
   else
     echo "deb https://packages.sury.org/apache2/ $codename main" > $apt/apache2.list
     wget --quiet https://packages.sury.org/apache2/apt.gpg -O /tmp/apache2_signing.key

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -634,10 +634,14 @@ APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/php_signing.key > /dev/n
 
 # Installing sury Apache2 repo
 if [ "$apache" = 'yes' ]; then
+  if [ "$release" -eq 10 ]; then
+    add-apt-repository "deb http://deb.debian.org/debian buser-backports main"
+  else
     echo "[ * ] Apache2"
     echo "deb https://packages.sury.org/apache2/ $codename main" > $apt/apache2.list
     wget --quiet https://packages.sury.org/apache2/apt.gpg -O /tmp/apache2_signing.key
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/apache2_signing.key > /dev/null 2>&1
+  fi
 fi
 
 # Installing MariaDB repo

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -634,10 +634,10 @@ APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/php_signing.key > /dev/n
 
 # Installing sury Apache2 repo
 if [ "$apache" = 'yes' ]; then
+  echo "[ * ] Apache2"
   if [ "$release" -eq 10 ]; then
-    add-apt-repository "deb http://deb.debian.org/debian buser-backports main"
+     echo "deb http://deb.debian.org/debian buster-backports main" > $apt/apache2.list
   else
-    echo "[ * ] Apache2"
     echo "deb https://packages.sury.org/apache2/ $codename main" > $apt/apache2.list
     wget --quiet https://packages.sury.org/apache2/apt.gpg -O /tmp/apache2_signing.key
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/apache2_signing.key > /dev/null 2>&1

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -647,7 +647,7 @@ fi
 # Installing MariaDB repo
 if [ "$mysql" = 'yes' ]; then
     echo "[ * ] MariaDB"
-    echo "deb [arch=amd64] https://mirrors.ukfast.co.uk/sites/mariadb/repo/$mariadb_v/$VERSION $codename main" > $apt/mariadb.list
+    echo "deb https://mirrors.ukfast.co.uk/sites/mariadb/repo/$mariadb_v/$VERSION $codename main" > $apt/mariadb.list
     if [ "$release" -eq 8 ]; then
         APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com CBCB082A1BB943DB > /dev/null 2>&1
     else

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 # Hestia Debian installer v1.0
 
 #----------------------------------------------------------#
@@ -621,8 +621,8 @@ echo
 # Installing Nginx repo
 if [ "$nginx" = 'yes' ]; then
     echo "[ * ] NGINX"
-    echo "deb [arch=amd64] http://nginx.org/packages/mainline/$VERSION/ $codename nginx" > $apt/nginx.list
-    wget --quiet http://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
+    echo "deb [arch=amd64] https://nginx.org/packages/mainline/$VERSION/ $codename nginx" > $apt/nginx.list
+    wget --quiet https://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/nginx_signing.key > /dev/null 2>&1
 fi
 
@@ -643,7 +643,7 @@ fi
 # Installing MariaDB repo
 if [ "$mysql" = 'yes' ]; then
     echo "[ * ] MariaDB"
-    echo "deb [arch=amd64] http://ams2.mirrors.digitalocean.com/mariadb/repo/$mariadb_v/$VERSION $codename main" > $apt/mariadb.list
+    echo "deb [arch=amd64] https://ams2.mirrors.digitalocean.com/mariadb/repo/$mariadb_v/$VERSION $codename main" > $apt/mariadb.list
     if [ "$release" -eq 8 ]; then
         APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --recv-keys --keyserver keyserver.ubuntu.com CBCB082A1BB943DB > /dev/null 2>&1
     else
@@ -653,7 +653,7 @@ fi
 
 # Installing Backport repo for Debian 8
 if [ "$release" -eq 8 ]; then
-    echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+    echo "deb [check-valid-until=no] https://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 fi
 
 # Installing HestiaCP repo
@@ -664,7 +664,7 @@ APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key adv --keyserver keyserver.ubuntu.
 # Installing PostgreSQL repo
 if [ "$postgresql" = 'yes' ]; then
     echo "[ * ] PostgreSQL"
-    echo "deb http://apt.postgresql.org/pub/repos/apt/ $codename-pgdg main" > $apt/postgresql.list
+    echo "deb https://apt.postgresql.org/pub/repos/apt/ $codename-pgdg main" > $apt/postgresql.list
     wget --quiet https://www.postgresql.org/media/keys/ACCC4CF8.asc -O /tmp/psql_signing.key
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add /tmp/psql_signing.key > /dev/null 2>&1
     rm /tmp/psql_signing.key


### PR DESCRIPTION
This is a first prototype of a few things that I want that make an HestiaCP install more secure.  I don't expect this pull to be accepted.  It's more for discussion and so that the HestiaCP team can take the parts or ideas that seem usefull to the project.  I will continue working and testing on this line of security enhancements.

Overview:
1) An option to use only the distros repos (when possible).  Depending on the tests results, I will add backport or external distros only when absolutely required.  This is probably only relevant when installing on the most recent version of Debian or Ubuntu.
2) General harmonization of key downloading for external repos.  There are many way to formulate this, the important is that the counterpart server is verified and that communications is encrypted.  The format I used is because it works with the torify command for this version of Debian (more variations work with torify in the next release).
3) An option to use tor for apt repo security, as suggested by Debian.  This protects against DNS based attacks and also falsifying SSL certificates.  Debian maintains tor hidden onion addresses for the repos and also have the apt-transport-tor package and support tor in sources.list.
4) The tor option I added also creates a hidden tor service for ssh (port 22) and the control panel (port 8083), thus they can be completely firewalled off leaving no attack surface for portscanning and vulnerability scanning. 
5) I removed the email user/password/url, which is never a secure communication method
6) HestiaCP servers are blocking access for tor!  :P  Thus, for now, I have can't use tor to get the HestiaCP repo and key.

Obviously still lots of testing needs to be done.