### PR TITLE
Fix/2007 07 fix unable download fork branch

### DIFF
--- a/bin/v-update-sys-hestia-git
+++ b/bin/v-update-sys-hestia-git
@@ -109,7 +109,7 @@ else
 fi
 
 if [ ! -z "$2" ]; then
-    branch_check=$(curl -s --head -w %{http_code} https://raw.githubusercontent.com/hestiacp/hestiacp/$branch/src/deb/hestia/control -o /dev/null)
+    branch_check=$(curl -s --head -w %{http_code} https://raw.githubusercontent.com/$fork/hestiacp/$branch/src/deb/hestia/control -o /dev/null)
     if [ $branch_check -ne "200" ]; then
         echo "ERROR: invalid branch name specified."
         exit 1


### PR DESCRIPTION
When downloading a branch from a fork  via v-update-sys-hestia-git returned in a error

root@dev:/usr/local/hestia/data/ips# v-update-sys-hestia-git braewoods sshfp
[!] Download code from GitHub repository: braewoods
ERROR: invalid branch name specified.

Even when branch existed 