### PR TITLE
#978 Disable the forced enable Password Auth

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -918,8 +918,6 @@ rm -f /usr/sbin/policy-rc.d
 
 
 echo "[ * ] Configuring system settings..."
-# Enable SSH password authentication
-sed -i "s/rdAuthentication no/rdAuthentication yes/g" /etc/ssh/sshd_config
 
 # Enable SFTP subsystem for SSH
 sftp_subsys_enabled=$(grep -iE "^#?.*subsystem.+(sftp )?sftp-server" /etc/ssh/sshd_config)

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -916,8 +916,6 @@ rm -f /usr/sbin/policy-rc.d
 #----------------------------------------------------------#
 
 echo "[ * ] Configuring system settings..."
-# Enable SSH password authentication
-sed -i "s/rdAuthentication no/rdAuthentication yes/g" /etc/ssh/sshd_config
 
 # Enable SFTP subsystem for SSH
 sftp_subsys_enabled=$(grep -iE "^#?.*subsystem.+(sftp )?sftp-server" /etc/ssh/sshd_config)


### PR DESCRIPTION
Since Pre "split" of Vesta this was the default action when installing

Since 1.2.0 Hestia has support for addig / mananging of "RSA/SSH keys" via Web UI and Hestia has no issue with running like this.

As we don't change the default behaviour of the install there is no change of locking your self out.