### PR TITLE
Remove uneccessary modifications to sshd_config

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -927,16 +927,6 @@ if [ ! -z "$sftp_subsys_enabled" ]; then
     sed -i -E "s/^#?.*Subsystem.+(sftp )?sftp-server/Subsystem sftp internal-sftp/g" /etc/ssh/sshd_config
 fi
 
-# Reduce SSH login grace time
-sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
-sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
-
-# Disable SSH suffix broadcast
-if [ -z "$(grep "^DebianBanner no" /etc/ssh/sshd_config)" ]; then
-    echo '' >> /etc/ssh/sshd_config
-    echo 'DebianBanner no' >> /etc/ssh/sshd_config
-fi
-
 # Restart SSH daemon
 systemctl restart ssh
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -925,16 +925,6 @@ if [ ! -z "$sftp_subsys_enabled" ]; then
     sed -i -E "s/^#?.*Subsystem.+(sftp )?sftp-server/Subsystem sftp internal-sftp/g" /etc/ssh/sshd_config
 fi
 
-# Reduce SSH login grace time
-sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
-sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
-
-# Disable SSH suffix broadcast
-if [ -z "$(grep "^DebianBanner no" /etc/ssh/sshd_config)" ]; then
-    echo '' >> /etc/ssh/sshd_config
-    echo 'DebianBanner no' >> /etc/ssh/sshd_config
-fi
-
 # Restart SSH daemon
 systemctl restart ssh
 


### PR DESCRIPTION
Low priority code housekeeping suggestion to remove uneccessary modifications to sshd_config.  The `DebianBanner no` and `LoginGraceTime 1m` are probably old legacy code and really don't do anything usefull.  The highly critical sshd_config file should be modified the least possible.  

`DebianBanner no` is against the protocol rules and security by obscurity doesn't work because there are other ways to infer the sshd version.   It could also lead to unexepected problems. The default has always been and still is `DebianBanner yes` in Debian 10 Buster and Ubuntu 20.04LTS

Reference: `man sshd_config`

Less code is also easier to maintain and audit.  