### PR TITLE
Install sshd config: Remove previous DebianBanner override, include in update

### DIFF
--- a/bin/v-update-sshd-config
+++ b/bin/v-update-sshd-config
@@ -1,0 +1,52 @@
+#!/bin/bash
+# info: update sshd config
+# options: NONE
+#
+# The functions updates the sshd config file
+
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+# Argument definition
+sshd_config=/etc/ssh/sshd_config
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+# Keep the following actions maintained in sync with the current install scripts
+
+# Enable SFTP subsystem for SSH
+sftp_subsys_enabled=$(grep -iE "^#?.*subsystem.+(sftp )?sftp-server" $sshd_config)
+if [ ! -z "$sftp_subsys_enabled" ]; then
+    sed -i -E "s/^#?.*Subsystem.+(sftp )?sftp-server/Subsystem sftp internal-sftp/g" $sshd_config
+fi
+
+# Comment out "DebianBanner no" if it exists, previous versions of HestiaCP where imposing this setting
+sed -i "s/^\s*DebianBanner no/#DebianBanner no # Changed by HestiaCP Script/gm" $sshd_config
+
+# Change LoginGraceTime from default 2m to 1m.   Not robust, but re-using the same as in the install script
+# Robust code would check for a non-commented "LoginGraceTime 1m",
+#   If nothing found, it would add it, if a LoginGraceTime other than 1m is found, comment it out with HestiaCP marking
+#   and add new line with "LoginGraceTime 1m"
+sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" $sshd_config
+sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" $sshd_config
+
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Logging
+# Maybe add this to the log?
+#log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/bin/v-update-sshd-config
+++ b/bin/v-update-sshd-config
@@ -10,7 +10,7 @@
 #----------------------------------------------------------#
 
 # Argument definition
-sshd_config=/etc/ssh/sshd_config
+sshd_config_augtool=/files/etc/ssh/sshd_config
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -23,7 +23,6 @@ sshd_config=/etc/ssh/sshd_config
 #----------------------------------------------------------#
 
 # Keep the following actions maintained in sync with the current install scripts
-sshd_config_augtool = /files/etc/ssh/sshd_config
 
 # Alaways save a backup copy of the config file if it has changed directly in the same directory
 # to permit fast audit, diff and recovery if required

--- a/bin/v-update-sshd-config
+++ b/bin/v-update-sshd-config
@@ -23,6 +23,16 @@ sshd_config=/etc/ssh/sshd_config
 #----------------------------------------------------------#
 
 # Keep the following actions maintained in sync with the current install scripts
+sshd_config_augtool = /files/etc/ssh/sshd_config
+
+# Alaways save a backup copy of the config file if it has changed directly in the same directory
+# to permit fast audit, diff and recovery if required
+# cp options: "-u" only copy if newer, "--backup=t" numbered backup, destination is hidden and has .bak extension.
+cp -u --backup=t /etc/ssh/sshd_config /etc/ssh/.sshd_config.bak
+
+# Important PasswordAuthentication: Previous versions of HestiaCP and VestaCP had imposed 'PasswordAuthentication yes'
+# However, this would be risky to change during an update as it is probable that installs have changed this setting
+# and changing it could completely lock out all sshd access.
 
 # Enable SFTP subsystem for SSH
 sftp_subsys_enabled=$(grep -iE "^#?.*subsystem.+(sftp )?sftp-server" $sshd_config)
@@ -30,15 +40,11 @@ if [ ! -z "$sftp_subsys_enabled" ]; then
     sed -i -E "s/^#?.*Subsystem.+(sftp )?sftp-server/Subsystem sftp internal-sftp/g" $sshd_config
 fi
 
-# Comment out "DebianBanner no" if it exists, previous versions of HestiaCP where imposing this setting
-sed -i "s/^\s*DebianBanner no/#DebianBanner no # Changed by HestiaCP Script/gm" $sshd_config
+# Remove DebianBanner setting.  Previous versions of HestiaCP had imposed this to 'DebianBanner no'
+augtool -s rm $sshd_config_augtool/DebianBanner 
 
-# Change LoginGraceTime from default 2m to 1m.   Not robust, but re-using the same as in the install script
-# Robust code would check for a non-commented "LoginGraceTime 1m",
-#   If nothing found, it would add it, if a LoginGraceTime other than 1m is found, comment it out with HestiaCP marking
-#   and add new line with "LoginGraceTime 1m"
-sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" $sshd_config
-sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" $sshd_config
+# Reduce SSH login grace time
+augtool -s set $sshd_config_augtool/LoginGraceTime 1m 
 
 
 #----------------------------------------------------------#

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -891,6 +891,11 @@ rm -f /usr/sbin/policy-rc.d
 
 echo "[ * ] Configuring system settings..."
 
+# Alaways save a backup copy of the config file if it has changed directly in the same directory
+# to permit fast audit, diff and recovery if required
+# cp options: "-u" only copy if newer, "--backup=t" numbered backup, destination is hidden and has .bak extension.
+cp -u --backup=t /etc/ssh/sshd_config /etc/ssh/.sshd_config.bak
+
 # Enable SFTP subsystem for SSH
 sftp_subsys_enabled=$(grep -iE "^#?.*subsystem.+(sftp )?sftp-server" /etc/ssh/sshd_config)
 if [ ! -z "$sftp_subsys_enabled" ]; then
@@ -898,8 +903,7 @@ if [ ! -z "$sftp_subsys_enabled" ]; then
 fi
 
 # Reduce SSH login grace time
-sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
-sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
+augtool -s set /files/etc/ssh/sshd_config/LoginGraceTime 1m 
 
 # Restart SSH daemon
 systemctl restart ssh

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -64,7 +64,7 @@ elif [ "$release" -eq 10 ]; then
         ipset libapache2-mpm-itk"
 fi
 
-installer_dependencies="apt-transport-https curl dirmngr gnupg wget"
+installer_dependencies="apt-transport-https augeas-tools curl dirmngr gnupg wget"
 
 # Defining help function
 help() {

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -901,12 +901,6 @@ fi
 sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
 sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
 
-# Disable SSH suffix broadcast
-if [ -z "$(grep "^DebianBanner no" /etc/ssh/sshd_config)" ]; then
-    echo '' >> /etc/ssh/sshd_config
-    echo 'DebianBanner no' >> /etc/ssh/sshd_config
-fi
-
 # Restart SSH daemon
 systemctl restart ssh
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -899,12 +899,6 @@ fi
 sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
 sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
 
-# Disable SSH suffix broadcast
-if [ -z "$(grep "^DebianBanner no" /etc/ssh/sshd_config)" ]; then
-    echo '' >> /etc/ssh/sshd_config
-    echo 'DebianBanner no' >> /etc/ssh/sshd_config
-fi
-
 # Restart SSH daemon
 systemctl restart ssh
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -889,6 +889,11 @@ rm -f /usr/sbin/policy-rc.d
 
 echo "[ * ] Configuring system settings..."
 
+# Alaways save a backup copy of the config file if it has changed directly in the same directory
+# to permit fast audit, diff and recovery if required
+# cp options: "-u" only copy if newer, "--backup=t" numbered backup, destination is hidden and has .bak extension.
+cp -u --backup=t /etc/ssh/sshd_config /etc/ssh/.sshd_config.bak
+
 # Enable SFTP subsystem for SSH
 sftp_subsys_enabled=$(grep -iE "^#?.*subsystem.+(sftp )?sftp-server" /etc/ssh/sshd_config)
 if [ ! -z "$sftp_subsys_enabled" ]; then
@@ -896,8 +901,7 @@ if [ ! -z "$sftp_subsys_enabled" ]; then
 fi
 
 # Reduce SSH login grace time
-sed -i "s/LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
-sed -i "s/#LoginGraceTime 2m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
+augtool -s set /files/etc/ssh/sshd_config/LoginGraceTime 1m 
 
 # Restart SSH daemon
 systemctl restart ssh

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -46,7 +46,7 @@ software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
     hestia-nginx hestia-php vim-common vsftpd whois zip acl sysstat setpriv
     ipset libonig5 libzip5"
 
-installer_dependencies="apt-transport-https curl dirmngr gnupg wget"
+installer_dependencies="apt-transport-https augeas-tools curl dirmngr gnupg wget"
 
 # Defining help function
 help() {

--- a/install/upgrade/versions/latest.sh
+++ b/install/upgrade/versions/latest.sh
@@ -15,3 +15,7 @@ echo "[ ! ] Updating default mail domain templates..."
 $BIN/v-update-mail-templates
 echo "[ ! ] Updating default DNS zone templates..."
 $BIN/v-update-dns-templates
+
+# Update sshd_config file
+echo "[ ! ] Updating sshd config..."
+$BIN/v-update-sshd-config


### PR DESCRIPTION
New pull to replace #986 

1) Removing the previously imposed `DebianBanner no` from the install

As per @ioannidesalex request for sshd_config (2 & 3) :

2) Retaining HestiaCP imposed `LoginGraceTime 1m`.  Code should be made more robust and used in both the install and update scripts.  See my comments.  

3) Updates should normalize the sshd_config file to the desired current HestiaCP Install standard.  This can be risky, but I have added a v-script to do this and added some comments on how ensure robust code.  

Final Nice to Have:

4) Maybe add the run of the v-script to the log?  See my comment at the bottom of the new v-script.

I will wait for futher feedback on this before making the code robust because the HestiaCP team may wish to take this over and make it to their liking or request a different approach for my pull.  I still reccommend the general approach of making only the absolute minimum changes to the sshd_config file, but when required, it should be robust and changes commented and marked HestiaCP for transparency and tracebility.  (eg # Added/Deleted/Changed by HestiaCP (with timestamp ideally)
