### PR TITLE
v-rebuild-users requiring "user"

### DIFF
--- a/bin/v-rebuild-users
+++ b/bin/v-rebuild-users
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: rebuild system user
-# options: USER [RESTART]
+# options: [RESTART]
 #
 # The function rebuilds system user accounts.
 
@@ -24,10 +24,6 @@ export PATH=$PATH:/usr/sbin
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '1' "$#" 'USER [RESTART]'
-is_format_valid 'user'
-is_object_valid 'user' 'USER' "$user"
-is_object_unsuspended 'user' 'USER' "$user"
 
 
 #----------------------------------------------------------#


### PR DESCRIPTION
Require a "user" mean while it does not depends on it