### PR TITLE
Add missing dependency software-properties-common for ubuntu

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -46,7 +46,7 @@ software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
     hestia-nginx hestia-php vim-common vsftpd whois zip acl sysstat setpriv
     ipset libonig5 libzip5 openssh-server ssh"
 
-installer_dependencies="apt-transport-https curl dirmngr gnupg wget"
+installer_dependencies="apt-transport-https curl dirmngr gnupg wget software-properties-common"
 
 # Defining help function
 help() {


### PR DESCRIPTION
Prevents issues with repositories not being added correctly on Ubuntu installs.  Closes #1073