### PR TITLE
Add $restart flag to v-add-web-domain-backend call (#1)

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -109,7 +109,7 @@ if [ ! -z "$WEB_BACKEND" ]; then
         fi
     fi
     BACKEND="$BACKEND_TEMPLATE"
-    $BIN/v-add-web-domain-backend "$user" "$domain" $BACKEND_TEMPLATE
+    $BIN/v-add-web-domain-backend "$user" "$domain" $BACKEND_TEMPLATE $restart
     check_result $? "Backend error" >/dev/null
 fi
 


### PR DESCRIPTION
v-add-web-domain-backend was always triggering a restart, even if $4 = 'no' (restart = no) was requested on original call to v-add-web-domain. Solution parameters needs to be passed onto the sub function to stop unnecessary restarts.