### PR TITLE
User shell didn't change after package change

### DIFF
--- a/bin/v-change-user-package
+++ b/bin/v-change-user-package
@@ -164,8 +164,7 @@ change_user_package
 
 # Update user shell
 shell_conf=$(echo "$pkg_data" | grep 'SHELL' | cut -f 2 -d \')
-shell=$(grep -w "$shell_conf" /etc/shells |head -n1)
-/usr/bin/chsh -s "$shell" "$user" &>/dev/null
+$BIN/v-change-user-shell $user $shell_conf
 
 # Run template trigger
 if [ -x "$HESTIA/data/packages/$package.sh" ]; then


### PR DESCRIPTION
Fixes issue explained in Discord:

**Alexandros Ioannides**: Can somebody try something? Create a new user with a package that doesn't allow ssh logins by default (eg default package). Then change the user's package via HestiaCP panel to another package that allows ssh logins. Then try to connect via ssh from another pc.