### PR TITLE
Issue with adding / managing keys when logged in as admin

### DIFF
--- a/web/templates/admin/edit_user.html
+++ b/web/templates/admin/edit_user.html
@@ -2,7 +2,9 @@
         <div class="l-sort clearfix">
           <div class="l-unit-toolbar__buttonstrip">
             <a class="ui-button cancel" id="btn-back" href="/list/user/"><i class="fas fa-arrow-left status-icon blue"></i> <?=_('Back')?></a>
-            <a href="/list/key/" id="btn-create" class="ui-button cancel" title="<?=_('Manage SSH keys');?>"><i class="fas fa-key status-icon orange"></i><?=_('Manage SSH keys')?></a>
+            <?php if( $_SESSION['user'] == $_GET['user'] || isset($_SESSION['look'])){?>
+                <a href="/list/key/" id="btn-create" class="ui-button cancel" title="<?=_('Manage SSH keys');?>"><i class="fas fa-key status-icon orange"></i><?=_('Manage SSH keys')?></a>
+            <?php } ?>
           </div>
           <div class="l-unit-toolbar__buttonstrip float-right">
             <a href="#" class="ui-button" title="<?=_('Save')?>" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i> <?=_('Save')?></a>


### PR DESCRIPTION
18:10] Curtis: @Jaap Figured it out. If you create a key for a user without logging into the user, it gets added to the admin authorized_keys file.

Just hide the option to manage the key