### PR TITLE
Issue with custom docroot php scripts one level up

### DIFF
--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -66,9 +66,13 @@ cat $WEBTPL/$WEB_BACKEND/$template.tpl |\
         -e "s|%backend%|$backend_type|g"\
         -e "s|%backend_version%|$backend_version|g" > $pool/$backend_type.conf
 
+
 # Set correct document root path
 if [ ! -z "$CUSTOM_DOCROOT" ]; then
     docroot="$CUSTOM_DOCROOT"
+    if [ ! -z "$CUSTOM_PHPROOT" ]; then
+        docroot="$CUSTOM_PHPROOT"
+    fi
     sed -i "s|/home\/$user\/web\/$domain\/public_html|$docroot|g"  $pool/$backend_type.conf
 else
     docroot="$HOMEDIR/$user/web/$domain/public_html/"

--- a/bin/v-change-web-domain-docroot
+++ b/bin/v-change-web-domain-docroot
@@ -1,7 +1,7 @@
 #!/bin/bash
 # info: Changes the document root for an existing web domain
 
-# options: USER DOMAIN TARGET_DOMAIN [DIRECTORY]
+# options: USER DOMAIN TARGET_DOMAIN [DIRECTORY] [PHP]
 # example usage:
 # add custom docroot:    v-change-web-domain-docroot admin domain.tld otherdomain.tld
 #                        points domain.tld to otherdomain.tld's document root.
@@ -25,6 +25,7 @@ domain=$2
 # so they are correctly passed through to domain.sh
 export target_domain=$3
 export target_directory=$4
+export php=$5
 
 # Includes
 source $HESTIA/func/main.sh
@@ -66,6 +67,7 @@ check_hestia_demo_mode
 # Unset existing custom document root path
 if [ ! -z "$CUSTOM_DOCROOT" ]; then
     update_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_DOCROOT' ""
+    update_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_PHPROOT' ""
 fi
 
 # If target domain value is 'default', remove the custom document root
@@ -73,6 +75,7 @@ fi
 # Otherwise, set target document root path accordingly based on passed values.
 if [ "$target_domain" = "default" ]; then
     update_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_DOCROOT' ""
+    update_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_PHPROOT' "" 
 else
     # Check for existence of specified directory under target domain's public_html folder
     if [ ! -z "$target_directory" ]; then
@@ -81,12 +84,24 @@ else
             exit 1
         else
             CUSTOM_DOCROOT="$HOMEDIR/$user/web/$target_domain/public_html/$target_directory/"
+            if [ ! -z "$php" ]; then
+                custom_phproot="$HOMEDIR/$user/web/$target_domain/public_html/"
+            else
+                custom_phproot="$HOMEDIR/$user/web/$target_domain/public_html/$target_directory/"
+            fi
         fi
     else
         CUSTOM_DOCROOT="$HOMEDIR/$user/web/$target_domain/public_html/"
+        custom_phproot="$HOMEDIR/$user/web/$target_domain/public_html/"
     fi
+    
     add_object_key 'web' 'DOMAIN' "$domain" 'CUSTOM_DOCROOT' 'IP6'
+    add_object_key 'web' 'DOMAIN' "$domain" 'CUSTOM_PHPROOT' 'IP6'
+    
     update_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_DOCROOT' "$CUSTOM_DOCROOT"
+    # CUSTOM_PHPROOT got overwriten by default
+    CUSTOM_PHPROOT=$custom_phproot
+    update_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_PHPROOT' "$CUSTOM_PHPROOT"  
 fi
 
 #----------------------------------------------------------#

--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -238,6 +238,11 @@ if (!empty($_POST['ok'])) {
 
         }else{
             $v_custom_doc_domain = escapeshellarg($_POST['v-custom-doc-domain']);
+            if(substr($_POST['v-custom-doc-folder'], -1) == '/'){
+                $v_custom_doc_folder = escapeshellarg(substr($_POST['v-custom-doc-folder'],0,-1));
+            }else{
+                $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);  
+            }
             $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);
             $v_domain = escapeshellarg(trim($_POST['v_domain']));
             

--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -241,7 +241,7 @@ if (!empty($_POST['ok'])) {
             $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);
             $v_domain = escapeshellarg(trim($_POST['v_domain']));
             
-            exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".$v_domain." ".$v_custom_doc_domain." ".$v_custom_doc_folder,  $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".$v_domain." ".$v_custom_doc_domain." ".$v_custom_doc_folder." yes",  $output, $return_var);
             check_return_code($return_var,$output);
             unset($output);  
             $v_custom_doc_root = 1; 

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -76,9 +76,11 @@ if (!empty($v_stats_user)) $v_stats_password = "";
 $v_custom_doc_root_prepath = '/home/'.$v_username.'/web/';
 $v_custom_doc_root = $data[$v_domain]['CUSTOM_DOCROOT'];
 
-$m = preg_match('/\/home\/'.$v_username.'\/web\/([A-Za-z0-9.-].*)\/([A-Za-z0-9.-\/].*)/', $v_custom_doc_root, $matches);
+$m = preg_match('/\/home\/demo\/web\/([[:alnum:]].*)\/public_html\/([[:alnum:]].*)/', $v_custom_doc_root, $matches);
 $v_custom_doc_domain = $matches[1];
-$v_custom_doc_folder = str_replace('public_html/','',$matches[2]);
+$v_custom_doc_folder = $matches[2];
+
+
 
 $v_ftp_user = $data[$v_domain]['FTP_USER'];
 $v_ftp_path = $data[$v_domain]['FTP_PATH'];
@@ -763,9 +765,13 @@ if (!empty($_POST['save'])) {
             check_return_code($return_var,$output);
             unset($output);     
         }else{
+            if(substr($_POST['v-custom-doc-folder'], -1) == '/'){
+                $v_custom_doc_folder = escapeshellarg(substr($_POST['v-custom-doc-folder'],0,-1));
+            }else{
+                $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);  
+            }
             $v_custom_doc_domain = escapeshellarg($_POST['v-custom-doc-domain']);
-            $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);
-        
+            
             exec(HESTIA_CMD."v-change-web-domain-docroot ".$v_username." ".escapeshellarg($v_domain)." ".$v_custom_doc_domain." ".$v_custom_doc_folder ." yes",  $output, $return_var);
             check_return_code($return_var,$output);
             unset($output);  

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -79,7 +79,9 @@ $v_custom_doc_root = $data[$v_domain]['CUSTOM_DOCROOT'];
 $m = preg_match('/\/home\/demo\/web\/([[:alnum:]].*)\/public_html\/([[:alnum:]].*)/', $v_custom_doc_root, $matches);
 $v_custom_doc_domain = $matches[1];
 $v_custom_doc_folder = $matches[2];
-
+if(substr($v_custom_doc_folder, -1) == '/'){
+    $v_custom_doc_folder = substr($v_custom_doc_folder,0,-1);
+}
 
 
 $v_ftp_user = $data[$v_domain]['FTP_USER'];

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -766,7 +766,7 @@ if (!empty($_POST['save'])) {
             $v_custom_doc_domain = escapeshellarg($_POST['v-custom-doc-domain']);
             $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);
         
-            exec(HESTIA_CMD."v-change-web-domain-docroot ".$v_username." ".escapeshellarg($v_domain)." ".$v_custom_doc_domain." ".$v_custom_doc_folder,  $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-docroot ".$v_username." ".escapeshellarg($v_domain)." ".$v_custom_doc_domain." ".$v_custom_doc_folder ." yes",  $output, $return_var);
             check_return_code($return_var,$output);
             unset($output);  
             $v_custom_doc_root = 1; 

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -76,7 +76,7 @@ if (!empty($v_stats_user)) $v_stats_password = "";
 $v_custom_doc_root_prepath = '/home/'.$v_username.'/web/';
 $v_custom_doc_root = $data[$v_domain]['CUSTOM_DOCROOT'];
 
-$m = preg_match('/\/home\/demo\/web\/([[:alnum:]].*)\/public_html\/([[:alnum:]].*)/', $v_custom_doc_root, $matches);
+$m = preg_match('/\/home\/'.$v_username.'\/web\/([[:alnum:]].*)\/public_html\/([[:alnum:]].*)/', $v_custom_doc_root, $matches);
 $v_custom_doc_domain = $matches[1];
 $v_custom_doc_folder = $matches[2];
 if(substr($v_custom_doc_folder, -1) == '/'){


### PR DESCRIPTION
Fixes issue with Custom docroot and PHP scripts

1. When installling Drupal for example:
In public_html you got /vendor and /web
v-change-web-domain-custom-docroot user domain.com domain.com web changes also open_basedir also to /home/demo/web/domain.eu/public_html/web causing system unable to work
Added "PHP" flag  v-change-web-domain-custom-docroot to force folder to use /home/demo/web/domain.eu/public_html

2. Fixes issue when entering  / on the end of folder and fixes issue with regex with folder/subfolder 

