### PR TITLE
Issues caused due to random generator

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -6,7 +6,7 @@ load 'test_helper/bats-file/load'
 
 
 function random() {
-    head /dev/urandom | tr -dc A-Za-z0-9 | head -c$1
+    head /dev/urandom | tr -dc 0-9 | head -c$1
 }
 
 function setup() {

--- a/test/test_actions.sh
+++ b/test/test_actions.sh
@@ -7,7 +7,7 @@ V_TEST="$HESTIA/test"
 
 # Define functions
 random() {
-    head /dev/urandom | tr -dc A-Za-z0-9 | head -c$1
+    head /dev/urandom | tr -dc 0-9 | head -c$1
 }
 
 echo_result() {


### PR DESCRIPTION
function random() {
    head /dev/urandom | tr -dc A-Za-z0-9 | head -c$1
}
to be replaced with
function random() {
   head /dev/urandom | tr -dc 0-9 | head -c$1
}
System expects an number