### PR TITLE
Exim local remote user delivery

### DIFF
--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -13,7 +13,7 @@ add_environment = <; PATH=/bin:/usr/bin
 keep_environment =
 disable_ipv6 = true
 
-domainlist local_domains = dsearch;/etc/exim4/domains/
+domainlist local_domains = @ : localhost : $primary_hostname : dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
 hostlist relay_from_hosts = 127.0.0.1
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
@@ -252,6 +252,15 @@ dnslookup:
   transport = remote_smtp
   no_more
 
+system_aliases:
+  driver = redirect
+  domains = $primary_hostname
+  allow_fail
+  allow_defer
+  data = ${lookup{$local_part}lsearch{/etc/aliases}}
+  file_transport = address_file
+  pipe_transport = address_pipe
+
 userforward:
   driver = redirect
   check_local_user
@@ -263,6 +272,12 @@ userforward:
   file_transport = address_file
   pipe_transport = address_pipe
   reply_transport = address_reply
+
+system_user:
+  driver = accept
+  domains = $primary_hostname
+  check_local_user
+  transport = system_user_delivery
 
 procmail:
   driver = accept
@@ -322,6 +337,15 @@ terminate_alias:
 #                      TRANSPORTS CONFIGURATION                      #
 ######################################################################
 begin transports
+
+system_user_delivery:
+  driver = appendfile
+  file = /var/mail/$local_part
+  delivery_date_add
+  envelope_to_add
+  return_path_add
+  group = mail
+  mode = 0660
 
 remote_smtp:
   driver = smtp

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1479,6 +1479,16 @@ if [ "$exim" = 'yes' ]; then
     systemctl stop sendmail > /dev/null 2>&1
     update-rc.d -f postfix remove > /dev/null 2>&1
     systemctl stop postfix > /dev/null 2>&1
+    if [ -f /etc/aliases ]; then
+        sed -ie "s/^root:*/#root:/" /etc/aliases;
+        if [ "$(tail -c 1 /etc/aliases)" == "" ]; then
+            echo "root: $email" >> /etc/aliases;
+        else
+            { echo "" ; echo "root: $email" ; } >> /etc/aliases;
+        fi
+    else
+        { echo "# /etc/aliases" ; echo "root: $email" ; } >> /etc/aliases;
+    fi
     update-rc.d exim4 defaults
     systemctl start exim4
     check_result $? "exim4 start failed"

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1525,7 +1525,16 @@ if [ "$exim" = 'yes' ]; then
     systemctl stop sendmail > /dev/null 2>&1
     update-rc.d -f postfix remove > /dev/null 2>&1
     systemctl stop postfix > /dev/null 2>&1
-
+    if [ -f /etc/aliases ]; then
+        sed -ie "s/^root:*/#root:/" /etc/aliases;
+        if [ "$(tail -c 1 /etc/aliases)" == "" ]; then
+            echo "root: $email" >> /etc/aliases;
+        else
+            { echo "" ; echo "root: $email" ; } >> /etc/aliases;
+        fi
+    else
+        { echo "# /etc/aliases" ; echo "root: $email" ; } >> /etc/aliases;
+    fi
     update-rc.d exim4 defaults
     systemctl start exim4 >> $LOG
     check_result $? "exim4 start failed"


### PR DESCRIPTION
This is the proposed solution for emails frozen in the exim queue that are addressed to root@host.domain.com As suggested by forum user fluidmindorg at https://forum.hestiacp.com/t/frozen-emails-to-root-host-domain-com-and-etc-aliases-not-used/850/4

It will allow exim the delivery of mail to local system accounts and honor /etc/aliases files, as well as out-of-the-box forward all messages addressed to root to the admin's email address. Although the admin can setup the mailbox root@server.FQDN (after Hestia installation) to get/forward all root's messages, I think most admins won't or don't know that they need to, in order not to miss important messages.

This is the follow-up of [PR #1108](https://github.com/hestiacp/hestiacp/pull/1108). I'm sorry @jaapmarcus for the delay responding, but I just had some free time.