### PR TITLE
Fix comment formatting in CLI commands 

### DIFF
--- a/bin/v-acknowledge-user-notification
+++ b/bin/v-acknowledge-user-notification
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update user notification
 # options: USER NOTIFICATION
+# labels: 
 #
 # The function updates user notification.
 

--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add backup host
 # options: TYPE HOST USERNAME PASSWORD [PATH] [PORT]
+# labels: 
+#
+# example: v-add-backup-host sftp backup.acme.com admin p4$$w@Rd
 #
 # This function adds a backup host
 

--- a/bin/v-add-cron-hestia-autoupdate
+++ b/bin/v-add-cron-hestia-autoupdate
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add cron job for hestia autoupdates
 # options: MODE
+# labels: 
 #
 # The function adds cronjob for hestia autoupdate from apt or git.
 

--- a/bin/v-add-cron-job
+++ b/bin/v-add-cron-job
@@ -3,7 +3,7 @@
 # options: USER MIN HOUR DAY MONTH WDAY COMMAND [JOB] [RESTART]
 # labels: 
 #
-# example: v-add-cronjob admin * * * * * sudo /usr/local/hestia/bin/v-backup-users
+# example: v-add-cron-job admin * * * * * sudo /usr/local/hestia/bin/v-backup-users
 #
 # The function adds a job to cron daemon. When executing commands, any output
 # is mailed to user's email if parameter REPORTS is set to 'yes'.

--- a/bin/v-add-cron-job
+++ b/bin/v-add-cron-job
@@ -1,9 +1,12 @@
 #!/bin/bash
 # info: add cron job
 # options: USER MIN HOUR DAY MONTH WDAY COMMAND [JOB] [RESTART]
+# labels: 
+#
+# example: v-add-cronjob admin * * * * * sudo /usr/local/hestia/bin/v-backup-users
 #
 # The function adds a job to cron daemon. When executing commands, any output
-# is  mailed to user's email if parameter REPORTS is set to 'yes'.
+# is mailed to user's email if parameter REPORTS is set to 'yes'.
 
 
 #----------------------------------------------------------#

--- a/bin/v-add-cron-letsencrypt-job
+++ b/bin/v-add-cron-letsencrypt-job
@@ -3,8 +3,6 @@
 # options: NONE
 # labels: 
 #
-# example: v-add-letsencrypt-job
-#
 # The script for enabling letsencrypt cronjob
 
 

--- a/bin/v-add-cron-letsencrypt-job
+++ b/bin/v-add-cron-letsencrypt-job
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add letsencrypt cronjob
 # options: NONE
+# labels: 
+#
+# example: v-add-letsencrypt-job
 #
 # The script for enabling letsencrypt cronjob
 

--- a/bin/v-add-cron-reports
+++ b/bin/v-add-cron-reports
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add cron reports
 # options: USER
+# labels: 
+#
+# example: v-add-cron-reports admin
 #
 # The script for enabling reports on cron tasks and administrative
 # notifications.

--- a/bin/v-add-cron-reports
+++ b/bin/v-add-cron-reports
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add cron reports
-# options: user
+# options: USER
 #
 # The script for enabling reports on cron tasks and administrative
 # notifications.

--- a/bin/v-add-cron-restart-job
+++ b/bin/v-add-cron-restart-job
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add cron reports
 # options: NONE
+# labels: 
 #
 # The script for enabling restart cron tasks
 

--- a/bin/v-add-database
+++ b/bin/v-add-database
@@ -1,8 +1,11 @@
 #!/bin/bash
 # info: add database
 # options: USER DATABASE DBUSER DBPASS [TYPE] [HOST] [CHARSET]
+# labels: 
 #
-# The function creates the database concatenating username  and user_db.
+# example: v-add-database admin wordpress_db matt qwerty123
+#
+# The function creates the database concatenating username and user_db.
 # Supported types of databases you can get using v-list-sys-config script.
 # If the host isn't stated and there are few hosts configured on the server,
 # then the host will be defined by one of three algorithms. "First" will choose

--- a/bin/v-add-database-host
+++ b/bin/v-add-database-host
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add new database server
-# options: TYPE HOST DBUSER DBPASS [MAX_DB] [CHARSETS] [TEMPLATE]
+# options: TYPE HOST DBUSER DBPASS [MAX_DB] [CHARSETS] [TEMPLATE] [PORT]
 #
 # The function add new database server to the server pool. It supports local
 # and remote database servers, which is useful for clusters. By adding a host

--- a/bin/v-add-database-host
+++ b/bin/v-add-database-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add new database server
 # options: TYPE HOST DBUSER DBPASS [MAX_DB] [CHARSETS] [TEMPLATE] [PORT]
+# labels: 
+#
+# example: v-add-database-host mysql localhost alice p@$$wOrd
 #
 # The function add new database server to the server pool. It supports local
 # and remote database servers, which is useful for clusters. By adding a host

--- a/bin/v-add-dns-domain
+++ b/bin/v-add-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add dns domain
 # options: USER DOMAIN IP [NS1] [NS2] [NS3] [..] [NS8] [RESTART]
+# labels: dns
+#
+# example: v-add-dns-domain admin example.com ns1.example.com ns2.example.com yes
 #
 # The function adds DNS zone with records defined in the template. If the exp
 # argument isn't stated, the expiration date value will be set to next year.

--- a/bin/v-add-dns-on-web-alias
+++ b/bin/v-add-dns-on-web-alias
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add dns domain or dns record after web domain alias
 # options: USER ALIAS IP [RESTART]
+# labels: dns
+#
+# example: v-add-dns-on-web-alias admin www.example.com 8.8.8.8
 #
 # The function adds dns domain or dns record based on web domain alias.
 

--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add dns record
 # options: USER DOMAIN RECORD TYPE VALUE [PRIORITY] [ID] [RESTART] [TTL]
+# labels: dns
+#
+# example: v-add-dns-record admin acme.com www A 162.227.73.112
 #
 # The call is used for adding new DNS record. Complex records of TXT, MX and
 # SRV types can be used by a filling in the 'value' argument. The function also

--- a/bin/v-add-domain
+++ b/bin/v-add-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add web/dns/mail domain
 # options: USER DOMAIN [IP] [RESTART]
+# labels: 
+#
+# example: v-add-domain admin example.com
 #
 # The function adds web/dns/mail domain to a server.
 

--- a/bin/v-add-firewall-ban
+++ b/bin/v-add-firewall-ban
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add firewall blocking rule
 # options: IP CHAIN
+# labels: 
+#
+# example: v-add-firewall-ban 37.120.129.20 MAIL
 #
 # The function adds new blocking rule to system firewall
 

--- a/bin/v-add-firewall-chain
+++ b/bin/v-add-firewall-chain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add firewall chain
 # options: CHAIN [PORT] [PROTOCOL] [PROTOCOL]
+# labels: 
+#
+# example: v-add-firewall-chain CRM 5678 TCP
 #
 # The function adds new rule to system firewall
 

--- a/bin/v-add-firewall-ipset
+++ b/bin/v-add-firewall-ipset
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add firewall ipset
 # options: NAME [SOURCE] [IPVERSION] [AUTOUPDATE] [FORCE]
+# labels: hestia
 #
 # The function adds new ipset to system firewall
 

--- a/bin/v-add-firewall-rule
+++ b/bin/v-add-firewall-rule
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add firewall rule
 # options: ACTION IP PORT [PROTOCOL] [COMMENT] [RULE]
+# labels: 
+#
+# example: v-add-firewall-rule DROP 185.137.111.77 25
 #
 # The function adds new rule to system firewall
 

--- a/bin/v-add-fs-archive
+++ b/bin/v-add-fs-archive
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: archive directory
-# options: USER ARCHIVE SOURCE
+# options: USER ARCHIVE SOURCE [SOURCE...]
 #
 # The function creates tar archive
 

--- a/bin/v-add-fs-archive
+++ b/bin/v-add-fs-archive
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: archive directory
 # options: USER ARCHIVE SOURCE [SOURCE...]
+# labels: 
+#
+# example: v-add-fs-archive admin archive.tar readme.txt
 #
 # The function creates tar archive
 

--- a/bin/v-add-fs-directory
+++ b/bin/v-add-fs-directory
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add directory
 # options: USER DIRECTORY
+# labels: 
+#
+# example: v-add-fs-directory admin mybar
 #
 # The function creates new directory on the file system
 

--- a/bin/v-add-fs-file
+++ b/bin/v-add-fs-file
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add file
 # options: USER FILE
+# labels: 
+#
+# example: v-add-fs-file admin readme.md
 #
 # The function creates new files on file system
 

--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: check letsencrypt domain
 # options: USER DOMAIN [ALIASES] [MAIL]
+# labels: web
+#
+# example: v-add-letsencrypt-domain admin wonderland.com www.wonderland.com
 #
 # The function check and validates domain with Let's Encrypt
 

--- a/bin/v-add-letsencrypt-host
+++ b/bin/v-add-letsencrypt-host
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add letsencrypt for host and backend
-# options:
+# options: NONE
 #
 # The function check and validates the backend certificate and generate
 # a new let's encrypt certificate.

--- a/bin/v-add-letsencrypt-host
+++ b/bin/v-add-letsencrypt-host
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add letsencrypt for host and backend
 # options: NONE
+# labels: hestia
 #
 # The function check and validates the backend certificate and generate
 # a new let's encrypt certificate.

--- a/bin/v-add-letsencrypt-user
+++ b/bin/v-add-letsencrypt-user
@@ -1,8 +1,11 @@
 #!/bin/bash
 # info: register letsencrypt user account
 # options: USER
+# labels: web
 #
-# The function creates and register LetsEncrypt account 
+# example: v-add-letsencrypt-user bob
+#
+# The function creates and register LetsEncrypt account
 
 
 #----------------------------------------------------------#

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail domain account
 # options: USER DOMAIN ACCOUNT PASSWORD [QUOTA]
+# labels: mail
+#
+# example: v-add-mail-account john example.com john P4$$vvOrD
 #
 # The function add new email account.
 

--- a/bin/v-add-mail-account-alias
+++ b/bin/v-add-mail-account-alias
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail account alias aka nickname
 # options: USER DOMAIN ACCOUNT ALIAS
+# labels: mail
+#
+# example: v-add-mail-account-alias admin acme.com alice alicia
 #
 # The function add new email alias.
 

--- a/bin/v-add-mail-account-autoreply
+++ b/bin/v-add-mail-account-autoreply
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail account autoreply message
 # options: USER DOMAIN ACCOUNT MESSAGE
+# labels: mail
+#
+# example: v-add-mail-account-autreply admin example.com user Hello from e-mail!
 #
 # The function add new email account.
 

--- a/bin/v-add-mail-account-autoreply
+++ b/bin/v-add-mail-account-autoreply
@@ -3,7 +3,7 @@
 # options: USER DOMAIN ACCOUNT MESSAGE
 # labels: mail
 #
-# example: v-add-mail-account-autreply admin example.com user Hello from e-mail!
+# example: v-add-mail-account-autoreply admin example.com user Hello from e-mail!
 #
 # The function add new email account.
 

--- a/bin/v-add-mail-account-forward
+++ b/bin/v-add-mail-account-forward
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail account forward address
 # options: USER DOMAIN ACCOUNT FORWARD
+# labels: mail
+#
+# example: v-add-mail-account-forward admin acme.com alice bob
 #
 # The function add new email account.
 

--- a/bin/v-add-mail-account-fwd-only
+++ b/bin/v-add-mail-account-fwd-only
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail account forward-only flag
 # options: USER DOMAIN ACCOUNT
+# labels: mail
+#
+# example: v-add-mail-account-fwd-only admin example.com user
 #
 # The function adds fwd-only flag
 

--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail domain
 # options: USER DOMAIN [ANTISPAM] [ANTIVIRUS] [DKIM] [DKIM_SIZE]
+# labels: mail
+#
+# example: v-add-mail-domain admin mydomain.tld
 #
 # The function adds MAIL domain.
 

--- a/bin/v-add-mail-domain-antispam
+++ b/bin/v-add-mail-domain-antispam
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail domain antispam support
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-add-mail-domain-antispam admin mydomain.tld
 #
 # The function enables spamassasin for incoming emails.
 

--- a/bin/v-add-mail-domain-antivirus
+++ b/bin/v-add-mail-domain-antivirus
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail domain antivirus support
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-add-mail-domain-antivirus admin mydomain.tld
 #
 # The function enables clamav scan for incoming emails.
 

--- a/bin/v-add-mail-domain-catchall
+++ b/bin/v-add-mail-domain-catchall
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail domain catchall account
 # options: USER DOMAIN EMAIL
+# labels: mail
+#
+# example: v-add-mail-domain-catchall admin example.com master@example.com
 #
 # The function enables catchall account for incoming emails.
 

--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add mail domain dkim support
 # options: USER DOMAIN [DKIM_SIZE]
+# labels: mail
+#
+# example: v-add-mail-domain-dkim admin acme.com
 #
 # The function adds DKIM signature to outgoing domain emails.
 

--- a/bin/v-add-mail-domain-ssl
+++ b/bin/v-add-mail-domain-ssl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add mail SSL for $domain
 # options: USER DOMAIN SSL_DIR [RESTART]
+# labels: hestia
 #
 # The function turns on SSL support for a mail domain. Parameter ssl_dir
 # is a path to a directory where 2 or 3 ssl files can be found. Certificate file 

--- a/bin/v-add-remote-dns-domain
+++ b/bin/v-add-remote-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add remote dns domain
 # options: USER DOMAIN [FLUSH]
+# labels: dns
+#
+# example: v-add-remote-dns-domain admin mydomain.tld yes
 #
 # The function synchronize dns domain with the remote server.
 

--- a/bin/v-add-remote-dns-host
+++ b/bin/v-add-remote-dns-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add new remote dns host
 # options: HOST PORT USER PASSWORD [TYPE] [DNS_USER]
+# labels: dns
+#
+# example: v-add-remote-dns-host slave.your_host.com 8083 admin your_passw0rd
 #
 # The function adds remote dns server to the dns cluster.
 

--- a/bin/v-add-remote-dns-record
+++ b/bin/v-add-remote-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add remote dns domain record
 # options: USER DOMAIN ID
+# labels: dns
+#
+# example: v-add-remote-dns-record bob acme.com 23
 #
 # The function synchronize dns domain with the remote server.
 

--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add file manager functionality to Hestia Control Panel
-# options: none
+# options: NONE
 #
 # The function installs the File Manager on the server
 # for access through the Web interface.

--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add file manager functionality to Hestia Control Panel
-# options: NONE
+# options: [MODE]
 #
 # The function installs the File Manager on the server
 # for access through the Web interface.

--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add file manager functionality to Hestia Control Panel
 # options: [MODE]
+# labels: hestia
 #
 # The function installs the File Manager on the server
 # for access through the Web interface.

--- a/bin/v-add-sys-firewall
+++ b/bin/v-add-sys-firewall
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add system firewall
 # options: NONE
+# labels: 
 #
 # The script enables firewall
 

--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -1,11 +1,14 @@
 #!/bin/bash
 # info: add system ip address
 # options: IP NETMASK [INTERFACE] [USER] [IP_STATUS] [IP_NAME] [NAT_IP]
+# labels: 
+#
+# example: v-add-sys-ip 216.239.32.21 255.255.255.0
 #
 # The function adds ip address into a system. It also creates rc scripts. You
 # can specify ip name which will be used as root domain for temporary aliases.
 # For example, if you set a1.myhosting.com as name, each new domain created on
-# this  ip will automatically receive alias $domain.a1.myhosting.com. Of course
+# this ip will automatically receive alias $domain.a1.myhosting.com. Of course
 # you must have wildcard record *.a1.myhosting.com pointed to ip. This feature 
 # is very handy when customer wants to test domain before dns migration.
 

--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add system quota
 # options: NONE
+# labels: 
 #
 # The script enables filesystem quota on /home partition
 

--- a/bin/v-add-sys-sftp-jail
+++ b/bin/v-add-sys-sftp-jail
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add system sftp jail
 # options: [RESTART]
+# labels: 
 #
 # The script enables sftp jailed environment
 

--- a/bin/v-add-sys-theme
+++ b/bin/v-add-sys-theme
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: install theme from local source or GitHub.
 # options: THEME [MODE] [ACTIVE]
+# labels: hestia
 #
 # The function for installing a custom theme or downloading one
 # from the HestiaCP theme repository.

--- a/bin/v-add-sys-theme
+++ b/bin/v-add-sys-theme
@@ -1,7 +1,7 @@
 #!/bin/bash
 # info: install theme from local source or GitHub.
-# options: theme [MODE] [ACTIVE]
-
+# options: THEME [MODE] [ACTIVE]
+#
 # The function for installing a custom theme or downloading one
 # from the HestiaCP theme repository.
 

--- a/bin/v-add-sys-webmail
+++ b/bin/v-add-sys-webmail
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add webmail support for a domain
 # options: USER DOMAIN [RESTART] [QUIET]
+# labels: hestia
 #
 # this function adds support for webmail services
 # to a mail domain.

--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add system user
 # options: USER PASSWORD EMAIL [PACKAGE] [NAME]
+# labels: 
+#
+# example: v-add-user admin2 P4$$w@rD bgates@aol.com
 #
 # The function creates new user account.
 

--- a/bin/v-add-user-2fa
+++ b/bin/v-add-user-2fa
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add 2fa to existing user
 # options: USER
+# labels: hestia panel
+#
+# example: v-add-user-2fa admin
 #
 # The function creates a new 2fa token for user.
 

--- a/bin/v-add-user-composer
+++ b/bin/v-add-user-composer
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add composer (php dependency manager) for a user
 # options: USER
+# labels: hestia
 #
 # The function adds support for composer (php dependency manager)
 # Homepage: https://getcomposer.org/

--- a/bin/v-add-user-notification
+++ b/bin/v-add-user-notification
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add user notification
 # options: USER TOPIC NOTICE [TYPE]
+# labels: 
 #
 # The function adds user notification.
 

--- a/bin/v-add-user-package
+++ b/bin/v-add-user-package
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: adding user package
 # options: PKG_DIR PACKAGE [REWRITE]
+# labels: 
 #
 # The function adds new user package to the system.
 

--- a/bin/v-add-user-sftp-jail
+++ b/bin/v-add-user-sftp-jail
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add user sftp jail
 # options: USER [RESTART]
+# labels: 
+#
+# example: v-add-user-sftp-jail admin
 #
 # The script enables sftp jailed environment
 

--- a/bin/v-add-user-sftp-key
+++ b/bin/v-add-user-sftp-key
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add user sftp key
 # options: USER [TTL]
+# labels: hestia
 #
 # The script creates and updates ssh key for filemanager usage
 

--- a/bin/v-add-user-ssh-key
+++ b/bin/v-add-user-ssh-key
@@ -1,8 +1,8 @@
 #!/bin/bash
 # info: add ssh key
-# options: USER key
+# options: USER KEY
 #
-# Function check if $user/.ssh/authorized_keys exists and create it
+# Function check if $user/.ssh/authorized_keys exists and create it.
 # After that it append the new key(s)
 
 #----------------------------------------------------------#

--- a/bin/v-add-user-ssh-key
+++ b/bin/v-add-user-ssh-key
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add ssh key
 # options: USER KEY
+# labels: hestia
 #
 # Function check if $user/.ssh/authorized_keys exists and create it.
 # After that it append the new key(s)

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add web domain
 # options: USER DOMAIN [IP] [ALIASES] [PROXY_EXTENSIONS] [RESTART]
+# labels: web
+#
+# example: v-add-web-domain admin wonderland.com 192.18.22.43 yes www.wonderland.com
 #
 # The function adds virtual host to a server. In cases when ip is
 # undefined in the script, "default" template will be used. The alias of

--- a/bin/v-add-web-domain-alias
+++ b/bin/v-add-web-domain-alias
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add web domain alias
 # options: USER DOMAIN ALIASES [RESTART]
+# labels: web
+#
+# example: v-add-web-domain-alias admin acme.com www.acme.com yes
 #
 # The call is intended for adding aliases to a domain (it is also called
 # "domain parking"). The function supports wildcards *.domain.tpl.

--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add web domain backend
 # options: USER DOMAIN [TEMPLATE] [RESTART]
+# labels: web
+#
+# example: v-add-web-domain-backend admin exmaple.com default yes
 #
 # The call is used for adding web backend configuration.
 

--- a/bin/v-add-web-domain-ftp
+++ b/bin/v-add-web-domain-ftp
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add ftp account for web domain.
 # options: USER DOMAIN FTP_USER FTP_PASSWORD [FTP_PATH]
+# labels: web
+#
+# example: v-add-web-domain-ftp alice wonderland.com alice_ftp p4$$vvOrD
 #
 # The function creates additional ftp account for web domain.
 

--- a/bin/v-add-web-domain-httpauth
+++ b/bin/v-add-web-domain-httpauth
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add password protection for web domain
 # options: USER DOMAIN AUTH_USER AUTH_PASSWORD [RESTART]
+# labels: web
+#
+# example: v-add-web-domain-httpauth admin acme.com user02 super_pass
 #
 # The call is used for securing web domain with http auth
 

--- a/bin/v-add-web-domain-proxy
+++ b/bin/v-add-web-domain-proxy
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add webdomain proxy support
 # options: USER DOMAIN [TEMPLATE] [EXTENTIONS] [RESTART]
+# labels: web
+#
+# example: v-add-web-domain-proxy admin example.com
 #
 # The function enables proxy support for a domain. This can significantly
 # improve website speed.

--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -1,11 +1,14 @@
 #!/bin/bash
 # info: adding ssl for domain
 # options: USER DOMAIN SSL_DIR [SSL_HOME] [RESTART]
+# labels: web
+#
+# example: v-add-web-domain-ssl admin example.com /home/admin/conf/example.com/web
 #
 # The function turns on SSL support for a domain. Parameter ssl_dir is a path
 # to directory where 2 or 3 ssl files can be found. Certificate file 
-# domain.tld.crt and its key domain.tld.key  are mandatory. Certificate
-# authority domain.tld.ca file is optional. If home directory  parameter
+# domain.tld.crt and its key domain.tld.key are mandatory. Certificate
+# authority domain.tld.ca file is optional. If home directory parameter
 # (ssl_home) is not set, https domain uses public_shtml as separate
 # documentroot directory.
 

--- a/bin/v-add-web-domain-ssl-force
+++ b/bin/v-add-web-domain-ssl-force
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: Adding force SSL for a domain
 # options: USER DOMAIN
+# labels: hestia web
+#
+# example: v-add-web-domain-ssl-force admin acme.com
 #
 # The function forces SSL for the requested domain.
 

--- a/bin/v-add-web-domain-ssl-hsts
+++ b/bin/v-add-web-domain-ssl-hsts
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: Adding hsts to a domain
 # options: USER DOMAIN
+# labels: hestia
 #
 # The function enables HSTS for the requested domain.
 

--- a/bin/v-add-web-domain-stats
+++ b/bin/v-add-web-domain-stats
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add log analyzer to generate domain statitics
 # options: USER DOMAIN TYPE
+# labels: web
+#
+# example: v-add-web-domain-stats admin example.com awstats
 #
 # The call is used for enabling log analyzer system to a domain. For viewing
 # the domain statistics use http://domain.tld/vstats/ link. Access this page

--- a/bin/v-add-web-domain-stats-user
+++ b/bin/v-add-web-domain-stats-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: add password protection to web domain statistics
 # options: USER DOMAIN STATS_USER STATS_PASSWORD [RESTART]
+# labels: web
+#
+# example: v-add-web-domain-stats-user admin example.com watchdog your_password
 #
 # The call is used for securing the web statistics page.
 

--- a/bin/v-add-web-php
+++ b/bin/v-add-web-php
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add php fpm version
 # options: VERSION
+# labels: hestia
 #
 # The function checks and delete a fpm php version if not used by any domain.
 

--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: backup system user with all its objects
 # options: USER NOTIFY
+# labels: 
+#
+# example: v-backup-user admin yes
 #
 # The call is used for backing up user with all its domains and databases.
 

--- a/bin/v-backup-users
+++ b/bin/v-backup-users
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: backup all users
 # options: NONE
+# labels: 
 #
 # The function backups all system users.
 

--- a/bin/v-change-cron-job
+++ b/bin/v-change-cron-job
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change cron job
 # options: USER JOB MIN HOUR DAY MONTH WDAY COMMAND
+# labels: 
+#
+# example: v-change-cron-job admin 7 * * * * * * /usr/bin/uptime
 #
 # The function is used for changing existing job. It fully replace job
 # parameters with new one but with same id.

--- a/bin/v-change-database-host-password
+++ b/bin/v-change-database-host-password
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change database server password
 # options: TYPE HOST USER PASSWORD
+# labels: 
+#
+# example: v-change-database-host-password mysql localhost wp_user pA$$w@rD
 #
 # The function changes database server password.
 

--- a/bin/v-change-database-owner
+++ b/bin/v-change-database-owner
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change database owner
 # options: DATABASE USER
+# labels: 
+#
+# example: v-change-database-owner mydb alice
 #
 # The function for changing database owner.
 

--- a/bin/v-change-database-password
+++ b/bin/v-change-database-password
@@ -1,8 +1,11 @@
 #!/bin/bash
 # info: change database password
 # options: USER DATABASE DBPASS
+# labels: 
 #
-# The function for changing database user  password to a database. It uses the
+# example: v-change-database-password admin wp_db neW_pAssWorD
+#
+# The function for changing database user password to a database. It uses the
 # full name of database as argument.
 
 

--- a/bin/v-change-database-user
+++ b/bin/v-change-database-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change database username
 # options: USER DATABASE DBUSER [DBPASS]
+# labels: 
+#
+# example: v-change-database-user admin my_db joe_user
 #
 # The function for changing database user. It uses the
 

--- a/bin/v-change-dns-domain-exp
+++ b/bin/v-change-dns-domain-exp
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain expiration date
 # options: USER DOMAIN EXP
+# labels: dns
+#
+# example: v-change-dns-domain-exp admin domain.pp.ua 2020-11-20
 #
 # The function of changing the term of expiration domain's registration. The
 # serial number will be refreshed automatically during update.

--- a/bin/v-change-dns-domain-ip
+++ b/bin/v-change-dns-domain-ip
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change dns domain ip address
-# options: USER DOMAIN IP
+# options: USER DOMAIN IP [RESTART]
 #
 # The function for changing the main ip of DNS zone.
 
@@ -31,7 +31,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '3' "$#" 'USER DOMAIN IP'
+check_args '3' "$#" 'USER DOMAIN IP [RESTART]'
 is_format_valid 'user' 'domain' 'ip'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-change-dns-domain-ip
+++ b/bin/v-change-dns-domain-ip
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain ip address
 # options: USER DOMAIN IP [RESTART]
+# labels: dns
+#
+# example: v-change-dns-domain-ip admin domain.com 123.212.111.222
 #
 # The function for changing the main ip of DNS zone.
 

--- a/bin/v-change-dns-domain-soa
+++ b/bin/v-change-dns-domain-soa
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain soa record
 # options: USER DOMAIN SOA [RESTART]
+# labels: dns
+#
+# example: v-change-dns-domain-soa admin acme.com d.ns.domain.tld
 #
 # The function for changing SOA record. This type of records can not be
 # modified by v-change-dns-record call.

--- a/bin/v-change-dns-domain-soa
+++ b/bin/v-change-dns-domain-soa
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change dns domain soa record
-# options: USER DOMAIN SOA
+# options: USER DOMAIN SOA [RESTART]
 #
 # The function for changing SOA record. This type of records can not be
 # modified by v-change-dns-record call.
@@ -32,7 +32,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '3' "$#" 'USER DOMAIN SOA'
+check_args '3' "$#" 'USER DOMAIN SOA [RESTART]'
 is_format_valid 'user' 'domain' 'soa'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-change-dns-domain-tpl
+++ b/bin/v-change-dns-domain-tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain template
 # options: USER DOMAIN TEMPLATE [RESTART]
+# labels: dns
+#
+# example: v-change-dns-domain-tpl admin example.com child-ns yes
 #
 # The function for changing the template of records. By updating old records
 # will be removed and new records will be generated in accordance with

--- a/bin/v-change-dns-domain-ttl
+++ b/bin/v-change-dns-domain-ttl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain ttl
 # options: USER DOMAIN TTL [RESTART]
+# labels: dns
+#
+# example: v-change-dns-domain-ttl alice example.com 14400
 #
 # The function for changing the time to live TTL parameter for all records.
 

--- a/bin/v-change-dns-domain-ttl
+++ b/bin/v-change-dns-domain-ttl
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change dns domain ttl
-# options: USER DOMAIN TTL
+# options: USER DOMAIN TTL [RESTART]
 #
 # The function for changing the time to live TTL parameter for all records.
 
@@ -31,7 +31,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '3' "$#" 'USER DOMAIN TTL'
+check_args '3' "$#" 'USER DOMAIN TTL [RESTART]'
 is_format_valid 'user' 'domain' 'ttl'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-change-dns-record
+++ b/bin/v-change-dns-record
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change dns domain record
-# options: USER DOMAIN ID VALUE [PRIORITY] [RESTART] [TTL]
+# options: USER DOMAIN ID RECORD TYPE VALUE [PRIORITY] [RESTART] [TTL]
 #
 # The function for changing DNS record.
 

--- a/bin/v-change-dns-record
+++ b/bin/v-change-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain record
 # options: USER DOMAIN ID RECORD TYPE VALUE [PRIORITY] [RESTART] [TTL]
+# labels: dns
+#
+# example: v-change-dns-record admin domain.ua 42 192.18.22.43
 #
 # The function for changing DNS record.
 

--- a/bin/v-change-dns-record-id
+++ b/bin/v-change-dns-record-id
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change dns domain record id
 # options: USER DOMAIN ID NEWID [RESTART]
+# labels: dns
+#
+# example: v-change-dns-record-id admin acme.com 24 42 yes
 #
 # The function for changing internal record id.
 

--- a/bin/v-change-domain-owner
+++ b/bin/v-change-domain-owner
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change domain owner
 # options: DOMAIN USER
+# labels: 
+#
+# example: v-change-domain-owner www.example.com bob
 #
 # The function of changing domain ownership.
 

--- a/bin/v-change-firewall-rule
+++ b/bin/v-change-firewall-rule
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change firewall rule
 # options: RULE ACTION IP PORT [PROTOCOL] [COMMENT]
+# labels: 
+#
+# example: v-change-firewall-rule 3 ACCEPT 5.188.123.17 443
 #
 # The function is used for changing existing firewall rule.
 # It fully replace rule with new one but keeps same id.

--- a/bin/v-change-fs-file-permission
+++ b/bin/v-change-fs-file-permission
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change file permission
 # options: USER FILE PERMISSIONS
+# labels: 
+#
+# example: v-change-fs-file-permission admin readme.txt 0777
 #
 # The function changes file access permissions on the file system
 

--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change mail account password
 # options: USER DOMAIN ACCOUNT PASSWORD
+# labels: mail
+#
+# example: v-change-mail-account-password admin mydomain.tld user p4$$vvOrD
 #
 # The function changes email account password.
 

--- a/bin/v-change-mail-account-quota
+++ b/bin/v-change-mail-account-quota
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change mail account quota
 # options: USER DOMAIN ACCOUNT QUOTA
+# labels: mail
+#
+# example: v-change-mail-account-quota admin mydomain.tld user01 unlimited
 #
 # The function changes email account disk quota.
 

--- a/bin/v-change-mail-domain-catchall
+++ b/bin/v-change-mail-domain-catchall
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change mail domain catchall email
 # options: USER DOMAIN EMAIL
+# labels: mail
+#
+# example: v-change-mail-domain-catchall user01 mydomain.tld master@mydomain.tld
 #
 # The function changes mail domain catchall.
 

--- a/bin/v-change-mail-domain-sslcert
+++ b/bin/v-change-mail-domain-sslcert
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: change domain ssl certificate
 # options: USER DOMAIN SSL_DIR [RESTART]
+# labels: hestia
 #
 # The function changes SSL domain certificate and the key. If ca file present
 # it will be replaced as well.

--- a/bin/v-change-remote-dns-domain-exp
+++ b/bin/v-change-remote-dns-domain-exp
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: change remote dns domain expiration date
 # options: USER DOMAIN
+# labels: dns
 #
 # The function synchronize dns domain with the remote server.
 

--- a/bin/v-change-remote-dns-domain-soa
+++ b/bin/v-change-remote-dns-domain-soa
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change remote dns domain SOA
 # options: USER DOMAIN
+# labels: dns
+#
+# example: v-change-remote-dns-domain-soa admin example.org.uk
 #
 # The function synchronize dns domain with the remote server.
 

--- a/bin/v-change-remote-dns-domain-ttl
+++ b/bin/v-change-remote-dns-domain-ttl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change remote dns domain TTL
 # options: USER DOMAIN
+# labels: dns
+#
+# example: v-change-remote-dns-domain-ttl admin domain.tld
 #
 # The function synchronize dns domain with the remote server.
 

--- a/bin/v-change-sys-config-value
+++ b/bin/v-change-sys-config-value
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change sysconfig value
 # options: KEY VALUE
+# labels: panel
+#
+# example: v-change-sys-config-value VERSION 1.0
 #
 # The function is for changing main config settings such as COMPANY_NAME or
 # COMPANY_EMAIL and so on.

--- a/bin/v-change-sys-db-alias
+++ b/bin/v-change-sys-db-alias
@@ -1,11 +1,12 @@
 #!/bin/bash
 # info: change phpmyadmin/phppgadmin alias url
-# options: type alias
-# example:  v-change-sys-db-alias pma phpmyadmin
-#           Sets phpMyAdmin alias to phpmyadmin
+# options: TYPE ALIAS
 #
-# example:  v-change-sys-db-alias pga phppgadmin
-#           Sets phpPgAdmin alias to phppgadmin
+# example: v-change-sys-db-alias pma phpmyadmin
+#          # Sets phpMyAdmin alias to phpmyadmin
+#
+# example: v-change-sys-db-alias pga phppgadmin
+#          # Sets phpPgAdmin alias to phppgadmin
 #
 # This function changes the database editor url in
 # apache2 or nginx configuration.

--- a/bin/v-change-sys-db-alias
+++ b/bin/v-change-sys-db-alias
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: change phpmyadmin/phppgadmin alias url
 # options: TYPE ALIAS
+# labels: hestia
 #
 # example: v-change-sys-db-alias pma phpmyadmin
 #          # Sets phpMyAdmin alias to phpmyadmin

--- a/bin/v-change-sys-demo-mode
+++ b/bin/v-change-sys-demo-mode
@@ -1,10 +1,10 @@
 #!/bin/bash
 # info: enable or disable demo mode
 # options: ACTIVE
+#
 # This function will set the demo mode variable,
 # which will prevent usage of certain v-scripts in the backend
 # and prevent modification of objects in the control panel.
-#
 # It will also disable virtual hosts for Apache and NGINX
 # for domains which have been created.
 

--- a/bin/v-change-sys-demo-mode
+++ b/bin/v-change-sys-demo-mode
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: enable or disable demo mode
 # options: ACTIVE
+# labels: hestia
 #
 # This function will set the demo mode variable,
 # which will prevent usage of certain v-scripts in the backend

--- a/bin/v-change-sys-hestia-ssl
+++ b/bin/v-change-sys-hestia-ssl
@@ -3,7 +3,7 @@
 # options: SSL_DIR [RESTART]
 # labels: panel
 #
-# example: v-change-hestia-ssl /home/new/dir/path yes
+# example: v-change-sys-hestia-ssl /home/new/dir/path yes
 #
 # The function changes hestia SSL certificate and the key.
 

--- a/bin/v-change-sys-hestia-ssl
+++ b/bin/v-change-sys-hestia-ssl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change hestia ssl certificate
 # options: SSL_DIR [RESTART]
+# labels: panel
+#
+# example: v-change-hestia-ssl /home/new/dir/path yes
 #
 # The function changes hestia SSL certificate and the key.
 

--- a/bin/v-change-sys-hostname
+++ b/bin/v-change-sys-hostname
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change hostname
 # options: HOSTNAME
+# labels: panel
+#
+# example: v-change-sys-hostname mydomain.tld
 #
 # The function for changing system hostname.
 

--- a/bin/v-change-sys-ip-name
+++ b/bin/v-change-sys-ip-name
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change ip name
 # options: IP NAME
+# labels: panel
+#
+# example: v-change-sys-ip-name 80.122.52.70 acme.com
 #
 # The function for changing dns domain associated with ip.
 

--- a/bin/v-change-sys-ip-nat
+++ b/bin/v-change-sys-ip-nat
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change ip nat address
 # options: IP NAT_IP [RESTART]
+# labels: panel
+#
+# example: 185.209.50.140 10.110.104.205
 #
 # The function for changing nat ip associated with ip.
 

--- a/bin/v-change-sys-ip-nat
+++ b/bin/v-change-sys-ip-nat
@@ -3,7 +3,7 @@
 # options: IP NAT_IP [RESTART]
 # labels: panel
 #
-# example: 185.209.50.140 10.110.104.205
+# example: v-change-sys-ip-nat 185.209.50.140 10.110.104.205
 #
 # The function for changing nat ip associated with ip.
 

--- a/bin/v-change-sys-ip-owner
+++ b/bin/v-change-sys-ip-owner
@@ -3,7 +3,7 @@
 # options: IP USER
 # labels: panel
 #
-# example: 91.198.136.14 admin
+# example: v-change-sys-ip-owner 91.198.136.14 admin
 #
 # The function of changing ip address ownership.
 

--- a/bin/v-change-sys-ip-owner
+++ b/bin/v-change-sys-ip-owner
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change ip owner
 # options: IP USER
+# labels: panel
+#
+# example: 91.198.136.14 admin
 #
 # The function of changing ip address ownership.
 

--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change ip status
 # options: IP IP_STATUS
+# labels: panel
+#
+# example: 91.198.136.14 yourstatus
 #
 # The function of changing an ip address's status.
 

--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -3,7 +3,7 @@
 # options: IP IP_STATUS
 # labels: panel
 #
-# example: 91.198.136.14 yourstatus
+# example: v-change-sys-ip-status 91.198.136.14 yourstatus
 #
 # The function of changing an ip address's status.
 

--- a/bin/v-change-sys-language
+++ b/bin/v-change-sys-language
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change sys language
 # options: LANGUAGE [UPDATE_USERS]
+# labels: panel
+#
+# example: v-change-sys-language ru
 #
 # The function for changing system language.
 

--- a/bin/v-change-sys-language
+++ b/bin/v-change-sys-language
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change sys language
-# options: LANGUAGE
+# options: LANGUAGE [UPDATE_USERS]
 #
 # The function for changing system language.
 
@@ -31,7 +31,7 @@ is_language_valid() {
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '1' "$#" 'LANGUAGE'
+check_args '1' "$#" 'LANGUAGE [UPDATE_USERS]'
 is_format_valid 'language'
 is_language_valid $language
 

--- a/bin/v-change-sys-port
+++ b/bin/v-change-sys-port
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change system backend port
 # options: PORT
+# labels: hestia panel
+#
+# example: v-change-sys-port 5678
 #
 # The function for changing the system backend port in NGINX configuration.
 

--- a/bin/v-change-sys-release
+++ b/bin/v-change-sys-release
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update web templates
 # options: [RESTART]
+# labels: hestia
 #
 # The function for changing the release branch for the
 # Hestia Control Panel. This allows the user to switch between

--- a/bin/v-change-sys-service-config
+++ b/bin/v-change-sys-service-config
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change service config
 # options: CONFIG SERVICE [RESTART]
+# labels: panel
+#
+# example: v-change-sys-service-config /home/admin/dovecot.conf dovecot yes
 #
 # The function for changing service confguration.
 

--- a/bin/v-change-sys-theme
+++ b/bin/v-change-sys-theme
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update web templates
 # options: THEME
+# labels: hestia
 #
 # The function for changing the currently active system theme.
 

--- a/bin/v-change-sys-theme
+++ b/bin/v-change-sys-theme
@@ -1,5 +1,6 @@
 #!/bin/bash
 # info: update web templates
+# options: NONE
 #
 # The function for changing the currently active system theme.
 

--- a/bin/v-change-sys-theme
+++ b/bin/v-change-sys-theme
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: update web templates
-# options: NONE
+# options: THEME
 #
 # The function for changing the currently active system theme.
 

--- a/bin/v-change-sys-timezone
+++ b/bin/v-change-sys-timezone
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change system timezone
 # options: TIMEZONE
+# labels: panel
+#
+# example: v-change-sys-timezone Europe/Berlin
 #
 # The function for changing system timezone.
 

--- a/bin/v-change-sys-webmail
+++ b/bin/v-change-sys-webmail
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change webmail alias url
 # options: WEBMAIL
+# labels: hestia panel
+#
+# example: v-change-sys-webmail YourtrickyURLhere
 #
 # This function changes the webmail url in apache2 or nginx configuration.
 

--- a/bin/v-change-user-contact
+++ b/bin/v-change-user-contact
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user contact email
 # options: USER EMAIL
+# labels: panel
+#
+# example: v-change-user-contact admin admin@yahoo.com
 #
 # The function for changing of e-mail associated with a certain user.
 

--- a/bin/v-change-user-language
+++ b/bin/v-change-user-language
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user language
 # options: USER LANGUAGE
+# labels: panel
+#
+# example: v-change-user-language admin en
 #
 # The function for changing language.
 

--- a/bin/v-change-user-name
+++ b/bin/v-change-user-name
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user full name
 # options: USER NAME [LAST_NAME]
+# labels: panel
+#
+# example: v-change-user-name admin John Smith
 #
 # The function allow to change user's full name.
 

--- a/bin/v-change-user-name
+++ b/bin/v-change-user-name
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change user full name
-# options: USER NAME
+# options: USER NAME [LAST_NAME]
 #
 # The function allow to change user's full name.
 
@@ -23,7 +23,7 @@ source $HESTIA/conf/hestia.conf
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'USER NAME'
+check_args '2' "$#" 'USER NAME [LAST_NAME]'
 is_format_valid 'user' 'name'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"

--- a/bin/v-change-user-ns
+++ b/bin/v-change-user-ns
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user nameservers
 # options: USER NS1 NS2 [NS3] [NS4] [NS5] [NS6] [NS7] [NS8]
+# labels: panel
+#
+# example: v-change-user-ns ns1.domain.tld ns2.domain.tld
 #
 # The function for changing default nameservers for specific user.
 

--- a/bin/v-change-user-package
+++ b/bin/v-change-user-package
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user package
 # options: USER PACKAGE [FORCE]
+# labels: panel
+#
+# example: v-change-user-package admin yourpackage
 #
 # The function changes user's hosting package.
 

--- a/bin/v-change-user-password
+++ b/bin/v-change-user-password
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user password
 # options: USER PASSWORD
+# labels: panel
+#
+# example: v-change-user-password admin NewPassword123
 #
 # The function changes user's password and updates RKEY value.
 

--- a/bin/v-change-user-php-cli
+++ b/bin/v-change-user-php-cli
@@ -1,7 +1,7 @@
 #!/bin/bash
 # info: add php version to .bash_aliases
 # options: USER VERSION
-
+#
 #  add line to .bash_aliases to set default php incase of multiPHP
 
 

--- a/bin/v-change-user-php-cli
+++ b/bin/v-change-user-php-cli
@@ -1,8 +1,9 @@
 #!/bin/bash
 # info: add php version to .bash_aliases
 # options: USER VERSION
+# labels: hestia
 #
-#  add line to .bash_aliases to set default php incase of multiPHP
+# add line to .bash_aliases to set default php incase of multiPHP
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-user-rkey
+++ b/bin/v-change-user-rkey
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: change user password
 # options: USER
+# labels: hestia
 #
 # The function changes user's password and updates RKEY value.
 

--- a/bin/v-change-user-role
+++ b/bin/v-change-user-role
@@ -1,6 +1,8 @@
 #!/bin/bash
 # info: updates user role
 # options: USER ROLE
+#
+# The function changes user's role.
 
 #----------------------------------------------------------#
 #                    Variable&Function                     #

--- a/bin/v-change-user-role
+++ b/bin/v-change-user-role
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: updates user role
 # options: USER ROLE
+# labels: hestia
 #
 # The function changes user's role.
 

--- a/bin/v-change-user-shell
+++ b/bin/v-change-user-shell
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user shell
 # options: USER SHELL
+# labels: panel
+#
+# example: v-change-user-shell admin nologin
 #
 # The function changes system shell of a user. Shell gives ability to use ssh.
 

--- a/bin/v-change-user-template
+++ b/bin/v-change-user-template
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change user default template
 # options: USER TYPE TEMPLATE
+# labels: panel
+#
+# example: v-change-user-template admin WEB wordpress
 #
 # The function changes default user web template.
 

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change web domain backend template
 # options: USER DOMAIN TEMPLATE [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-backend-tpl admin acme.com socket
 #
 # The function changes backend template
 

--- a/bin/v-change-web-domain-dirlist
+++ b/bin/v-change-web-domain-dirlist
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: enable/disable directory listing
 # options: USER DOMAIN MODE
+# labels: hestia
 #
 # The call is used for changing the directory list mode.
 

--- a/bin/v-change-web-domain-docroot
+++ b/bin/v-change-web-domain-docroot
@@ -1,14 +1,15 @@
 #!/bin/bash
 # info: Changes the document root for an existing web domain
-
 # options: USER DOMAIN TARGET_DOMAIN [DIRECTORY] [PHP]
-# example usage:
-# add custom docroot:    v-change-web-domain-docroot admin domain.tld otherdomain.tld
-#                        points domain.tld to otherdomain.tld's document root.
 #
-# remove custom docroot: v-change-web-domain-docroot admin test.local default
-#                        returns document root to default value for domain.
-
+# example: v-change-web-domain-docroot admin domain.tld otherdomain.tld
+#          # add custom docroot
+#          # points domain.tld to otherdomain.tld's document root.
+#
+# example: v-change-web-domain-docroot admin test.local default
+#          # remove custom docroot
+#          # returns document root to default value for domain.
+#
 # This call changes the document root of a chosen web domain
 # to another available domain under the user context.
 

--- a/bin/v-change-web-domain-docroot
+++ b/bin/v-change-web-domain-docroot
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: Changes the document root for an existing web domain
 # options: USER DOMAIN TARGET_DOMAIN [DIRECTORY] [PHP]
+# labels: hestia
 #
 # example: v-change-web-domain-docroot admin domain.tld otherdomain.tld
 #          # add custom docroot

--- a/bin/v-change-web-domain-ftp-password
+++ b/bin/v-change-web-domain-ftp-password
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change ftp user password.
 # options: USER DOMAIN FTP_USER FTP_PASSWORD
+# labels: web
+#
+# example: v-change-web-domain-ftp-password admin example.com ftp_usr ftp_qwerty
 #
 # The function changes ftp user password.
 

--- a/bin/v-change-web-domain-ftp-path
+++ b/bin/v-change-web-domain-ftp-path
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change path for ftp user.
 # options: USER DOMAIN FTP_USER FTP_PATH
+# labels: web
+#
+# example: v-change-web-domain-ftp-path admin example.com /home/admin/example.com
 #
 # The function changes ftp user path.
 

--- a/bin/v-change-web-domain-httpauth
+++ b/bin/v-change-web-domain-httpauth
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change password for http auth user
 # options: USER DOMAIN AUTH_USER AUTH_PASSWORD [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-httpauth admin acme.com alice white_rA$$bIt
 #
 # The call is used for changing http auth user password
 

--- a/bin/v-change-web-domain-httpauth
+++ b/bin/v-change-web-domain-httpauth
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change password for http auth user
-# options: USER DOMAIN AUTH_USER AUTH_PASSWORD
+# options: USER DOMAIN AUTH_USER AUTH_PASSWORD [RESTART]
 #
 # The call is used for changing http auth user password
 

--- a/bin/v-change-web-domain-ip
+++ b/bin/v-change-web-domain-ip
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change web domain ip
 # options: USER DOMAIN DOMAIN [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-ip admin example.com 167.86.105.230 yes
 #
 # The call is used for changing domain ip
 

--- a/bin/v-change-web-domain-name
+++ b/bin/v-change-web-domain-name
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change web domain name
 # options: USER DOMAIN NEW_DOMAIN [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-name alice wonderland.com lookinglass.com yes
 #
 # The call is used for changing the domain name.
 

--- a/bin/v-change-web-domain-proxy-tpl
+++ b/bin/v-change-web-domain-proxy-tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change web domain proxy template
 # options: USER DOMAIN TEMPLATE [EXTENTIONS] [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-proxy-tpl admin domain.tld hosting
 #
 # The function changes proxy template
 

--- a/bin/v-change-web-domain-sslcert
+++ b/bin/v-change-web-domain-sslcert
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change domain ssl certificate
 # options: USER DOMAIN SSL_DIR [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-sslcert admin example.com /home/admin/tmp
 #
 # The function changes SSL domain certificate and the key. If ca file present
 # it will be replaced as well.

--- a/bin/v-change-web-domain-sslhome
+++ b/bin/v-change-web-domain-sslhome
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: changing domain ssl home
-# options: NONE
+# options: USER DOMAIN SSL_HOME [RESTART]
 #
 # The function changes SSL home directory.
 

--- a/bin/v-change-web-domain-sslhome
+++ b/bin/v-change-web-domain-sslhome
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: changing domain ssl home
 # options: USER DOMAIN SSL_HOME [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-sslhome admin acme.com /home/admin/acme.com/public_shtml
 #
 # The function changes SSL home directory.
 

--- a/bin/v-change-web-domain-sslhome
+++ b/bin/v-change-web-domain-sslhome
@@ -1,5 +1,8 @@
 #!/bin/bash
 # info: changing domain ssl home
+# options: NONE
+#
+# The function changes SSL home directory.
 
 #----------------------------------------------------------#
 #                    Variable&Function                     #

--- a/bin/v-change-web-domain-stats
+++ b/bin/v-change-web-domain-stats
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change web domain statistics
 # options: USER DOMAIN TYPE
+# labels: web
+#
+# example: v-change-web-domain-stats admin example.com awstats
 #
 # The function of deleting site's system of statistics. Its type is
 # automatically chooses from client's configuration file.

--- a/bin/v-change-web-domain-tpl
+++ b/bin/v-change-web-domain-tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: change web domain template
 # options: USER DOMAIN TEMPLATE [RESTART]
+# labels: web
+#
+# example: v-change-web-domain-tpl admin acme.com opencart
 #
 # The function changes template of the web configuration file. The content
 # of webdomain directories remains untouched.

--- a/bin/v-check-api-key
+++ b/bin/v-check-api-key
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: check api key
 # options: KEY [IP]
+# labels: 
 #
 # The function checks a key file in $HESTIA/data/keys/
 

--- a/bin/v-check-api-key
+++ b/bin/v-check-api-key
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: check api key
-# options: KEY
+# options: KEY [IP]
 #
 # The function checks a key file in $HESTIA/data/keys/
 

--- a/bin/v-check-fs-permission
+++ b/bin/v-check-fs-permission
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: open file
 # options: USER FILE
+# labels: 
+#
+# example: v-check-fs-permission admin readme.txt
 #
 # The function opens/reads files on the file system
 

--- a/bin/v-check-user-2fa
+++ b/bin/v-check-user-2fa
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: check user token
 # options: USER TOKEN
+# labels: hestia panel
+#
+# example: v-check-user-2fa admin 493690
 #
 # The function verifies user 2fa token.
 

--- a/bin/v-check-user-hash
+++ b/bin/v-check-user-hash
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: check user hash
 # options: USER HASH [IP]
+# labels: 
+#
+# example: v-check-user-hash admin CN5JY6SMEyNGnyCuvmK5z4r7gtHAC4mRZ...
 #
 # The function verifies user hash
 

--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: check user password
 # options: USER PASSWORD [IP]
+# labels: 
+#
+# example: v-check-user-password admin qwerty1234
 #
 # The function verifies user password from file
 

--- a/bin/v-copy-fs-directory
+++ b/bin/v-copy-fs-directory
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: copy directory
 # options: USER SRC_DIRECTORY DST_DIRECTORY
+# labels: 
+#
+# example: v-copy-fs-directory alice /home/alice/dir1 /home/bob/dir2
 #
 # The function copies directory on the file system
 

--- a/bin/v-copy-fs-file
+++ b/bin/v-copy-fs-file
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: copy file
 # options: USER SRC_FILE DST_FILE
+# labels: 
+#
+# example: v-copy-fs-file admin readme.txt readme_new.txt
 #
 # The function copies file on the file system
 

--- a/bin/v-copy-user-package
+++ b/bin/v-copy-user-package
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: duplicate existing package
 # options: PACKAGE NEW_PACKAGE
+# labels: hestia
 #
 # The function allows the user to duplicate an existing
 # package file to facilitate easier configuration.

--- a/bin/v-copy-user-package
+++ b/bin/v-copy-user-package
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: duplicate existing package
-# options: NONE
+# options: PACKAGE NEW_PACKAGE
 #
 # The function allows the user to duplicate an existing
 # package file to facilitate easier configuration.

--- a/bin/v-copy-user-package
+++ b/bin/v-copy-user-package
@@ -1,5 +1,6 @@
 #!/bin/bash
 # info: duplicate existing package
+# options: NONE
 #
 # The function allows the user to duplicate an existing
 # package file to facilitate easier configuration.

--- a/bin/v-delete-backup-host
+++ b/bin/v-delete-backup-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete backup ftp server
 # options: TYPE [HOST]
+# labels: 
+#
+# example: v-delete-backup-host sftp
 #
 # The function deletes ftp backup host
 

--- a/bin/v-delete-backup-host
+++ b/bin/v-delete-backup-host
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete backup ftp server
-# options: TYPE
+# options: TYPE [HOST]
 #
 # The function deletes ftp backup host
 

--- a/bin/v-delete-cron-hestia-autoupdate
+++ b/bin/v-delete-cron-hestia-autoupdate
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete hestia autoupdate cron job
 # options: NONE
+# labels: 
 #
 # The function deletes hestia autoupdate cron job.
 

--- a/bin/v-delete-cron-job
+++ b/bin/v-delete-cron-job
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete cron job
 # options: USER JOB
+# labels: 
+#
+# example: v-delete-cron-job admin 9
 #
 # The function deletes cron job.
 

--- a/bin/v-delete-cron-reports
+++ b/bin/v-delete-cron-reports
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete cron reports
 # options: USER
+# labels: 
+#
+# example: v-delete-cron-reports admin
 #
 # The script for disabling reports on cron tasks and administrative
 # notifications.

--- a/bin/v-delete-cron-restart-job
+++ b/bin/v-delete-cron-restart-job
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete restart job
 # options: NONE
+# labels: 
 #
 # The script for disabling restart cron tasks
 

--- a/bin/v-delete-database
+++ b/bin/v-delete-database
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete database
 # options: USER DATABASE
+# labels: 
+#
+# example: v-delete-database admin wp_db
 #
 # The function for deleting the database. If database user have access to
 # another database, he will not be deleted.

--- a/bin/v-delete-database-host
+++ b/bin/v-delete-database-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete database server
 # options: TYPE HOST
+# labels: 
+#
+# example: v-delete-database-host pgsql localhost
 #
 # The function for deleting the database host from hestia configuration. It will
 # be deleted if there are no databases created on it only.

--- a/bin/v-delete-databases
+++ b/bin/v-delete-databases
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user databases
 # options: USER
+# labels: 
+#
+# example: v-delete-databases admin
 #
 # The function deletes all user databases.
 

--- a/bin/v-delete-dns-domain
+++ b/bin/v-delete-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete dns domain
 # options: USER DOMAIN
+# labels: dns
+#
+# example: v-delete-dns-domain alice acme.com
 #
 # The function for deleting DNS domain. By deleting it all records will also be
 # deleted.

--- a/bin/v-delete-dns-domains
+++ b/bin/v-delete-dns-domains
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete dns domains
-# options: USER
+# options: USER [RESTART]
 #
 # The function for deleting all users DNS domains.
 
@@ -22,7 +22,7 @@ source $HESTIA/conf/hestia.conf
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '1' "$#" 'USER'
+check_args '1' "$#" 'USER [RESTART]'
 is_format_valid 'user'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-delete-dns-domains
+++ b/bin/v-delete-dns-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete dns domains
 # options: USER [RESTART]
+# labels: dns
+#
+# example: v-delete-dns-domains bob
 #
 # The function for deleting all users DNS domains.
 

--- a/bin/v-delete-dns-domains-src
+++ b/bin/v-delete-dns-domains-src
@@ -3,7 +3,7 @@
 # options: USER SRC [RESTART]
 # labels: dns
 #
-# example: v-delete-dns-domain-src admin '' yes
+# example: v-delete-dns-domains-src admin '' yes
 #
 # The function for deleting DNS domains related to a certain host.
 

--- a/bin/v-delete-dns-domains-src
+++ b/bin/v-delete-dns-domains-src
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete dns domains based on SRC field
 # options: USER SRC [RESTART]
+# labels: dns
+#
+# example: v-delete-dns-domain-src admin '' yes
 #
 # The function for deleting DNS domains related to a certain host.
 

--- a/bin/v-delete-dns-on-web-alias
+++ b/bin/v-delete-dns-on-web-alias
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete dns domain or dns record based on web domain alias
-# options: USER DOMAIN
+# options: USER DOMAIN ALIAS [RESTART]
 #
 # The function deletes dns domain or dns record based on web domain alias.
 
@@ -34,7 +34,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '3' "$#" 'USER DOMAIN ALIAS'
+check_args '3' "$#" 'USER DOMAIN ALIAS [RESTART]'
 is_format_valid 'user' 'domain'
 is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'

--- a/bin/v-delete-dns-on-web-alias
+++ b/bin/v-delete-dns-on-web-alias
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete dns domain or dns record based on web domain alias
 # options: USER DOMAIN ALIAS [RESTART]
+# labels: dns
+#
+# example: v-delete-dns-on-web-alias admin example.com www.example.com
 #
 # The function deletes dns domain or dns record based on web domain alias.
 

--- a/bin/v-delete-dns-record
+++ b/bin/v-delete-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete dns record
 # options: USER DOMAIN ID [RESTART]
+# labels: dns
+#
+# example: v-delete-dns-record bob acme.com 42 yes
 #
 # The function for deleting a certain record of DNS zone.
 

--- a/bin/v-delete-domain
+++ b/bin/v-delete-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete web/dns/mail domain
 # options: USER DOMAIN
+# labels: panel
+#
+# example: v-delete-domain admin domain.tld
 #
 # The function deletes web/dns/mail domain.
 

--- a/bin/v-delete-firewall-ban
+++ b/bin/v-delete-firewall-ban
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete firewall blocking rule
 # options: IP CHAIN
+# labels: panel
+#
+# example: v-delete-firewall-ban 198.11.130.250 MAIL
 #
 # The function deletes blocking rule from system firewall
 

--- a/bin/v-delete-firewall-chain
+++ b/bin/v-delete-firewall-chain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete firewall chain
 # options: CHAIN
+# labels: panel
+#
+# example: v-delete-firewall-chain WEB
 #
 # The function adds new rule to system firewall
 

--- a/bin/v-delete-firewall-ipset
+++ b/bin/v-delete-firewall-ipset
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete firewall ipset
 # options: NAME
+# labels: hestia
 #
 # The function removes ipset from system and from hestia
 

--- a/bin/v-delete-firewall-rule
+++ b/bin/v-delete-firewall-rule
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete firewall rule
 # options: RULE
+# labels: panel
+#
+# example: v-delete-firewall-rule SSH_BLOCK
 #
 # The function deletes firewall rule.
 

--- a/bin/v-delete-fs-directory
+++ b/bin/v-delete-fs-directory
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete directory
 # options: USER DIRECTORY
+# labels: 
+#
+# example: v-delete-fs-directory admin report1
 #
 # The function deletes directory on the file system
 

--- a/bin/v-delete-fs-file
+++ b/bin/v-delete-fs-file
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete file
 # options: USER FILE
+# labels: 
+#
+# example: v-delete-fs-file admin readme.txt
 #
 # The function deletes file on the file system
 

--- a/bin/v-delete-letsencrypt-domain
+++ b/bin/v-delete-letsencrypt-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: deleting letsencrypt ssl cetificate for domain
 # options: USER DOMAIN [RESTART] [MAIL]
+# labels: panel
+#
+# example: v-delete-letsencrypt-domain admin acme.com yes
 #
 # The function turns off letsencrypt SSL support for a domain.
 

--- a/bin/v-delete-mail-account
+++ b/bin/v-delete-mail-account
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail account
 # options: USER DOMAIN ACCOUNT
+# labels: mail
+#
+# example: v-delete-mail-account admin acme.com alice
 #
 # The function deletes email account.
 

--- a/bin/v-delete-mail-account-alias
+++ b/bin/v-delete-mail-account-alias
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail account alias aka nickname
 # options: USER DOMAIN ACCOUNT ALIAS
+# labels: mail
+#
+# example: v-delete-mail-account-alias admin example.com alice alicia
 #
 # The function deletes email account alias.
 

--- a/bin/v-delete-mail-account-autoreply
+++ b/bin/v-delete-mail-account-autoreply
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail account autoreply message
 # options: USER DOMAIN ACCOUNT ALIAS
+# labels: mail
+#
+# example: v-delete-mail-account-autoreply admin mydomain.tld bob
 #
 # The function delete email account autoreply.
 

--- a/bin/v-delete-mail-account-forward
+++ b/bin/v-delete-mail-account-forward
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail account forward
 # options: USER DOMAIN ACCOUNT EMAIL
+# labels: mail
+#
+# example: v-delete-mail-account-forward admin acme.com tony bob@acme.com
 #
 # The function add delete email account forward address.
 

--- a/bin/v-delete-mail-account-fwd-only
+++ b/bin/v-delete-mail-account-fwd-only
@@ -3,7 +3,7 @@
 # options: USER DOMAIN ACCOUNT
 # labels: mail
 #
-# example: v-delete-mail-accont-fwd-only admin example.com jack
+# example: v-delete-mail-account-fwd-only admin example.com jack
 #
 # The function deletes fwd-only flag
 

--- a/bin/v-delete-mail-account-fwd-only
+++ b/bin/v-delete-mail-account-fwd-only
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail account forward-only flag
 # options: USER DOMAIN ACCOUNT
+# labels: mail
+#
+# example: v-delete-mail-accont-fwd-only admin example.com jack
 #
 # The function deletes fwd-only flag
 

--- a/bin/v-delete-mail-domain
+++ b/bin/v-delete-mail-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail domain
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-delete-mail-domain admin mydomain.tld
 #
 # The function for deleting MAIL domain. By deleting it all accounts will
 # also be deleted.

--- a/bin/v-delete-mail-domain-antispam
+++ b/bin/v-delete-mail-domain-antispam
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail domain antispam support
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-delete-mail-domain-antispam admin mydomain.tld
 #
 # The function disable spamassasin for incoming emails.
 

--- a/bin/v-delete-mail-domain-antivirus
+++ b/bin/v-delete-mail-domain-antivirus
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail domain antivirus support
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-delete-mail-domain-antivirus admin mydomain.tld
 #
 # The function disables clamav scan for incoming emails.
 

--- a/bin/v-delete-mail-domain-catchall
+++ b/bin/v-delete-mail-domain-catchall
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail domain catchall email
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-delete-mail-domain-catchall admin mydomain.tld
 #
 # The function disables mail domain cathcall.
 

--- a/bin/v-delete-mail-domain-dkim
+++ b/bin/v-delete-mail-domain-dkim
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail domain dkim support
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-delete-mail-domain-dkim admin mydomain.tld
 #
 # The function delete DKIM domain pem.
 

--- a/bin/v-delete-mail-domain-dkim
+++ b/bin/v-delete-mail-domain-dkim
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete mail domain dkim support
-# options: USER DOMAIN [DKIM_SIZE]
+# options: USER DOMAIN
 #
 # The function delete DKIM domain pem.
 

--- a/bin/v-delete-mail-domain-ssl
+++ b/bin/v-delete-mail-domain-ssl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete mail domain ssl support
 # options: USER DOMAIN
+# labels: hestia
 #
 # The function delete ssl certificates.
 

--- a/bin/v-delete-mail-domains
+++ b/bin/v-delete-mail-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete mail domains
 # options: USER
+# labels: mail
+#
+# example: v-delete-mail-domains admin
 #
 # The function for deleting all users mail domains.
 

--- a/bin/v-delete-remote-dns-domain
+++ b/bin/v-delete-remote-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete remote dns domain
 # options: USER DOMAIN
+# labels: dns
+#
+# example: v-delete-remote-dns-domain admin example.tld
 #
 # The function synchronize dns with the remote server.
 

--- a/bin/v-delete-remote-dns-domains
+++ b/bin/v-delete-remote-dns-domains
@@ -1,6 +1,8 @@
 #!/bin/bash
 # info: delete remote dns domains
 # options: [HOST]
+# labels: dns
+#
 # The function deletes remote dns domains.
 
 

--- a/bin/v-delete-remote-dns-host
+++ b/bin/v-delete-remote-dns-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete remote dns host
 # options: HOST
+# labels: dns
+#
+# example: v-delete-remote-dns-host example.org
 #
 # The function for deleting the remote dns host from hestia configuration.
 

--- a/bin/v-delete-remote-dns-record
+++ b/bin/v-delete-remote-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete remote dns domain record
 # options: USER DOMAIN ID
+# labels: dns
+#
+# example: v-delete-remote-dns-record user07 acme.com 44
 #
 # The function synchronize dns with the remote server.
 

--- a/bin/v-delete-sys-filemanager
+++ b/bin/v-delete-sys-filemanager
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: remove file manager functionality from Hestia Control Panel
 # options: [FULL]
+# labels: hestia
 #
 # The function removes the File Manager and its entry points
 

--- a/bin/v-delete-sys-firewall
+++ b/bin/v-delete-sys-firewall
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete system firewall
 # options: NONE
+# labels: panel
 #
 # The script disables firewall support
 

--- a/bin/v-delete-sys-ip
+++ b/bin/v-delete-sys-ip
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete system ip
 # options: IP
+# labels: panel
+#
+# example: v-delete-sys-ip 212.42.76.210
 #
 # The function for deleting a system ip. It does not allow to delete first ip
 # on interface and do not allow to delete ip which is used by a web domain.

--- a/bin/v-delete-sys-quota
+++ b/bin/v-delete-sys-quota
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete system quota
 # options: NONE
+# labels: panel
 #
 # The script disables filesystem quota on /home partition
 

--- a/bin/v-delete-sys-sftp-jail
+++ b/bin/v-delete-sys-sftp-jail
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete system sftp jail
 # options: NONE
+# labels: panel
 #
 # The script disables sftp jailed environment
 

--- a/bin/v-delete-sys-theme
+++ b/bin/v-delete-sys-theme
@@ -1,6 +1,8 @@
 #!/bin/bash
-# info: removes a theme from the custom theme library.
+# info: removes a theme from the custom theme library
 # options: [RESTART]
+#
+# The function removes a theme from the custom theme library.
 
 
 #----------------------------------------------------------#

--- a/bin/v-delete-sys-theme
+++ b/bin/v-delete-sys-theme
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: removes a theme from the custom theme library
 # options: [RESTART]
+# labels: hestia
 #
 # The function removes a theme from the custom theme library.
 

--- a/bin/v-delete-sys-webmail
+++ b/bin/v-delete-sys-webmail
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete webmail support for a domain
 # options: USER DOMAIN [RESTART] [QUIET]
+# labels: hestia
 #
 # this function removes support for webmail from
 # a specified mail domain.

--- a/bin/v-delete-user
+++ b/bin/v-delete-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-delete-user whistler
 #
 # This function deletes a certain user and all his resources such as domains,
 # databases, cron jobs, etc.

--- a/bin/v-delete-user
+++ b/bin/v-delete-user
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete user
-# options: USER
+# options: USER [RESTART]
 #
 # This function deletes a certain user and all his resources such as domains,
 # databases, cron jobs, etc.
@@ -26,7 +26,7 @@ source $HESTIA/conf/hestia.conf
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '1' "$#" 'USER'
+check_args '1' "$#" 'USER [RESTART]'
 is_format_valid 'user'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"

--- a/bin/v-delete-user-2fa
+++ b/bin/v-delete-user-2fa
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete 2fa of existing user
 # options: USER
+# labels: hestia panel
+#
+# example: v-delete-user-2fa admin
 #
 # The function deletes 2fa token of a user.
 

--- a/bin/v-delete-user-backup
+++ b/bin/v-delete-user-backup
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user backup
 # options: USER BACKUP
+# labels: panel
+#
+# example: v-delete-user-backup admin.2012-12-21_00-10-00.tar
 #
 # The function deletes user backup.
 

--- a/bin/v-delete-user-backup-exclusions
+++ b/bin/v-delete-user-backup-exclusions
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete backup exclusion
 # options: USER [SYSTEM]
+# labels: panel
+#
+# example: v-delete-user-backup-exclusions admin
 #
 # The function for deleting backup exclusion
 

--- a/bin/v-delete-user-ips
+++ b/bin/v-delete-user-ips
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user ips
 # options: USER
+# labels: panel
+#
+# example: v-delete-user-ips admin
 #
 # The function deletes all user's ip addresses.
 

--- a/bin/v-delete-user-log
+++ b/bin/v-delete-user-log
@@ -1,5 +1,6 @@
 #!/bin/bash
 # info: Delete log file for user
+# options: NONE
 #
 # The function for deleting a users log file
 

--- a/bin/v-delete-user-log
+++ b/bin/v-delete-user-log
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: Delete log file for user
-# options: NONE
+# options: USER
 #
 # The function for deleting a users log file
 

--- a/bin/v-delete-user-log
+++ b/bin/v-delete-user-log
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: Delete log file for user
 # options: USER
+# labels: hestia
 #
 # The function for deleting a users log file
 

--- a/bin/v-delete-user-notification
+++ b/bin/v-delete-user-notification
@@ -3,7 +3,7 @@
 # options: USER NOTIFICATION
 # labels: panel
 #
-# example: admin "Hello, admin!"
+# example: v-delete-user-notification admin "Hello, admin!"
 #
 # The function deletes user notification.
 

--- a/bin/v-delete-user-notification
+++ b/bin/v-delete-user-notification
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user notification
 # options: USER NOTIFICATION
+# labels: panel
+#
+# example: admin "Hello, admin!"
 #
 # The function deletes user notification.
 

--- a/bin/v-delete-user-package
+++ b/bin/v-delete-user-package
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user package
 # options: PACKAGE
+# labels: panel
+#
+# example: v-delete-user-package admin palegreen
 #
 # The function for deleting user package. It does not allow to delete package
 # if it is in use.

--- a/bin/v-delete-user-sftp-jail
+++ b/bin/v-delete-user-sftp-jail
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete user sftp jail
 # options: USER
+# labels: panel
+#
+# example: v-delete-user-sftp-jail whistler
 #
 # The script disables sftp jailed environment for USER
 

--- a/bin/v-delete-user-ssh-key
+++ b/bin/v-delete-user-ssh-key
@@ -1,8 +1,8 @@
 #!/bin/bash
 # info: add ssh key
-# options: USER key
+# options: USER KEY
 #
-# Function check if $user/.ssh/authorized_keys exists and create it
+# Function check if $user/.ssh/authorized_keys exists and create it.
 # After that it append the new key(s)
 
 #----------------------------------------------------------#

--- a/bin/v-delete-user-ssh-key
+++ b/bin/v-delete-user-ssh-key
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add ssh key
 # options: USER KEY
+# labels: hestia
 #
 # Function check if $user/.ssh/authorized_keys exists and create it.
 # After that it append the new key(s)

--- a/bin/v-delete-web-domain
+++ b/bin/v-delete-web-domain
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete web domain
-# options: USER DOMAIN
+# options: USER DOMAIN [RESTART]
 #
 # The call of function leads to the removal of domain and all its components
 # (statistics, folders contents, ssl certificates, etc.). This operation is
@@ -34,7 +34,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'USER DOMAIN'
+check_args '2' "$#" 'USER DOMAIN [RESTART]'
 is_format_valid 'user' 'domain'
 is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-delete-web-domain
+++ b/bin/v-delete-web-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete web domain
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain admin wonderland.com
 #
 # The call of function leads to the removal of domain and all its components
 # (statistics, folders contents, ssl certificates, etc.). This operation is

--- a/bin/v-delete-web-domain-alias
+++ b/bin/v-delete-web-domain-alias
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete web domain alias
 # options: USER DOMAIN ALIAS [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain-alias admin example.com www.example.com
 #
 # The function of deleting the alias domain (parked domain). By this call
 # default www aliase can be removed as well.

--- a/bin/v-delete-web-domain-backend
+++ b/bin/v-delete-web-domain-backend
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: deleting web domain backend configuration
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain-backend admin acme.com
 #
 # The function of deleting the virtualhost backend configuration.
 

--- a/bin/v-delete-web-domain-backend
+++ b/bin/v-delete-web-domain-backend
@@ -13,6 +13,7 @@
 user=$1
 domain=$2
 domain_idn=$2
+restart=$3
 
 # Includes
 source $HESTIA/func/main.sh
@@ -29,7 +30,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'USER DOMAIN'
+check_args '2' "$#" 'USER DOMAIN [RESTART]'
 is_format_valid 'user' 'domain'
 is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-delete-web-domain-ftp
+++ b/bin/v-delete-web-domain-ftp
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete webdomain ftp account
 # options: USER DOMAIN FTP_USER
+# labels: web
+#
+# example: v-delete-web-domain-ftp admin wonderland.com bob_ftp
 #
 # The function deletes additional ftp account.
 

--- a/bin/v-delete-web-domain-httpauth
+++ b/bin/v-delete-web-domain-httpauth
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete http auth user
 # options: USER DOMAIN AUTH_USER [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain-httpauth admin example.com alice
 #
 # The call is used for deleting http auth user
 

--- a/bin/v-delete-web-domain-proxy
+++ b/bin/v-delete-web-domain-proxy
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: deleting web domain proxy configuration
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain-proxy alice lookinglass.com
 #
 # The function of deleting the virtualhost proxy configuration.
 

--- a/bin/v-delete-web-domain-proxy
+++ b/bin/v-delete-web-domain-proxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: deleting web domain proxy configuration
-# options: USER DOMAIN
+# options: USER DOMAIN [RESTART]
 #
 # The function of deleting the virtualhost proxy configuration.
 
@@ -30,7 +30,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'USER DOMAIN'
+check_args '2' "$#" 'USER DOMAIN [RESTART]'
 is_format_valid 'user' 'domain'
 is_system_enabled "$PROXY_SYSTEM" 'WEB_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-delete-web-domain-ssl
+++ b/bin/v-delete-web-domain-ssl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete web domain SSL support
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain-ssl admin acme.com
 #
 # The function disable https support and deletes SSL certificates.
 

--- a/bin/v-delete-web-domain-ssl
+++ b/bin/v-delete-web-domain-ssl
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: delete web domain SSL support
-# options: USER DOMAIN
+# options: USER DOMAIN [RESTART]
 #
 # The function disable https support and deletes SSL certificates.
 
@@ -30,7 +30,7 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'USER DOMAIN'
+check_args '2' "$#" 'USER DOMAIN [RESTART]'
 is_format_valid 'user' 'domain'
 is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
 is_object_valid 'user' 'USER' "$user"

--- a/bin/v-delete-web-domain-ssl-force
+++ b/bin/v-delete-web-domain-ssl-force
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: remove ssl force from domain
 # options: USER DOMAIN [RESTART]
+# labels: hestia web
+#
+# example: v-delete-web-domain-ssl-force admin domain.tld
 #
 # The function removes force SSL configurations.
 

--- a/bin/v-delete-web-domain-ssl-hsts
+++ b/bin/v-delete-web-domain-ssl-hsts
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: remove ssl force from domain
 # options: USER DOMAIN [RESTART]
+# labels: hestia
 #
 # The function removes force SSL configurations.
 

--- a/bin/v-delete-web-domain-stats
+++ b/bin/v-delete-web-domain-stats
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete web domain statistics
 # options: USER DOMAIN
+# labels: web
+#
+# example: v-delete-web-domain-stats user02 h1.example.com
 #
 # The function of deleting site's system of statistics. Its type is
 # automatically chooses from client's configuration file.

--- a/bin/v-delete-web-domain-stats-user
+++ b/bin/v-delete-web-domain-stats-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: disable webdomain stats  authentication support
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-delete-web-domain-stats-user admin acme.com
 #
 # The function removes authentication of statistics system. If the script is
 # called without naming a certain user, all users will be removed. After

--- a/bin/v-delete-web-domains
+++ b/bin/v-delete-web-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: delete web domains
 # options: USER [RESTART]
+# labels: web
+#
+# example: v-delete-web-domains admin
 #
 # The function deletes all user's webdomains.
 

--- a/bin/v-delete-web-php
+++ b/bin/v-delete-web-php
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: delete php fpm version
 # options: VERSION
+# labels: hestia
 #
 # The function checks and delete a fpm php version if not used by any domain.
 

--- a/bin/v-download-backup
+++ b/bin/v-download-backup
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: Download backup
-# options: USER BACKUP 
+# options: USER BACKUP
+# labels: hestia
 #
 # The function download back-up from remote server
 

--- a/bin/v-extract-fs-archive
+++ b/bin/v-extract-fs-archive
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: archive to directory
 # options: USER ARCHIVE DIRECTORY [SELECTED_DIR] [STRIP] [TEST]
+# labels: 
+#
+# example: v-extract-fs-archive admin latest.tar.gz /home/admin
 #
 # The function extracts archive into directory on the file system
 

--- a/bin/v-generate-api-key
+++ b/bin/v-generate-api-key
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: generate api key
-# options: none
+# options: NONE
 #
 # The function creates a key file in $HESTIA/data/keys/
 

--- a/bin/v-generate-api-key
+++ b/bin/v-generate-api-key
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: generate api key
 # options: NONE
+# labels: panel
 #
 # The function creates a key file in $HESTIA/data/keys/
 

--- a/bin/v-generate-password-hash
+++ b/bin/v-generate-password-hash
@@ -2,6 +2,9 @@
 <?php
 //# info: generate password hash
 //# options: HASH_METHOD SALT PASSWORD
+//# labels: panel
+//#
+//# example: v-generate-password-hash sha-512 rAnDom_string yourPassWord
 //#
 //# The function generates password hash
 

--- a/bin/v-generate-password-hash
+++ b/bin/v-generate-password-hash
@@ -1,14 +1,14 @@
 #!/usr/local/hestia/php/bin/php
 <?php
-//# info: generate password  hash
-//# options: HASH-METHOD SALT PASSWORD
-//
+//# info: generate password hash
+//# options: HASH_METHOD SALT PASSWORD
+//#
 //# The function generates password hash
 
 // Checking arguments
 if ((empty($argv[1])) || (empty($argv[2]))) {
     echo "Error: not enought arguments\n";
-    echo "Usage: " . $argv[0] ." HASH-METHOD SALT PASSWORD\n";
+    echo "Usage: " . $argv[0] ." HASH_METHOD SALT PASSWORD\n";
     exit(1);
 }
 

--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: generate self signed certificate and CSR request
 # options: DOMAIN EMAIL COUNTRY STATE CITY ORG UNIT [ALIASES] [FORMAT]
+# labels: panel
+#
+# example: v-generate-ssl-cert example.com mail@yahoo.com USA California Monterey ACME.COM IT
 #
 # The function generates self signed SSL certificate and CSR request
 

--- a/bin/v-get-dns-domain-value
+++ b/bin/v-get-dns-domain-value
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: get dns domain value
 # options: USER DOMAIN KEY
+# labels: dns
+#
+# example: v-get-dns-domain-value admin example.com SOA
 #
 # The function for getting a certain DNS domain parameter.
 

--- a/bin/v-get-fs-file-type
+++ b/bin/v-get-fs-file-type
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: get file type
 # options: USER FILE
+# labels: 
+#
+# example: v-get-fs-file-type admin index.html
 #
 # The function shows file type
 

--- a/bin/v-get-mail-account-value
+++ b/bin/v-get-mail-account-value
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: get mail account value
 # options: USER DOMAIN ACCOUNT KEY
+# labels: mail
+#
+# example: v-get-mail-account-value admin example.tld tester QUOTA
 #
 # The function for getting a certain mail account parameter.
 

--- a/bin/v-get-mail-domain-value
+++ b/bin/v-get-mail-domain-value
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: get mail domain value
 # options: USER DOMAIN KEY
+# labels: mail
+#
+# example: v-get-mail-domain-value admin example.com DKIM
 #
 # The function for getting a certain mail domain parameter.
 

--- a/bin/v-get-sys-timezone
+++ b/bin/v-get-sys-timezone
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: get system timezone
 # options: [FORMAT]
+# labels: panel
 #
 # The function to get system timezone
 

--- a/bin/v-get-sys-timezones
+++ b/bin/v-get-sys-timezones
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system timezone
 # options: [FORMAT]
+# labels: panel
 #
 # The function checks system timezone settings
 

--- a/bin/v-get-user-salt
+++ b/bin/v-get-user-salt
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: get user salt
 # options: USER [IP] [FORMAT]
+# labels: panel
+#
+# example: v-get-user-salt admin
 #
 # The function provides users salt
 

--- a/bin/v-get-user-value
+++ b/bin/v-get-user-value
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: get user value
 # options: USER KEY
+# labels: panel
+#
+# example: v-get-user-value admin FNAME
 #
 # The function for obtaining certain user's parameters.
 

--- a/bin/v-insert-dns-domain
+++ b/bin/v-insert-dns-domain
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: insert dns domain
 # options: USER DATA [SRC] [FLUSH] [RESTART]
+# labels: 
 #
 # The function inserts raw record to the dns.conf
 

--- a/bin/v-insert-dns-record
+++ b/bin/v-insert-dns-record
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: insert dns record
 # options: USER DOMAIN DATA [RESTART]
+# labels: 
 #
 # The function inserts raw dns record to the domain conf
 

--- a/bin/v-insert-dns-records
+++ b/bin/v-insert-dns-records
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: inserts dns records
 # options: USER DOMAIN DATA_FILE [RESTART]
+# labels: 
 #
 # The function copy dns record to the domain conf
 

--- a/bin/v-list-backup-host
+++ b/bin/v-list-backup-host
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: list backup host
-# options: TYPE HOST [FORMAT]
+# options: TYPE [FORMAT]
 #
 # The function for obtaining the list of backup host parameters.
 

--- a/bin/v-list-backup-host
+++ b/bin/v-list-backup-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list backup host
 # options: TYPE [FORMAT]
+# labels: panel
+#
+# example: v-list-backup-host local
 #
 # The function for obtaining the list of backup host parameters.
 

--- a/bin/v-list-cron-job
+++ b/bin/v-list-cron-job
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list cron job
 # options: USER JOB [FORMAT]
+# labels: panel
+#
+# example: v-list-cron-job admin 7
 #
 # The function of obtaining cron job parameters.
 

--- a/bin/v-list-cron-jobs
+++ b/bin/v-list-cron-jobs
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user cron jobs
 # options: USER [FORMAT]
+# labels: panel
+#
+# example: v-list-cron-jobs admin
 #
 # The function for obtaining the list of all users cron jobs.
 

--- a/bin/v-list-database
+++ b/bin/v-list-database
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list database
 # options: USER DATABASE [FORMAT]
+# labels: panel
+#
+# example: v-list-database wp_db
 #
 # The function for obtaining of all database's parameters.
 

--- a/bin/v-list-database-host
+++ b/bin/v-list-database-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list database host
 # options: TYPE HOST [FORMAT]
+# labels: panel
+#
+# example: v-list-database-host mysql localhost
 #
 # The function for obtaining database host parameters.
 

--- a/bin/v-list-database-hosts
+++ b/bin/v-list-database-hosts
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list database hosts
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of all configured database hosts.
 

--- a/bin/v-list-database-types
+++ b/bin/v-list-database-types
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list supported database types
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of database types.
 

--- a/bin/v-list-databases
+++ b/bin/v-list-databases
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: listing databases
 # options: USER [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of all user's databases.
 

--- a/bin/v-list-dns-domain
+++ b/bin/v-list-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list dns domain
 # options: USER DOMAIN [FORMAT]
+# labels: dns
+#
+# example: v-list-dns-domain alice wonderland.com
 #
 # The function of obtaining the list of dns domain parameters.
 

--- a/bin/v-list-dns-domains
+++ b/bin/v-list-dns-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list dns domains
 # options: USER [FORMAT]
+# labels: dns
+#
+# example: v-list-dns-domains admin
 #
 # The function for obtaining all DNS domains of a user.
 

--- a/bin/v-list-dns-records
+++ b/bin/v-list-dns-records
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list dns domain records
 # options: USER DOMAIN [FORMAT]
+# labels: dns
+#
+# example: v-list-dns-records admin example.com
 #
 # The function for getting all DNS domain records.
 

--- a/bin/v-list-dns-template
+++ b/bin/v-list-dns-template
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list dns template
 # options: TEMPLATE [FORMAT]
+# labels: dns
+#
+# example: v-list-dns-template zoho
 #
 # The function for obtaining the DNS template parameters.
 

--- a/bin/v-list-dns-templates
+++ b/bin/v-list-dns-templates
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list dns templates
 # options: [FORMAT]
+# labels: dns
 #
 # The function for obtaining the list of all DNS templates available.
 

--- a/bin/v-list-firewall
+++ b/bin/v-list-firewall
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list iptables rules
 # options: [FORMAT]
+# labels: 
 #
 # The function of obtaining the list of all iptables rules.
 

--- a/bin/v-list-firewall-ban
+++ b/bin/v-list-firewall-ban
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list firewall block list
 # options: [FORMAT]
+# labels: panel
 #
 # The function of obtaining the list of currently blocked ips.
 

--- a/bin/v-list-firewall-ipset
+++ b/bin/v-list-firewall-ipset
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: List firewall ipset
 # options: [FORMAT]
+# labels: hestia
 #
 # The function prints defined ipset lists
 

--- a/bin/v-list-firewall-rule
+++ b/bin/v-list-firewall-rule
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list firewall rule
 # options: RULE [FORMAT]
+# labels: panel
+#
+# example: v-list-firewall-rule 2
 #
 # The function of obtaining firewall rule parameters.
 

--- a/bin/v-list-fs-directory
+++ b/bin/v-list-fs-directory
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list directory
 # options: USER DIRECTORY
+# labels: 
+#
+# example: v-list-fs-directory /home/admin/web
 #
 # The function lists directory on the file system
 

--- a/bin/v-list-letsencrypt-user
+++ b/bin/v-list-letsencrypt-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list letsencrypt key
 # options: USER [FORMAT]
+# labels: panel
+#
+# example: v-list-letsencrypt-user admin
 #
 # The function for obtaining the letsencrypt key thumbprint
 

--- a/bin/v-list-mail-account
+++ b/bin/v-list-mail-account
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail domain account
 # options: USER DOMAIN ACCOUNT [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-account admin domain.tld tester
 #
 # The function of obtaining the list of account parameters.
 

--- a/bin/v-list-mail-account-autoreply
+++ b/bin/v-list-mail-account-autoreply
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail account autoreply
 # options: USER DOMAIN ACCOUNT [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-account-autoreply admin example.com testing
 #
 # The function of obtaining mail account autoreply message.
 

--- a/bin/v-list-mail-accounts
+++ b/bin/v-list-mail-accounts
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail domain accounts
 # options: USER DOMAIN [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-accounts admin acme.com
 #
 # The function of obtaining the list of all user domains.
 

--- a/bin/v-list-mail-domain
+++ b/bin/v-list-mail-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail domain
 # options: USER DOMAIN [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-domain user01 mydomain.com
 #
 # The function of obtaining the list of domain parameters.
 

--- a/bin/v-list-mail-domain-dkim
+++ b/bin/v-list-mail-domain-dkim
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail domain dkim
 # options: USER DOMAIN [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-domain-dkim admin maildomain.tld
 #
 # The function of obtaining domain dkim files.
 

--- a/bin/v-list-mail-domain-dkim-dns
+++ b/bin/v-list-mail-domain-dkim-dns
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail domain dkim dns records
 # options: USER DOMAIN [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-domain-dkim-dns admin example.com
 #
 # The function of obtaining domain dkim dns records for proper setup.
 

--- a/bin/v-list-mail-domain-ssl
+++ b/bin/v-list-mail-domain-ssl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list mail domain ssl certificate
 # options: USER DOMAIN [FORMAT]
+# labels: hestia
 #
 # The function of obtaining domain ssl files.
 

--- a/bin/v-list-mail-domains
+++ b/bin/v-list-mail-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mail domains
 # options: USER [FORMAT]
+# labels: mail
+#
+# example: v-list-mail-domains admin
 #
 # The function of obtaining the list of all user domains.
 

--- a/bin/v-list-remote-dns-hosts
+++ b/bin/v-list-remote-dns-hosts
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list remote dns host
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of remote dns host.
 

--- a/bin/v-list-sys-clamd-config
+++ b/bin/v-list-sys-clamd-config
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list clamd config parameters
 # options: [FORMAT]
+# labels: 
+#
+# example: v-list-sys-clamdconfig
 #
 # The function for obtaining the list of clamd config parameters.
 

--- a/bin/v-list-sys-clamd-config
+++ b/bin/v-list-sys-clamd-config
@@ -3,8 +3,6 @@
 # options: [FORMAT]
 # labels: 
 #
-# example: v-list-sys-clamdconfig
-#
 # The function for obtaining the list of clamd config parameters.
 
 

--- a/bin/v-list-sys-config
+++ b/bin/v-list-sys-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system configuration
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of system parameters.
 

--- a/bin/v-list-sys-cpu-status
+++ b/bin/v-list-sys-cpu-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system cpu info
 # options: [FORMAT]
+# labels: 
 #
 # The function lists cpu information
 

--- a/bin/v-list-sys-db-status
+++ b/bin/v-list-sys-db-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list db status
 # options: [FORMAT]
+# labels: 
 #
 # The function lists db server status
 

--- a/bin/v-list-sys-disk-status
+++ b/bin/v-list-sys-disk-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list disk information
 # options: [FORMAT]
+# labels: 
 #
 # The function lists disk information
 

--- a/bin/v-list-sys-dns-status
+++ b/bin/v-list-sys-dns-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list dns status
 # options: [FORMAT]
+# labels: 
 #
 # The function lists dns server status
 

--- a/bin/v-list-sys-dovecot-config
+++ b/bin/v-list-sys-dovecot-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list dovecot config parameters
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of dovecot config parameters.
 

--- a/bin/v-list-sys-hestia-autoupdate
+++ b/bin/v-list-sys-hestia-autoupdate
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list hestia autoupdate settings
 # options: [FORMAT]
+# labels: 
+#
+# example: v-list-hestia-autoupdate
 #
 # The function for obtaining autoupdate setings.
 

--- a/bin/v-list-sys-hestia-autoupdate
+++ b/bin/v-list-sys-hestia-autoupdate
@@ -3,8 +3,6 @@
 # options: [FORMAT]
 # labels: 
 #
-# example: v-list-hestia-autoupdate
-#
 # The function for obtaining autoupdate setings.
 
 

--- a/bin/v-list-sys-hestia-ssl
+++ b/bin/v-list-sys-hestia-ssl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list hestia ssl certificate
 # options: [FORMAT]
+# labels: 
 #
 # The function of obtaining hestia ssl files.
 

--- a/bin/v-list-sys-hestia-updates
+++ b/bin/v-list-sys-hestia-updates
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system updates
 # options: [FORMAT]
+# labels: 
 #
 # The function checks available updates for hestia packages.
 

--- a/bin/v-list-sys-info
+++ b/bin/v-list-sys-info
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system os
 # options: [FORMAT]
+# labels: 
 #
 # The function checks available updates for hestia packages.
 

--- a/bin/v-list-sys-interfaces
+++ b/bin/v-list-sys-interfaces
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system interfaces
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of network interfaces.
 

--- a/bin/v-list-sys-ip
+++ b/bin/v-list-sys-ip
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list system ip
 # options: IP [FORMAT]
+# labels: panel
+#
+# example: v-list-sys-ip 116.203.78.202
 #
 # The function for getting the list of system ip parameters.
 

--- a/bin/v-list-sys-ips
+++ b/bin/v-list-sys-ips
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system ips
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of system ip adresses.
 

--- a/bin/v-list-sys-languages
+++ b/bin/v-list-sys-languages
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system users
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of system users without
 # detailed information.

--- a/bin/v-list-sys-mail-status
+++ b/bin/v-list-sys-mail-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list mail status
 # options: [FORMAT]
+# labels: mail
 #
 # The function lists mail server status
 

--- a/bin/v-list-sys-memory-status
+++ b/bin/v-list-sys-memory-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list virtual memory info
 # options: [FORMAT]
+# labels: panel
 #
 # The function lists virtual memory information
 

--- a/bin/v-list-sys-mysql-config
+++ b/bin/v-list-sys-mysql-config
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list mysql config parameters
 # options: [FORMAT]
+# labels: panel
+#
+# example: v-list-mysql-config
 #
 # The function for obtaining the list of mysql config parameters.
 

--- a/bin/v-list-sys-mysql-config
+++ b/bin/v-list-sys-mysql-config
@@ -3,8 +3,6 @@
 # options: [FORMAT]
 # labels: panel
 #
-# example: v-list-mysql-config
-#
 # The function for obtaining the list of mysql config parameters.
 
 

--- a/bin/v-list-sys-network-status
+++ b/bin/v-list-sys-network-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system network status
 # options: [FORMAT]
+# labels: 
 #
 # The function lists network status
 

--- a/bin/v-list-sys-nginx-config
+++ b/bin/v-list-sys-nginx-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list nginx config parameters
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of nginx config parameters.
 

--- a/bin/v-list-sys-pgsql-config
+++ b/bin/v-list-sys-pgsql-config
@@ -3,8 +3,6 @@
 # options: [FORMAT]
 # labels: panel
 #
-# example: v-list-pgsql-config
-#
 # The function for obtaining the list of postgresql config parameters.
 
 

--- a/bin/v-list-sys-pgsql-config
+++ b/bin/v-list-sys-pgsql-config
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list postgresql config parameters
 # options: [FORMAT]
+# labels: panel
+#
+# example: v-list-pgsql-config
 #
 # The function for obtaining the list of postgresql config parameters.
 

--- a/bin/v-list-sys-php
+++ b/bin/v-list-sys-php
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: listing availble PHP versions installed
 # options: [FORMAT]
+# labels: hestia
 #
 # List /etc/php/* version check if folder fpm is avalible
 

--- a/bin/v-list-sys-php-config
+++ b/bin/v-list-sys-php-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list php config parameters
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of php config parameters.
 

--- a/bin/v-list-sys-proftpd-config
+++ b/bin/v-list-sys-proftpd-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list proftpd config parameters
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of proftpd config parameters.
 

--- a/bin/v-list-sys-rrd
+++ b/bin/v-list-sys-rrd
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system rrd charts
 # options: [FORMAT]
+# labels: panel
 #
 # List available rrd graphics, its titles and paths.
 

--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system services
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of configured system services.
 

--- a/bin/v-list-sys-shells
+++ b/bin/v-list-sys-shells
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system shells
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of system shells.
 

--- a/bin/v-list-sys-spamd-config
+++ b/bin/v-list-sys-spamd-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list spamassassin config parameters
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of spamassassin config parameters.
 

--- a/bin/v-list-sys-themes
+++ b/bin/v-list-sys-themes
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: list web templates
-# options: USER [FORMAT]
+# options: [FORMAT]
 #
 # The function for obtaining the list of themes in the theme
 # library and displaying them in the backend or user interface.

--- a/bin/v-list-sys-themes
+++ b/bin/v-list-sys-themes
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list web templates
 # options: [FORMAT]
+# labels: hestia
 #
 # The function for obtaining the list of themes in the theme
 # library and displaying them in the backend or user interface.

--- a/bin/v-list-sys-users
+++ b/bin/v-list-sys-users
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list system users
 # options: [FORMAT]
+# labels: panel
 #
 # The function for obtaining the list of system users without
 # detailed information.

--- a/bin/v-list-sys-vsftpd-config
+++ b/bin/v-list-sys-vsftpd-config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list vsftpd config parameters
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of vsftpd config parameters.
 

--- a/bin/v-list-sys-web-status
+++ b/bin/v-list-sys-web-status
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list web status
 # options: [FORMAT]
+# labels: 
 #
 # The function lists web server status
 

--- a/bin/v-list-user
+++ b/bin/v-list-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user parameters
 # options: USER [FORMAT]
+# labels: 
+#
+# example: v-list-user admin
 #
 # The function to obtain user parameters.
 

--- a/bin/v-list-user-backup
+++ b/bin/v-list-user-backup
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user backup
 # options: USER BACKUP [FORMAT]
+# labels: 
+#
+# example: v-list-user-backups admin admin.2019-05-19_03-31-30.tar
 #
 # The function of obtaining the list of backup parameters. This call, just as
 # all v_list_* calls, supports 3 formats - json, shell and plain.

--- a/bin/v-list-user-backup-exclusions
+++ b/bin/v-list-user-backup-exclusions
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list backup exclusions
 # options: USER [FORMAT]
+# labels: 
+#
+# example: v-list-user-backup-exclusions admin
 #
 # The function for obtaining the backup exclusion list
 

--- a/bin/v-list-user-backups
+++ b/bin/v-list-user-backups
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user backups
 # options: USER [FORMAT]
+# labels: 
+#
+# example: v-list-user-backups admin
 #
 # The function for obtaining the list of available user backups.
 

--- a/bin/v-list-user-ips
+++ b/bin/v-list-user-ips
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user ips
 # options: USER [FORMAT]
+# labels: 
+#
+# example: v-list-user-ips admin
 #
 # The function for obtaining the list of available ip addresses.
 

--- a/bin/v-list-user-log
+++ b/bin/v-list-user-log
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list user log
 # options: USER [FORMAT]
+# labels: 
 #
 # The function of obtaining the list of 100 last users commands.
 

--- a/bin/v-list-user-notifications
+++ b/bin/v-list-user-notifications
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user notifications
 # options: USER [FORMAT]
+# labels: 
+#
+# example: v-list-user-notifications admin
 #
 # The function for getting the list notifications
 

--- a/bin/v-list-user-ns
+++ b/bin/v-list-user-ns
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user nameservers
 # options: USER [FORMAT]
+# labels: 
+#
+# example: v-list-user-ns admin
 #
 # Function for obtaining the list of user's DNS servers.
 

--- a/bin/v-list-user-package
+++ b/bin/v-list-user-package
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list user package
 # options: PACKAGE [FORMAT]
+# labels: 
 #
 # The function for getting the list of system ip parameters.
 

--- a/bin/v-list-user-packages
+++ b/bin/v-list-user-packages
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list user packages
 # options: [FORMAT]
+# labels: 
 #
 # The function for obtaining the list of available hosting packages.
 

--- a/bin/v-list-user-ssh-key
+++ b/bin/v-list-user-ssh-key
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add ssh key
-# options: USER 
+# options: USER [FORMAT]
 #
 # Lists $user/.ssh/authorized_keys
 

--- a/bin/v-list-user-ssh-key
+++ b/bin/v-list-user-ssh-key
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: add ssh key
 # options: USER [FORMAT]
+# labels: hestia
 #
 # Lists $user/.ssh/authorized_keys
 

--- a/bin/v-list-user-stats
+++ b/bin/v-list-user-stats
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: list user stats
-# options: [FORMAT]
+# options: USER [FORMAT]
 #
 # The function for listing user statistics
 

--- a/bin/v-list-user-stats
+++ b/bin/v-list-user-stats
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list user stats
 # options: USER [FORMAT]
+# labels: panel
+#
+# example: v-list-users-stats admin
 #
 # The function for listing user statistics
 

--- a/bin/v-list-user-stats
+++ b/bin/v-list-user-stats
@@ -3,7 +3,7 @@
 # options: USER [FORMAT]
 # labels: panel
 #
-# example: v-list-users-stats admin
+# example: v-list-user-stats admin
 #
 # The function for listing user statistics
 

--- a/bin/v-list-users
+++ b/bin/v-list-users
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list users
 # options: [FORMAT]
+# labels: panel
 #
 # The function to obtain the list of all system users.
 

--- a/bin/v-list-users-stats
+++ b/bin/v-list-users-stats
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list overall user stats
 # options: [FORMAT]
+# labels: 
 #
 # The function for listing overall user statistics
 

--- a/bin/v-list-web-domain
+++ b/bin/v-list-web-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list web domain parameters
 # options: USER DOMAIN [FORMAT]
+# labels: web
+#
+# example: v-list-web-domain admin example.com
 #
 # The function to obtain web domain parameters.
 

--- a/bin/v-list-web-domain-accesslog
+++ b/bin/v-list-web-domain-accesslog
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list web domain access log
 # options: USER DOMAIN [LINES] [FORMAT]
+# labels: web
+#
+# example: v-list-web-domain-accesslog admin example.com
 #
 # The function of obtaining raw access web domain logs.
 

--- a/bin/v-list-web-domain-errorlog
+++ b/bin/v-list-web-domain-errorlog
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list web domain error log
 # options: USER DOMAIN [LINES] [FORMAT]
+# labels: web
+#
+# example: v-list-web-domain-errorlog admin acme.com
 #
 # The function of obtaining raw error web domain logs.
 

--- a/bin/v-list-web-domain-ssl
+++ b/bin/v-list-web-domain-ssl
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list web domain ssl certificate
 # options: USER DOMAIN [FORMAT]
+# labels: web
+#
+# example: v-list-web-domain-ssl admin wonderland.com
 #
 # The function of obtaining domain ssl files.
 

--- a/bin/v-list-web-domains
+++ b/bin/v-list-web-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: list web domains
 # options: USER [FORMAT]
+# labels: web
+#
+# example: v-list-web-domains alice
 #
 # The function to obtain the list of all user web domains.
 

--- a/bin/v-list-web-stats
+++ b/bin/v-list-web-stats
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list web statistics
 # options: [FORMAT]
+# labels: web
 #
 # The function for obtaining the list of web statistics analyzer.
 

--- a/bin/v-list-web-templates
+++ b/bin/v-list-web-templates
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: list web templates
-# options: USER [FORMAT]
+# options: [FORMAT]
 #
 # The function for obtaining the list of web templates available to a user.
 

--- a/bin/v-list-web-templates
+++ b/bin/v-list-web-templates
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: list web templates
 # options: [FORMAT]
+# labels: web
 #
 # The function for obtaining the list of web templates available to a user.
 

--- a/bin/v-list-web-templates-backend
+++ b/bin/v-list-web-templates-backend
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: listing backend templates
 # options: [FORMAT]
+# labels: web
 #
 # The function for obtaining the list of available backend templates.
 

--- a/bin/v-list-web-templates-proxy
+++ b/bin/v-list-web-templates-proxy
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: listing proxy templates
 # options: [FORMAT]
+# labels: web
 #
 # The function for obtaining the list of proxy templates available to a user.
 

--- a/bin/v-move-fs-directory
+++ b/bin/v-move-fs-directory
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: move file
 # options: USER SRC_DIRECTORY DST_DIRECTORY
+# labels: 
+#
+# example: v-move-fs-directory admin /home/admin/web /home/user02/
 #
 # The function moved file or directory on the file system. This function
 # can also be used to rename files just like normal mv command.

--- a/bin/v-move-fs-file
+++ b/bin/v-move-fs-file
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: move file
 # options: USER SRC_FILE DST_FILE
+# labels: 
+#
+# example: v-move-fs-file admin readme.txt new_readme.txt
 #
 # The function moved file or directory on the file system. This function
 # can also be used to rename files just like normal mv command.

--- a/bin/v-open-fs-config
+++ b/bin/v-open-fs-config
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: open config
 # options: CONFIG
+# labels: 
+#
+# example: v-open-fs-config /etc/mysql/my.cnf
 #
 # The function opens/reads config files on the file system
 

--- a/bin/v-open-fs-file
+++ b/bin/v-open-fs-file
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: open file
 # options: USER FILE
+# labels: 
+#
+# example: v-open-fs-file admin README.md
 #
 # The function opens/reads files on the file system
 

--- a/bin/v-rebuild-all
+++ b/bin/v-rebuild-all
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: rebuild all assets for a specified user
 # options: USER [RESTART]
+# labels: hestia
 #
 # The function rebuilds all assets for a user account:
 # - Web domains

--- a/bin/v-rebuild-cron-jobs
+++ b/bin/v-rebuild-cron-jobs
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: rebuild cron jobs
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-rebuild-cron-jobs admin yes
 #
 # The function rebuilds system cron config file for specified user.
 

--- a/bin/v-rebuild-database
+++ b/bin/v-rebuild-database
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: rebuild databases
-# options: USER
+# options: USER DATABASE
 #
 # The function for rebuilding a single database for a user
 

--- a/bin/v-rebuild-database
+++ b/bin/v-rebuild-database
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: rebuild databases
 # options: USER DATABASE
+# labels: hestia
 #
 # The function for rebuilding a single database for a user
 

--- a/bin/v-rebuild-databases
+++ b/bin/v-rebuild-databases
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: rebuild databases
 # options: USER
+# labels: panel
+#
+# example: v-rebuild-databases admin
 #
 # The function for rebuilding of all databases of a single user.
 

--- a/bin/v-rebuild-dns-domain
+++ b/bin/v-rebuild-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: rebuild dns domain
 # options: USER DOMAIN [RESTART] [UPDATE_SERIAL]
+# labels: dns
+#
+# example: v-rebuild-dns-domain alice wonderland.com
 #
 # The function rebuilds DNS configuration files.
 

--- a/bin/v-rebuild-dns-domains
+++ b/bin/v-rebuild-dns-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: rebuild dns domains
 # options: USER [RESTART] [UPDATE_SERIAL]
+# labels: dns
+#
+# example: v-rebuild-dns-domains alice
 #
 # The function rebuilds DNS configuration files.
 

--- a/bin/v-rebuild-mail-domain
+++ b/bin/v-rebuild-mail-domain
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: rebuild mail domain
 # options: USER DOMAIN
+# labels: hestia
 #
 # The function rebuilds configuration files for a single domain.
 

--- a/bin/v-rebuild-mail-domains
+++ b/bin/v-rebuild-mail-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: rebuild mail domains
 # options: USER
+# labels: mail
+#
+# example: v-rebuild-mail-domains admin
 #
 # The function rebuilds EXIM configuration files for all mail domains.
 

--- a/bin/v-rebuild-user
+++ b/bin/v-rebuild-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: rebuild system user
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-rebuild-user admin yes
 #
 # The function rebuilds system user account.
 

--- a/bin/v-rebuild-users
+++ b/bin/v-rebuild-users
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: rebuild system user
 # options: [RESTART]
+# labels: hestia
 #
 # The function rebuilds system user accounts.
 

--- a/bin/v-rebuild-web-domain
+++ b/bin/v-rebuild-web-domain
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: rebuild web domain
 # options: USER DOMAIN [RESTART]
+# labels: hestia
 #
 # The function rebuilds web configuration files.
 

--- a/bin/v-rebuild-web-domains
+++ b/bin/v-rebuild-web-domains
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: rebuild web domains
 # options: USER [RESTART]
+# labels: 
 #
 # The function rebuilds web configuration files.
 

--- a/bin/v-refresh-sys-theme
+++ b/bin/v-refresh-sys-theme
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: change active system theme
 # options: NONE
+# labels: hestia
 #
 # The function for changing the currently active system theme.
 

--- a/bin/v-refresh-sys-theme
+++ b/bin/v-refresh-sys-theme
@@ -1,4 +1,7 @@
 #!/bin/bash
+# info: change active system theme
+# options: NONE
+#
 # The function for changing the currently active system theme.
 
 #----------------------------------------------------------#

--- a/bin/v-rename-package
+++ b/bin/v-rename-package
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: change package name
 # options: OLD_NAME NEW_NAME
+# labels: hestia
 #
 # The function changes the name of an existing package.
 

--- a/bin/v-restart-cron
+++ b/bin/v-restart-cron
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart cron service
 # options: NONE
+# labels: panel
 #
 # The function tells crond service to reread its configuration files.
 

--- a/bin/v-restart-dns
+++ b/bin/v-restart-dns
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart dns service
 # options: NONE
+# labels: dns
 #
 # The function tells BIND service to reload dns zone files.
 

--- a/bin/v-restart-ftp
+++ b/bin/v-restart-ftp
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart ftp service
 # options: NONE
+# labels: panel
 #
 # The function tells ftp server to reread its configuration.
 

--- a/bin/v-restart-mail
+++ b/bin/v-restart-mail
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart mail service
 # options: NONE
+# labels: mail
 #
 # The function tells exim or dovecot services to reload configuration files.
 

--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart proxy server
 # options: NONE
+# labels: panel
 #
 # The function reloads proxy server configuration.
 

--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: restart service
-# options: service [RESTART]
+# options: SERVICE [RESTART]
 #
 # The function restarts system service.
 

--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart service
 # options: SERVICE [RESTART]
+# labels: panel
 #
 # The function restarts system service.
 

--- a/bin/v-restart-system
+++ b/bin/v-restart-system
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: restart operating system
-# options: RESTART
+# options: RESTART [DELAY]
 #
 # The function restarts operating system.
 

--- a/bin/v-restart-system
+++ b/bin/v-restart-system
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: restart operating system
-# options: restart
+# options: RESTART
 #
 # The function restarts operating system.
 

--- a/bin/v-restart-system
+++ b/bin/v-restart-system
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: restart operating system
 # options: RESTART [DELAY]
+# labels: panel
+#
+# example: v-restart-system yes
 #
 # The function restarts operating system.
 

--- a/bin/v-restart-web
+++ b/bin/v-restart-web
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart web server
 # options: NONE
+# labels: web
 #
 # The function reloads web server configuration.
 

--- a/bin/v-restart-web-backend
+++ b/bin/v-restart-web-backend
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: restart backend server
 # options: NONE
+# labels: web
 #
 # The function reloads backend server configuration.
 

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: restore user
 # options: USER BACKUP [WEB] [DNS] [MAIL] [DB] [CRON] [UDIR] [NOTIFY]
+# labels: panel
+#
+# example: v-restore-user admin 2019-04-22_01-00-00.tar
 #
 # The function for restoring user from backup.
 

--- a/bin/v-run-cli-cmd
+++ b/bin/v-run-cli-cmd
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: run cli command
-# options: USER FILE
+# options: USER CMD [ARG...]
 #
 # The function runs a limited list of cli commands with dropped privileges as the specific hestia user
 

--- a/bin/v-run-cli-cmd
+++ b/bin/v-run-cli-cmd
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: run cli command
 # options: USER CMD [ARG...]
+# labels: hestia
 #
 # The function runs a limited list of cli commands with dropped privileges as the specific hestia user
 

--- a/bin/v-schedule-letsencrypt-domain
+++ b/bin/v-schedule-letsencrypt-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: adding cronjob for letsencrypt cetificate installation
 # options: USER DOMAIN [ALIASES]
+# labels: panel
+#
+# example: v-schedule-letsencrypt-domain admin example.com www.example.com
 #
 # The function adds cronjob for letsencrypt ssl certificate installation
 

--- a/bin/v-schedule-user-backup
+++ b/bin/v-schedule-user-backup
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: schedule user backup creation
 # options: USER
+# labels: panel
+#
+# example: v-schedule-user-backup admin
 #
 # The function for scheduling user backup creation.
 

--- a/bin/v-schedule-user-backup-download
+++ b/bin/v-schedule-user-backup-download
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: Schedule a backup
-# options: USER BACKUP 
+# options: USER BACKUP
+# labels: hestia
 #
 # The function for scheduling user backup creation.
 

--- a/bin/v-schedule-user-restore
+++ b/bin/v-schedule-user-restore
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: schedule user backup restoration
 # options: USER BACKUP [WEB] [DNS] [MAIL] [DB] [CRON] [UDIR]
+# labels: panel
+#
+# example: v-schedule-user-restore 2019-04-22_01-00-00.tar
 #
 # The function for scheduling user backup restoration.
 

--- a/bin/v-search-command
+++ b/bin/v-search-command
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: search for available commands
 # options: ARG1 [ARG...]
+# labels: hestia
 #
 # This function searches for available Hestia Control Panel commands
 # and returns results based on the specified criteria.

--- a/bin/v-search-command
+++ b/bin/v-search-command
@@ -1,12 +1,13 @@
 #!/bin/bash
-
 # info: search for available commands
+# options: NONE
 #
 # This function searches for available Hestia Control Panel commands
 # and returns results based on the specified criteria.
-#
+
 # Originally developed for VestaCP by Federico Krum
 # https://github.com/FastDigitalOceanDroplets/VestaCP/blob/master/files/v-search-command
+
 
 #----------------------------------------------------------#
 #                    Variable&Function                     #

--- a/bin/v-search-command
+++ b/bin/v-search-command
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: search for available commands
-# options: NONE
+# options: ARG1 [ARG...]
 #
 # This function searches for available Hestia Control Panel commands
 # and returns results based on the specified criteria.

--- a/bin/v-search-domain-owner
+++ b/bin/v-search-domain-owner
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: search domain owner
 # options: DOMAIN [TYPE]
+# labels: panel
+#
+# example: v-search-domain-owner acme.com
 #
 # The function that allows to find user objects.
 

--- a/bin/v-search-fs-object
+++ b/bin/v-search-fs-object
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: search file or directory
 # options: USER OBJECT [PATH]
+# labels: 
+#
+# example: v-search-fs-object admin hello.txt
 #
 # The function search files and directories on the file system
 

--- a/bin/v-search-object
+++ b/bin/v-search-object
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: search objects
 # options: OBJECT [FORMAT]
+# labels: panel
+#
+# example: v-search-object example.com json
 #
 # The function that allows to find system objects.
 

--- a/bin/v-search-user-object
+++ b/bin/v-search-user-object
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: search objects
 # options: USER OBJECT [FORMAT]
+# labels: panel
+#
+# example: v-search-user-object admin example.com json
 #
 # The function that allows to find user objects.
 

--- a/bin/v-start-service
+++ b/bin/v-start-service
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: start service
-# options: service
+# options: SERVICE
 #
 # The function starts system service.
 

--- a/bin/v-start-service
+++ b/bin/v-start-service
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: start service
 # options: SERVICE
+# labels: panel
+#
+# example: v-start-service mysql
 #
 # The function starts system service.
 

--- a/bin/v-stop-firewall
+++ b/bin/v-stop-firewall
@@ -1,8 +1,9 @@
 #!/bin/bash
 # info: stop system firewall
 # options: NONE
+# labels: panel
 #
-# The function stops  iptables
+# The function stops iptables
 
 
 #----------------------------------------------------------#

--- a/bin/v-stop-service
+++ b/bin/v-stop-service
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: stop service
-# options: service
+# options: SERVICE
 #
 # The function stops system service.
 

--- a/bin/v-stop-service
+++ b/bin/v-stop-service
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: stop service
 # options: SERVICE
+# labels: panel
+#
+# example: v-stop-service apache2
 #
 # The function stops system service.
 

--- a/bin/v-suspend-cron-job
+++ b/bin/v-suspend-cron-job
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend cron job
 # options: USER JOB [RESTART]
+# labels: panel
+#
+# example: v-suspend-cron-job admin 5 yes
 #
 # The function suspends a certain job of the cron scheduler.
 

--- a/bin/v-suspend-cron-jobs
+++ b/bin/v-suspend-cron-jobs
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: Suspending sys cron jobs
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-suspend-cron-jobs admin
 #
 # The function suspends all user cron jobs.
 

--- a/bin/v-suspend-database
+++ b/bin/v-suspend-database
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend database
 # options: USER DATABASE
+# labels: panel
+#
+# example: v-suspend-database admin admin_wordpress_db
 #
 # The function for suspending a certain user database.
 

--- a/bin/v-suspend-database-host
+++ b/bin/v-suspend-database-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend database server
 # options: TYPE HOST
+# labels: panel
+#
+# example: v-suspend-database-host mysql localhost
 #
 # The function for suspending a database server.
 

--- a/bin/v-suspend-databases
+++ b/bin/v-suspend-databases
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend databases
 # options: USER
+# labels: panel
+#
+# example: v-suspend-databases admin
 #
 # The function for suspending of all databases of a single user.
 

--- a/bin/v-suspend-dns-domain
+++ b/bin/v-suspend-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend dns domain
 # options: USER DOMAIN [RESTART]
+# labels: dns
+#
+# example: v-suspend-dns-domain alice acme.com
 #
 # The function suspends a certain user's domain.
 

--- a/bin/v-suspend-dns-domains
+++ b/bin/v-suspend-dns-domains
@@ -3,7 +3,7 @@
 # options: USER [RESTART]
 # labels: dns
 #
-# example: v-suspend-dns-domain admin yes
+# example: v-suspend-dns-domains admin yes
 #
 # The function suspends all user's DNS domains.
 

--- a/bin/v-suspend-dns-domains
+++ b/bin/v-suspend-dns-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend dns domains
 # options: USER [RESTART]
+# labels: dns
+#
+# example: v-suspend-dns-domain admin yes
 #
 # The function suspends all user's DNS domains.
 

--- a/bin/v-suspend-dns-record
+++ b/bin/v-suspend-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend dns domain record
 # options: USER DOMAIN ID [RESTART]
+# labels: dns
+#
+# example: v-suspend-dns-record alice wonderland.com 42 yes
 #
 # The function suspends a certain domain record.
 

--- a/bin/v-suspend-domain
+++ b/bin/v-suspend-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend web/dns/mail domain
 # options: USER DOMAIN
+# labels: panel
+#
+# example: v-suspend-domain admin example.com
 #
 # The function suspends web/dns/mail domain.
 

--- a/bin/v-suspend-firewall-rule
+++ b/bin/v-suspend-firewall-rule
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend firewall rule
 # options: RULE
+# labels: panel
+#
+# example: v-suspend-firewall-rule 7
 #
 # The function suspends a certain firewall rule.
 

--- a/bin/v-suspend-mail-account
+++ b/bin/v-suspend-mail-account
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend mail account
 # options: USER DOMAIN ACCOUNT
+# labels: mail
+#
+# example: v-suspend-mail-account admin acme.com bob
 #
 # The function suspends mail account.
 

--- a/bin/v-suspend-mail-accounts
+++ b/bin/v-suspend-mail-accounts
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend all mail domain accounts
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-suspend-mail-accounts admin example.com
 #
 # The function suspends all mail domain accounts.
 

--- a/bin/v-suspend-mail-domain
+++ b/bin/v-suspend-mail-domain
@@ -1,8 +1,11 @@
 #!/bin/bash
 # info: suspend mail domain
 # options: USER DOMAIN
+# labels: mail
 #
-# The function suspends mail domain. 
+# example: v-suspend-mail-domain admin domain.com
+#
+# The function suspends mail domain.
 
 
 #----------------------------------------------------------#

--- a/bin/v-suspend-mail-domains
+++ b/bin/v-suspend-mail-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend mail domains
 # options: USER
+# labels: mail
+#
+# example: v-suspend-mail-domains admin
 #
 # The function suspends all user's MAIL domains.
 

--- a/bin/v-suspend-remote-dns-host
+++ b/bin/v-suspend-remote-dns-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend remote dns server
 # options: HOST
+# labels: dns
+#
+# example: v-suspend-remote-dns-host hostname.tld
 #
 # The function for suspending remote dns server.
 

--- a/bin/v-suspend-user
+++ b/bin/v-suspend-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend user
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-suspend-user alice yes
 #
 # The function suspends a certain user and all his objects.
 

--- a/bin/v-suspend-web-domain
+++ b/bin/v-suspend-web-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: suspend web domain
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-suspend-web-domain admin example.com yes
 #
 # The function for suspending the site's operation. After blocking it all
 # visitors will be redirected to a web page explaining the reason of suspend.

--- a/bin/v-suspend-web-domain
+++ b/bin/v-suspend-web-domain
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: suspend web domain
-# options: USER DOMAIN
+# options: USER DOMAIN [RESTART]
 #
 # The function for suspending the site's operation. After blocking it all
 # visitors will be redirected to a web page explaining the reason of suspend.

--- a/bin/v-suspend-web-domains
+++ b/bin/v-suspend-web-domains
@@ -1,8 +1,11 @@
 #!/bin/bash
 # info: suspend web domains
 # options: USER [RESTART]
+# labels: web
 #
-# The function of suspending all user's sites. 
+# example: v-suspend-web-domains bob
+#
+# The function of suspending all user's sites.
 
 
 #----------------------------------------------------------#

--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -1,6 +1,8 @@
 #!/bin/bash
 # info: synchronize dns domains
 # options: HOST
+# labels: dns
+#
 # The function synchronize all dns domains.
 
 

--- a/bin/v-unsuspend-cron-job
+++ b/bin/v-unsuspend-cron-job
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend cron job
 # options: USER JOB [RESTART]
+# labels: panel
+#
+# example: v-unsuspend-cron-job admin 7 yes
 #
 # The function unsuspend certain cron job.
 

--- a/bin/v-unsuspend-cron-jobs
+++ b/bin/v-unsuspend-cron-jobs
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend sys cron
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-unsuspend-cron-jobs admin no
 #
 # The function unsuspends all suspended cron jobs.
 

--- a/bin/v-unsuspend-database
+++ b/bin/v-unsuspend-database
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend database
 # options: USER DATABASE
+# labels: panel
+#
+# example: v-unsuspend-database admin mydb
 #
 # The function for unsuspending database.
 

--- a/bin/v-unsuspend-database-host
+++ b/bin/v-unsuspend-database-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend database server
 # options: TYPE HOST
+# labels: panel
+#
+# example: v-unsuspend-database-host mysql localhost
 #
 # The function for unsuspending a database server.
 

--- a/bin/v-unsuspend-databases
+++ b/bin/v-unsuspend-databases
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: unsuspend databases
 # options: USER
+# labels: panel
 #
 # The function for unsuspending all user's databases.
 

--- a/bin/v-unsuspend-dns-domain
+++ b/bin/v-unsuspend-dns-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend dns domain
 # options: USER DOMAIN
+# labels: dns
+#
+# example: v-unsuspend-dns-domain alice wonderland.com
 #
 # The function unsuspends a certain user's domain.
 

--- a/bin/v-unsuspend-dns-domains
+++ b/bin/v-unsuspend-dns-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend dns domains
 # options: USER [RESTART]
+# labels: dns
+#
+# example: v-unsuspend-dns-domains alice
 #
 # The function unsuspends all user's DNS domains.
 

--- a/bin/v-unsuspend-dns-record
+++ b/bin/v-unsuspend-dns-record
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend dns domain record
 # options: USER DOMAIN ID [RESTART]
+# labels: dns
+#
+# example: v-unsuspend-dns-record admin example.com 33
 #
 # The function unsuspends a certain domain record.
 

--- a/bin/v-unsuspend-domain
+++ b/bin/v-unsuspend-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend web/dns/mail domain
 # options: USER DOMAIN
+# labels: panel
+#
+# example: v-unsuspend-domain admin acme.com
 #
 # The function unsuspends web/dns/mail domain.
 

--- a/bin/v-unsuspend-firewall-rule
+++ b/bin/v-unsuspend-firewall-rule
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend firewall rule
 # options: RULE
+# labels: panel
+#
+# example: v-unsuspend-firewall-rule 7
 #
 # The function unsuspends a certain firewall rule.
 

--- a/bin/v-unsuspend-mail-account
+++ b/bin/v-unsuspend-mail-account
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend mail account
 # options: USER DOMAIN ACCOUNT
+# labels: mail
+#
+# example: v-suspend-mail-account admin acme.com tester
 #
 # The function unsuspends mail account.
 

--- a/bin/v-unsuspend-mail-account
+++ b/bin/v-unsuspend-mail-account
@@ -3,7 +3,7 @@
 # options: USER DOMAIN ACCOUNT
 # labels: mail
 #
-# example: v-suspend-mail-account admin acme.com tester
+# example: v-unsuspend-mail-account admin acme.com tester
 #
 # The function unsuspends mail account.
 

--- a/bin/v-unsuspend-mail-accounts
+++ b/bin/v-unsuspend-mail-accounts
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend all mail domain accounts
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-unsuspend-mail-accounts admin acme.com
 #
 # The function unsuspends all mail domain accounts.
 

--- a/bin/v-unsuspend-mail-domain
+++ b/bin/v-unsuspend-mail-domain
@@ -1,8 +1,11 @@
 #!/bin/bash
 # info: unsuspend mail domain
 # options: USER DOMAIN
+# labels: mail
 #
-# The function unsuspends mail domain. 
+# example: v-unsuspend-mail-domain user02 acme.com
+#
+# The function unsuspends mail domain.
 
 
 #----------------------------------------------------------#

--- a/bin/v-unsuspend-mail-domains
+++ b/bin/v-unsuspend-mail-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend mail domains
 # options: USER
+# labels: mail
+#
+# example: v-unsuspend-mail-domains admin
 #
 # The function unsuspends all user's MAIL domains.
 

--- a/bin/v-unsuspend-remote-dns-host
+++ b/bin/v-unsuspend-remote-dns-host
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend remote dns server
 # options: HOST
+# labels: dns
+#
+# example: v-unsuspend-remote-dns-host hosname.com
 #
 # The function for unsuspending remote dns server.
 

--- a/bin/v-unsuspend-user
+++ b/bin/v-unsuspend-user
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend user
 # options: USER [RESTART]
+# labels: panel
+#
+# example: v-unsuspend-user bob
 #
 # The function unsuspends user and all his objects.
 

--- a/bin/v-unsuspend-web-domain
+++ b/bin/v-unsuspend-web-domain
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend web domain
 # options: USER DOMAIN [RESTART]
+# labels: web
+#
+# example: v-unsuspend-web-domain admin acme.com
 #
 # The function of unsuspending the domain.
 

--- a/bin/v-unsuspend-web-domain
+++ b/bin/v-unsuspend-web-domain
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: unsuspend web domain
-# options: USER DOMAIN
+# options: USER DOMAIN [RESTART]
 #
 # The function of unsuspending the domain.
 

--- a/bin/v-unsuspend-web-domains
+++ b/bin/v-unsuspend-web-domains
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: unsuspend web domains
 # options: USER [RESTART]
+# labels: web
+#
+# example: v-unsuspend-web-domains admin
 #
 # The function of unsuspending all user's sites.
 

--- a/bin/v-update-database-disk
+++ b/bin/v-update-database-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update database disk usage
 # options: USER DATABASE
+# labels: panel
+#
+# example: v-update-database-disk admin wp_db
 #
 # The function recalculates disk usage for specific database.
 

--- a/bin/v-update-databases-disk
+++ b/bin/v-update-databases-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update databases disk usage
 # options: USER
+# labels: panel
+#
+# example: v-update-databases-disk admin
 #
 # The function recalculates disk usage for all user databases.
 

--- a/bin/v-update-dns-templates
+++ b/bin/v-update-dns-templates
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update dns templates
 # options: [RESTART]
+# labels: dns
 #
 # The function for obtaining updated pack of dns templates.
 

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update system firewall rules
 # options: NONE
+# labels: panel
 #
 # The function updates iptables rules
 

--- a/bin/v-update-firewall-ipset
+++ b/bin/v-update-firewall-ipset
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update firewall ipset
 # options: [REFRESH]
+# labels: hestia
 #
 # The function creates ipset lists and updates the lists if they are expired or ondemand
 

--- a/bin/v-update-host-certificate
+++ b/bin/v-update-host-certificate
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update host certificate for hestia
 # options: USER HOSTNAME
+# labels: panel
+#
+# example: v-update-host-certificate admin example.com
 #
 # Function updates certificates for hestia
 

--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update letsencrypt ssl certificates
 # options: NONE
+# labels: panel
 #
 # The function for renew letsencrypt expired ssl certificate for all users
 

--- a/bin/v-update-mail-domain-disk
+++ b/bin/v-update-mail-domain-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update mail domain disk usage
 # options: USER DOMAIN
+# labels: mail
+#
+# example: v-update-mail-domain-disk admin example.com
 #
 # The function updates domain disk usage.
 

--- a/bin/v-update-mail-domains-disk
+++ b/bin/v-update-mail-domains-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: calculate disk usage for all mail domains
 # options: USER
+# labels: mail
+#
+# example: v-update-mail-domains-disk admin
 #
 # The function calculates disk usage for all mail domains.
 

--- a/bin/v-update-mail-templates
+++ b/bin/v-update-mail-templates
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update mail templates
 # options: [RESTART]
+# labels: hestia
 #
 # The function for obtaining updated pack of mail templates.
 

--- a/bin/v-update-sys-hestia
+++ b/bin/v-update-sys-hestia
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update hestia package/configs
 # options: PACKAGE
+# labels: panel
+#
+# example: v-update-sys-hestia exim4
 #
 # The function runs as rpm update trigger. It pulls shell script from hestia
 # server and runs it.

--- a/bin/v-update-sys-hestia
+++ b/bin/v-update-sys-hestia
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: update hestia package/configs
-# options: PACKAGE [VERSION]
+# options: PACKAGE
 #
 # The function runs as rpm update trigger. It pulls shell script from hestia
 # server and runs it.

--- a/bin/v-update-sys-hestia-all
+++ b/bin/v-update-sys-hestia-all
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: update all hestia packages
-# options: USER [RESTART]
+# options: NONE
 #
 # The function of updating all hestia packages
 

--- a/bin/v-update-sys-hestia-all
+++ b/bin/v-update-sys-hestia-all
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update all hestia packages
 # options: NONE
+# labels: panel
 #
 # The function of updating all hestia packages
 

--- a/bin/v-update-sys-hestia-git
+++ b/bin/v-update-sys-hestia-git
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: Delete log file for user
 # options: REPOSITORY BRANCH INSTALL [PACKAGES]
+# labels: hestia
 #
 # example: v-update-sys-hestia-git hestiacp staging/beta install all
 #          # Will download from the hestiacp repository

--- a/bin/v-update-sys-hestia-git
+++ b/bin/v-update-sys-hestia-git
@@ -1,15 +1,16 @@
 #!/bin/bash
-
-# v-update-sys-hestia-git
+# info: Delete log file for user
+# options: REPOSITORY BRANCH INSTALL [PACKAGES]
+#
+# example: v-update-sys-hestia-git hestiacp staging/beta install all
+#          # Will download from the hestiacp repository
+#          # Pulls code from staging/beta branch
+#          # install: installs package immediately
+#          # install-auto: installs package and schedules automatic updates from Git
+#          # 'all': (optional) - compiles nginx and php alongside panel.
+#          #                     this option takes a long time, only use when needed
+#
 # Downloads and compiles/installs packages from GitHub repositories
-# Options:  REPOSITORY BRANCH INSTALL [PACKAGES]
-# Example:  v-update-sys-hestia-git hestiacp staging/beta install all
-#           - Will download from the hestiacp repository
-#           - Pulls code from staging/beta branch
-#           - install: installs package immediately
-#           - install-auto: installs package and schedules automatic updates from Git
-#           - 'all': (optional) - compiles nginx and php alongside panel.
-#                                 this option takes a long time, only use when needed
 
 
 # Define download function

--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update system ip
 # options: NONE
+# labels: panel
+#
+# example: Intended for internal usage
 #
 # The function scans configured ip in the system and register them with hestia
 # internal database. This call is intended for use on vps servers, where ip is

--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: update system ip
-# options: [NONE]
+# options: NONE
 #
 # The function scans configured ip in the system and register them with hestia
 # internal database. This call is intended for use on vps servers, where ip is

--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -3,7 +3,8 @@
 # options: NONE
 # labels: panel
 #
-# example: Intended for internal usage
+# example: v-update-sys-ip
+#          # Intended for internal usage
 #
 # The function scans configured ip in the system and register them with hestia
 # internal database. This call is intended for use on vps servers, where ip is

--- a/bin/v-update-sys-ip-counters
+++ b/bin/v-update-sys-ip-counters
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update IP usage counters
 # options: IP
+# labels: panel
 #
 # Function updates usage U_WEB_ADOMAINS and U_SYS_USERS counters.
 

--- a/bin/v-update-sys-queue
+++ b/bin/v-update-sys-queue
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update system queue
 # options: PIPE
+# labels: panel
 #
 # This function is responsible queue processing. Restarts of services,
 # scheduled backups, web log parsing and other heavy resource consuming

--- a/bin/v-update-sys-rrd
+++ b/bin/v-update-sys-rrd
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update system rrd charts
 # options: NONE
+# labels: panel
 #
 # The script is wrapper for all rrd functions. It updates all 
 # v-update-sys-rrd_* at once.

--- a/bin/v-update-sys-rrd-apache2
+++ b/bin/v-update-sys-rrd-apache2
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update apache2 rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating apache rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-ftp
+++ b/bin/v-update-sys-rrd-ftp
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update ftp rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating ftpd rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-httpd
+++ b/bin/v-update-sys-rrd-httpd
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update httpd rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating apache rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-la
+++ b/bin/v-update-sys-rrd-la
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update load average rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating load average rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-mail
+++ b/bin/v-update-sys-rrd-mail
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update mail rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating mail rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-mem
+++ b/bin/v-update-sys-rrd-mem
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update memory rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating memory rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-mysql
+++ b/bin/v-update-sys-rrd-mysql
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update MySQL rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating mysql rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-net
+++ b/bin/v-update-sys-rrd-net
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update network rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating network usage rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-nginx
+++ b/bin/v-update-sys-rrd-nginx
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update nginx rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating nginx rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-pgsql
+++ b/bin/v-update-sys-rrd-pgsql
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update PostgreSQL rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating postgresql rrd database and graphic.
 

--- a/bin/v-update-sys-rrd-ssh
+++ b/bin/v-update-sys-rrd-ssh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update ssh rrd
 # options: PERIOD
+# labels: panel
 #
 # The function is for updating ssh rrd database and graphic.
 

--- a/bin/v-update-user-backup-exclusions
+++ b/bin/v-update-user-backup-exclusions
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update backup exclusion list
 # options: USER FILE
+# labels: panel
+#
+# example: v-update-user-backup-exclusions admin .bash_history
 #
 # The function for updating backup exclusion list
 

--- a/bin/v-update-user-counters
+++ b/bin/v-update-user-counters
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update user usage counters
 # options: USER
+# labels: panel
 #
 # Function updates usage counters like U_WEB_DOMAINS, U_MAIL_ACCOUNTS, etc.
 

--- a/bin/v-update-user-disk
+++ b/bin/v-update-user-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update user disk usage
 # options: USER
+# labels: panel
+#
+# example: v-update-user-disk admin
 #
 # The functions recalculates disk usage and updates database.
 

--- a/bin/v-update-user-package
+++ b/bin/v-update-user-package
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update user package
 # options: PACKAGE
+# labels: panel
+#
+# example: v-update-user-package default
 #
 # The function propagates package to connected users.
 

--- a/bin/v-update-user-quota
+++ b/bin/v-update-user-quota
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update user disk quota
 # options: USER
+# labels: panel
+#
+# example: v-update-user-quota alice
 #
 # The functions upates disk quota for specific user
 

--- a/bin/v-update-user-stats
+++ b/bin/v-update-user-stats
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update user statistics
 # options: USER
+# labels: panel
 #
 # Function logs user parameters into statistics database.
 

--- a/bin/v-update-web-domain-disk
+++ b/bin/v-update-web-domain-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update disk usage for domain
 # options: USER DOMAIN
+# labels: web
+#
+# example: v-update-web-domain-disk alice wonderland.com
 #
 # The function recalculates disk usage for specific webdomain.
 

--- a/bin/v-update-web-domain-ssl
+++ b/bin/v-update-web-domain-ssl
@@ -1,11 +1,14 @@
 #!/bin/bash
 # info: updating ssl certificate for domain
 # options: USER DOMAIN SSL_DIR [RESTART]
+# labels: web
+#
+# example: v-update-web-domain-ssl admin domain.com /home/admin/tmp
 #
 # The function updates the SSL certificate for a domain. Parameter ssl_dir is a path
 # to directory where 2 or 3 ssl files can be found. Certificate file 
-# domain.tld.crt and its key domain.tld.key  are mandatory. Certificate
-# authority domain.tld.ca file is optional. 
+# domain.tld.crt and its key domain.tld.key are mandatory. Certificate
+# authority domain.tld.ca file is optional.
 
 
 #----------------------------------------------------------#

--- a/bin/v-update-web-domain-stat
+++ b/bin/v-update-web-domain-stat
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update domain statistics
 # options: USER DOMAIN
+# labels: web
+#
+# example: v-update-web-domain-stat alice acme.com
 #
 # The function runs log analyzer for specific webdomain.
 

--- a/bin/v-update-web-domain-traff
+++ b/bin/v-update-web-domain-traff
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update domain bandwidth usage
 # options: USER DOMAIN
+# labels: web
+#
+# example: v-update-web-domain-traff admin example.com
 #
 # The function recalculates bandwidth usage for specific domain.
 

--- a/bin/v-update-web-domains-disk
+++ b/bin/v-update-web-domains-disk
@@ -1,6 +1,9 @@
 #!/bin/bash
-# info: update domains disk usage 
+# info: update domains disk usage
 # options: USER
+# labels: web
+#
+# example: v-update-web-domains-disk alice
 #
 # The function recalculates disk usage for all user webdomains.
 

--- a/bin/v-update-web-domains-stat
+++ b/bin/v-update-web-domains-stat
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update domains statistics
 # options: USER
+# labels: web
+#
+# example: v-update-web-domains-stat admin
 #
 # The function runs log analyzer usage for all user webdomains.
 

--- a/bin/v-update-web-domains-traff
+++ b/bin/v-update-web-domains-traff
@@ -1,6 +1,9 @@
 #!/bin/bash
 # info: update domains bandwidth usage
 # options: USER
+# labels: web
+#
+# example: v-update-web-domains-traff bob
 #
 # The function recalculates bandwidth usage for all user webdomains.
 

--- a/bin/v-update-web-templates
+++ b/bin/v-update-web-templates
@@ -1,6 +1,7 @@
 #!/bin/bash
 # info: update web templates
 # options: [RESTART]
+# labels: web
 #
 # The function for obtaining updated pack of web templates.
 


### PR DESCRIPTION
Partially addresses #1271

The first comment block in all CLI scripts was generated for consistency with [dedicated tools](https://github.com/bisubus/hestia-cli-docs) to allow for reliable parsing and documentation generation. Examples and categories from existing Hestia documentation have been merged to the annotation. Some missing data like descriptions have been added manually. Strict format for the annotation is a common denominator of existing comments and described [here](https://github.com/bisubus/hestia-cli-docs#format).

Script options have been checked with a tool to determine mismatches between documented and actually used args and fixed manually. Almost all changes are cosmetic, some address discrepancies in `check_args` arg validation, mostly optional `RESTART`. Scripts were checked with Shellcheck to avoid regressions, no changes before and after were found, except for a bug with misused arg in `v-delete-web-domain-backend` that was fixed.