### PR TITLE
[Security] Avoid SNI leak (for the server)

### DIFF
--- a/install/deb/nginx/unassigned.inc
+++ b/install/deb/nginx/unassigned.inc
@@ -37,6 +37,7 @@ server {
     server_name _;
     ssl_certificate      /usr/local/hestia/ssl/certificate.crt;
     ssl_certificate_key  /usr/local/hestia/ssl/certificate.key;
+    ssl_reject_handshake on;
 
     return 301 http://$host$request_uri;
 

--- a/install/deb/templates/web/nginx/proxy_ip.tpl
+++ b/install/deb/templates/web/nginx/proxy_ip.tpl
@@ -13,10 +13,11 @@ server {
 }
 
 server {
-    listen      %ip%:%proxy_ssl_port% ssl http2;
+    listen      %ip%:%proxy_ssl_port% ssl http2 default;
     server_name _;
     ssl_certificate      /usr/local/hestia/ssl/certificate.crt;
     ssl_certificate_key  /usr/local/hestia/ssl/certificate.key;
+    ssl_reject_handshake on;
 
     return 301 http://$host$request_uri;
 


### PR DESCRIPTION
This feature requires the released Nginx mainline 1.19.4, which is not an obstacle for Hestia.

E.g:
Visit https://server_ip
The server host name or a web domain name will be displayed.
After applying this change, it will only return: ERR_SSL_UNRECOGNIZED_NAME_ALERT

It can also completely solve such issues:
https://github.com/hestiacp/hestiacp/issues/1103
https://github.com/hestiacp/hestiacp/issues/1295

See also:
https://github.com/nginx/nginx/commit/9cdb278454367448366354f2786b36c1fef1f92e