### PR TITLE
Makes changing ip status more graceful

### DIFF
--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -36,7 +36,7 @@ if [ "$web_domains" -ne '0' ] && [ "$sys_user" != "$ip_owner" ]; then
     check_result "$E_INUSE" "ip $ip is used"
 fi
 if [ "$ip_owner" != "admin" ] && [ "$ip_status" == "shared" ]; then
-    check_result "$E_INVALID" "Only the 'admin' user can have a shared ip"
+    $HESTIA/bin/v-change-sys-ip-owner $ip admin
 fi
 
 # Perform verification if read-only mode is enabled


### PR DESCRIPTION
The previous method threw an error when trying to change the ip status while it was owned by a user. This proposed fix changes the owner to admin automatically if shared is selected.