### PR TITLE
Fixes iptables appearing stopped when fail2ban is stopped

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -284,12 +284,11 @@ fi
 # Checking FIREWALL system
 if [ ! -z "$FIREWALL_SYSTEM" ] && [ "$FIREWALL_SYSTEM" != 'remote' ]; then
     state="stopped"
-    /sbin/iptables -n -L fail2ban-HESTIA >/dev/null 2>&1
-    if [ "$?" -eq 0 ]; then
+    if $(iptables -S INPUT | grep -qx '\-P INPUT DROP'); then
         state="running"
     fi
     data="$data\nNAME='$FIREWALL_SYSTEM' SYSTEM='firewall'"
-    data="$data STATE='$state' CPU='0' MEM='0' RTIME='$rtime'"
+    data="$data STATE='$state' CPU='0' MEM='0' RTIME='0'"
 fi
 
 


### PR DESCRIPTION
Fixes #1371 and changes the run time to 0 since there is no pid file to get an accurate value from anyways.