### PR TITLE
[Bug] /list/server?web cache stats unreadable in dark layout

### DIFF
--- a/web/list/server/index.php
+++ b/web/list/server/index.php
@@ -66,6 +66,9 @@ if (isset($_GET['web'])) {
     exec (HESTIA_CMD.'v-list-sys-web-status', $output, $return_var);
     foreach($output as $file) {
         $file=str_replace('border="0"', 'border="1"', $file);
+        $file=str_replace('bgcolor="#ffffff"', '', $file);
+        $file=str_replace('bgcolor="#000000"', '', $file);
+        
         echo $file . "\n";
     }
     echo "    </pre>\n</body>\n</html>\n";

--- a/web/list/server/index.php
+++ b/web/list/server/index.php
@@ -67,7 +67,7 @@ if (isset($_GET['web'])) {
     foreach($output as $file) {
         $file=str_replace('border="0"', 'border="1"', $file);
         $file=str_replace('bgcolor="#ffffff"', '', $file);
-        $file=str_replace('bgcolor="#000000"', '', $file);
+        $file=str_replace('bgcolor="#000000"', 'bgcolor="#282828"', $file);
         
         echo $file . "\n";
     }


### PR DESCRIPTION
Removed default white in ssl cache stats + adjusted same header to “dark bg”