### PR TITLE
Fixes psql command in v-update-sys-rrd-pgsql

### DIFF
--- a/bin/v-update-sys-rrd-pgsql
+++ b/bin/v-update-sys-rrd-pgsql
@@ -76,7 +76,7 @@ for host in $hosts; do
         done
 
         export PGPASSWORD="$PASSWORD"
-        sql="psql -h $HOST -U $USER -c"
+        sql="psql -h $HOST -U $USER"
 
         # Checking empty vars
         if [ -z $HOST ] || [ -z $USER ] || [ -z $PASSWORD ]; then
@@ -88,7 +88,7 @@ for host in $hosts; do
         # Parsing data
         q='SELECT SUM(xact_commit + xact_rollback), SUM(numbackends)
                 FROM pg_stat_database;'
-        status=$($sql plsql -d postgres -c "$q" 2>/dev/null); code="$?"
+        status=$($sql -d postgres -c "$q" 2>/dev/null); code="$?"
         if [ '0' -ne "$code" ]; then
             active=0
             slow=0


### PR DESCRIPTION
Giving another go at #1429.

Fixes the errors in the postgres rrd database & graphic update script, which was causing errors:

```
2020-12-01 08:25:01.673 -03 [15444] postgres@postgres ERROR:  syntax error at or near "plsql" at character 1
2020-12-01 08:25:01.673 -03 [15444] postgres@postgres STATEMENT:  plsql
```