### PR TITLE
Added check if return value is an array

### DIFF
--- a/web/edit/server/index.php
+++ b/web/edit/server/index.php
@@ -110,8 +110,10 @@ unset($output);
 exec (HESTIA_CMD."v-list-remote-dns-hosts json", $output, $return_var);
 $dns_cluster = json_decode(implode('', $output), true);
 unset($output);
-foreach ($dns_cluster as $key => $value) {
-    $v_dns_cluster = 'yes';
+if(is_array($dns_cluster)){
+    foreach ($dns_cluster as $key => $value) {
+        $v_dns_cluster = 'yes';
+    }
 }
 
 // List Database hosts

--- a/web/edit/server/index.php
+++ b/web/edit/server/index.php
@@ -110,7 +110,7 @@ unset($output);
 exec (HESTIA_CMD."v-list-remote-dns-hosts json", $output, $return_var);
 $dns_cluster = json_decode(implode('', $output), true);
 unset($output);
-if(is_array($dns_cluster)){
+if (is_array($dns_cluster)) {
     foreach ($dns_cluster as $key => $value) {
         $v_dns_cluster = 'yes';
     }


### PR DESCRIPTION
   $dns_cluster = json_decode(implode('', $output), true);

    foreach ($dns_cluster as $key => $value) {
        $v_dns_cluster = 'yes';
    }

Returned NULL when cluster is disabled causing  error in error log

2020/12/22 21:48:25 [error] 29766#0: *63 FastCGI sent in stderr: "PHP message: PHP Warning:  Invalid argument supplied for foreach() in /usr/local/hestia/web/edit/server/index.php on line 113" while reading response header from upstream, client: xx.xx.xx.xx, server: _, request: "POST /edit/server/ HTTP/1.1", upstream: "fastcgi://unix:/var/run/hestia-php.sock:", host: "dev.eris.nu:8083", referrer: "https://dev.text.xx:8083/edit/server/"