### PR TITLE
Adding last name as option for backward issues with Blesta / WMHCS plugins

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add system user
-# options: USER PASSWORD EMAIL [PACKAGE] [NAME]
+# options: USER PASSWORD EMAIL [PACKAGE] [NAME] [LASTNAME]
 # labels: 
 #
 # example: v-add-user admin2 P4$$w@rD bgates@aol.com
@@ -18,7 +18,10 @@ password=$2; HIDE=2
 email=$3
 package=${4-default}
 name=$5
-
+# Last name has been added for backward compatibility with WHMCS / Blesta VestaCP Plugins
+if [ ! -z "$6" ]; then 
+    name="$name $6";
+fi
 # Includes
 source $HESTIA/func/main.sh
 source $HESTIA/conf/hestia.conf


### PR DESCRIPTION
v-add-user test 1234 client@domain.com default Jaap Marcus

Will result in Jaap as full name. 

So older Vesta/WMHCS Still uses the "Vesta" standaard 