### PR TITLE
Fix Nginx web statistics authorization

### DIFF
--- a/bin/v-add-web-domain-stats
+++ b/bin/v-add-web-domain-stats
@@ -1,5 +1,5 @@
 #!/bin/bash
-# info: add log analyzer to generate domain statitics
+# info: add log analyzer to generate domain statistics
 # options: USER DOMAIN TYPE
 # labels: web
 #

--- a/bin/v-add-web-domain-stats-user
+++ b/bin/v-add-web-domain-stats-user
@@ -52,8 +52,8 @@ conf_dir="$HOMEDIR/$user/conf/web"
 
 # Adding htaccess file
 if [ "$WEB_SYSTEM" = 'nginx' ]; then
-    echo "auth_basic \"Web Statistics\";" > $conf_dir/$domain.auth
-    echo "auth_basic_user_file $stats_dir/.htpasswd;" >> $conf_dir/$domain.auth
+    echo "auth_basic \"Web Statistics\";" > $stats_dir/auth.conf
+    echo "auth_basic_user_file $stats_dir/.htpasswd;" >> $stats_dir/auth.conf
 else
     echo "AuthUserFile $stats_dir/.htpasswd" > $stats_dir/.htaccess
     echo "AuthName \"Web Statistics\"" >> $stats_dir/.htaccess

--- a/bin/v-delete-web-domain-stats-user
+++ b/bin/v-delete-web-domain-stats-user
@@ -1,5 +1,5 @@
 #!/bin/bash
-# info: disable webdomain stats  authentication support
+# info: disable web domain stats authentication support
 # options: USER DOMAIN [RESTART]
 # labels: web
 #
@@ -47,7 +47,7 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-# Defining statistic dir
+# Deleting statistic dir
 rm -f $HOMEDIR/$user/web/$domain/stats/.htpasswd
 rm -f $HOMEDIR/$user/web/$domain/stats/.htaccess
 

--- a/bin/v-delete-web-domain-stats-user
+++ b/bin/v-delete-web-domain-stats-user
@@ -48,13 +48,13 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Deleting statistic dir
-rm -f $HOMEDIR/$user/web/$domain/stats/.htpasswd
-rm -f $HOMEDIR/$user/web/$domain/stats/.htaccess
+stats_dir="$HOMEDIR/$user/web/$domain/stats"
+rm -f $stats_dir/.htpasswd
+rm -f $stats_dir/.htaccess
 
 # Deleting nginx auth config
 if [ "$WEB_SYSTEM" = 'nginx' ]; then
-    conf_dir="$HOMEDIR/$user/conf/web"
-    rm -f $conf_dir/$domain.auth 2>/dev/null
+    rm -f $stats_dir/auth.conf 2>/dev/null
     $BIN/v-restart-web $restart
     check_result $? "Web restart failed" >/dev/null
 fi


### PR DESCRIPTION
This is a fix for web statistics authorization bug affecting Hestiacp configured with nginx as a `WEB_SYSTEM`.

The checkbox "Statistics Authorization" didn't work for me when checked.

<img width="498" alt="Screenshot 2020-12-27 at 15 56 23" src="https://user-images.githubusercontent.com/282550/103173621-6b573300-485c-11eb-831f-446a4ed8b487.png">

I've looked through the Nginx templates and it appears that all templates have the same location for statistics authentication:

```
    location /vstats/ {
        alias   %home%/%user%/web/%domain%/stats/;
        include %home%/%user%/web/%domain%/stats/auth.conf*;
    }
```

And `web-domain-stats-user` scripts manage manage a file located at `$HOMEDIR/$user/conf/web/$domain.auth`, that is not even near the expected path. So I updated both `delete` and `add` to manage the file in the `$stats_dir`.