### PR TITLE
$pgsql was never set instead of $postgresql is set

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1021,7 +1021,7 @@ if [ "$mysql" = 'yes' ]; then
     installed_db_types='mysql'
 fi
 
-if [ "$pgsql" = 'yes' ]; then
+if [ "$postgresql" = 'yes' ]; then
     installed_db_types="$installed_db_type,pgsql"
 fi
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1072,7 +1072,7 @@ if [ "$mysql" = 'yes' ]; then
     installed_db_types='mysql'
 fi
 
-if [ "$pgsql" = 'yes' ]; then
+if [ "$postgresql" = 'yes' ]; then
     installed_db_types="$installed_db_type,pgsql"
 fi
 


### PR DESCRIPTION
$pgsql var was never. Use $postgresql instead. 

Just checked older 1.3.2 are not affected so we are save to use no upgrade script

Due to:
https://github.com/hestiacp/hestiacp/blob/20c5bed3aa2b55f1e8e6e89bfdf20cc919cf251f/bin/v-add-database-host#L120-L130