### PR TITLE
Fix #1529 Set Admin to Administrator on install

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1021,8 +1021,8 @@ if [ "$mysql" = 'yes' ]; then
     installed_db_types='mysql'
 fi
 
-if [ "$pgsql" = 'yes' ]; then
-    installed_db_types="$installed_db_type,pgsql"
+if [ "$postgresql" = 'yes' ]; then
+    installed_db_types="$installed_db_types,pgsql"
 fi
 
 if [ ! -z "$installed_db_types" ]; then
@@ -1712,6 +1712,7 @@ check_result $? "can't enable sftp jail"
 $HESTIA/bin/v-add-user admin $vpass $email default "System Administrator"
 check_result $? "can't create admin user"
 $HESTIA/bin/v-change-user-shell admin nologin
+$HESTIA/bin/v-change-user-role admin admin
 $HESTIA/bin/v-change-user-language admin $lang
 
 # Roundcube permissions fix

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1072,8 +1072,8 @@ if [ "$mysql" = 'yes' ]; then
     installed_db_types='mysql'
 fi
 
-if [ "$pgsql" = 'yes' ]; then
-    installed_db_types="$installed_db_type,pgsql"
+if [ "$postgresql" = 'yes' ]; then
+    installed_db_types="$installed_db_types,pgsql"
 fi
 
 if [ ! -z "$installed_db_types" ]; then
@@ -1757,6 +1757,7 @@ check_result $? "can't enable sftp jail"
 $HESTIA/bin/v-add-user admin $vpass $email default "System Administrator"
 check_result $? "can't create admin user"
 $HESTIA/bin/v-change-user-shell admin nologin
+$HESTIA/bin/v-change-user-role admin admin
 $HESTIA/bin/v-change-user-language admin $lang
 
 # Configuring system IPs

--- a/install/upgrade/versions/1.3.3.sh
+++ b/install/upgrade/versions/1.3.3.sh
@@ -20,3 +20,6 @@ if [ -e "/etc/nginx/nginx.conf" ]; then
         echo '    [!] fastcgi_cache_path found skipping install of fast cgi cache support!'
     fi
 fi
+
+echo '[*] Set Role "Admin" to Administrator'
+$HESTIA/bin/v-change-user-role admin admin

--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -163,7 +163,7 @@ if (!empty($_POST['save'])) {
         unset($output);
     }
     // Change Role (admin only)
-    if (($v_role != $_POST['$v_role']) && ($_SESSION['user'] == 'admin') && (empty($_SESSION['error_msg']))) {
+    if (($v_role != $_POST['$v_role']) && ($_SESSION['user'] == 'admin') && $v_username != "admin" && (empty($_SESSION['error_msg']))) {
         $v_role = escapeshellarg($_POST['v_role']);
         exec (HESTIA_CMD."v-change-user-role ".escapeshellarg($v_username)." ".$v_role, $output, $return_var);
         check_return_code($return_var,$output);


### PR DESCRIPTION
Fix #1529 During install admin account get set to Administrator role (Will not change behaviour as it was already hardcode)
During upgrade "admin" account will also set to "Administrator" to prevent questions
Disabled "Changing role" via UI for admin user

Minor fix on line 1076  (Installers) where an s was missing
