### PR TITLE
Mitigate XSS attack in Lets Encrypt exchange

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -281,7 +281,7 @@ for auth in $authz; do
             if [ "$WEB_SYSTEM" = 'nginx' ] || [ "$PROXY_SYSTEM" = 'nginx' ]; then
                 conf="$HOMEDIR/$user/conf/web/$domain/nginx.conf_letsencrypt"
                 sconf="$HOMEDIR/$user/conf/web/$domain/nginx.ssl.conf_letsencrypt"
-                echo 'location ~ "^/\.well-known/acme-challenge/(.*)$" {' \
+                echo 'location ~ "^/\.well-known/acme-challenge/([-_A-Za-z0-9]+)$" {' \
                     > $conf
                 echo '    default_type text/plain;' >> $conf
                 echo '    return 200 "$1.'$THUMB'";' >> $conf


### PR DESCRIPTION
As part of the Lets Encrypt exchange, a challenge is sent to `[DOMAIN]/.well-known/acme-challenge/[TOKEN]`
The response is supposed to be `[TOKEN].[THUMBPRINT]`

Hestia copies the TOKEN verbatim into the response, which allows malformed requests to include scripting attacks.
e.g. 
`http://example.com/.well-known/acme-challenge/<script>document.write(document.cookie);</script>`

While the Content-Type is also set to `text/plain`, this does not mitigate the execution of code in all cases (see http://www.debugtheweb.com/test/mime/script.asp for an example that exploits this on modern browsers).

To be safe, Hestia should only allow base64url characters in the acme-challenge request token (as per ACME RFC 8555 https://datatracker.ietf.org/doc/rfc8555/)