### PR TITLE
[Fix] Enable SSL on default when installing Prestashop when enabled

### DIFF
--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -36,7 +36,7 @@ $v_web_apps = [
     [ 'name'=>'Joomla',    'group'=>'cms', 'enabled'=>false,'version'=>'latest', 'thumbnail'=>'/images/webapps/joomla-thumb.png' ],
 
     [ 'name'=>'Opencart',   'group'=>'ecommerce', 'enabled'=>true,  'version'=>'3.0.3.3', 'thumbnail'=>'/images/webapps/opencart-thumb.png' ],
-    [ 'name'=>'Prestashop', 'group'=>'ecommerce', 'enabled'=>true, 'version'=>'1.7.6.5', 'thumbnail'=>'/images/webapps/prestashop-thumb.png' ],
+    [ 'name'=>'Prestashop', 'group'=>'ecommerce', 'enabled'=>true, 'version'=>'1.7.7.1', 'thumbnail'=>'/images/webapps/prestashop-thumb.png' ],
 
     [ 'name'=>'Laravel', 'group'=>'starter', 'enabled'=>true, 'version'=>'7.x', 'thumbnail'=>'/images/webapps/laravel-thumb.png' ],
     [ 'name'=>'Symfony', 'group'=>'starter', 'enabled'=>true, 'version'=>'4.3.x', 'thumbnail'=>'/images/webapps/symfony-thumb.png' ],

--- a/web/src/app/WebApp/Installers/PrestashopSetup.php
+++ b/web/src/app/WebApp/Installers/PrestashopSetup.php
@@ -16,7 +16,7 @@ class PrestashopSetup extends BaseSetup {
             ],
         'database' => true,
         'resources' => [
-            'archive'  => [ 'src' => 'https://github.com/PrestaShop/PrestaShop/releases/download/1.7.6.5/prestashop_1.7.6.5.zip' ],
+            'archive'  => [ 'src' => 'https://github.com/PrestaShop/PrestaShop/releases/download/1.7.7.1/prestashop_1.7.7.1.zip' ],
         ],
 
     ];
@@ -24,9 +24,15 @@ class PrestashopSetup extends BaseSetup {
     public function install(array $options=null) : bool
     {
         parent::install($options);
-
         $this->appcontext->archiveExtract($this->getDocRoot($this->extractsubdir . '/prestashop.zip'), $this->getDocRoot());
-
+        //check if ssl is enabled 
+        $this->appcontext->run('v-list-web-domain',[$this -> appcontext->user(),$this -> domain,'json'],$status);
+        if($status->code !== 0) {
+            throw new \Exception("Cannot list domain");
+        }
+        
+        if ($status -> json == 'no'){ $ssl_enabled = 0; }else{ $ssl_enabled = 1;}
+        
         $this->appcontext->runUser('v-run-cli-cmd', [
             "/usr/bin/php",
             $this->getDocRoot("/install/index_cli.php"),
@@ -37,8 +43,9 @@ class PrestashopSetup extends BaseSetup {
             "--lastname="    . $options['prestashop_account_last_name'],
             "--password="    . $options['prestashop_account_password'],
             "--email="       . $options['prestashop_account_email'],
-            "--domain="      . $this->domain], $status);
-
+            "--domain="      . $this->domain,
+            "--ssl="         . $ssl_enabled,],  $status);
+        
         // remove install folder
         $this->appcontext->runUser('v-delete-fs-directory', [$this->getDocRoot("/install")]);
         $this->cleanup();


### PR DESCRIPTION
Enable SSL on “default” if SSL is enabled
Updated version to the last  stable version (1.7.6.5 to 1.7.7.1)