### PR TITLE
[Bug] #1498 Removed check for invalid chars

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -676,7 +676,7 @@ is_number_format_valid() {
 
 # Autoreply format validator
 is_autoreply_format_valid() {
-    if [[ "$1" =~ [$|\`] ]] || [ 10240 -le ${#1} ]; then
+    if [[ 10240 -le ${#1} ]; then
         check_result $E_INVALID "invalid autoreply format :: $1"
     fi
 }


### PR DESCRIPTION
Due to a security issue in the past it was not save to use any bash chars in the command how ever 
https://github.com/hestiacp/hestiacp/commit/39e9b6397b3b63742da5e2413aa2feb4e11b747a#diff-71cb484db93b3b6f68468e10fdc7bfb904668241842f835ed5b24c4a0dd53a12

Should fix the issue. 

Close: https://github.com/hestiacp/hestiacp/issues/1498