### PR TITLE
#944 Filegator does keep track of the “current path” in the user session

### DIFF
--- a/web/login/index.php
+++ b/web/login/index.php
@@ -27,6 +27,7 @@ if (isset($_SESSION['user'])) {
             $_SESSION['look_alert'] = 'yes';
             # Remove current path for filemanager
             unset($_SESSION['_sf2_attributes']);
+            unset($_SESSION['_sf2_meta']);
         }
     }
     if ($_SESSION['user'] == 'admin' && empty($_GET['loginas'])) {

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -25,6 +25,8 @@ if (isset($_SESSION['user'])) {
             reset($data);
             $_SESSION['look'] = key($data);
             $_SESSION['look_alert'] = 'yes';
+            # Remove current path for filemanager
+            unset($_SESSION['_sf2_attributes']);
         }
     }
     if ($_SESSION['user'] == 'admin' && empty($_GET['loginas'])) {

--- a/web/logout/index.php
+++ b/web/logout/index.php
@@ -4,8 +4,10 @@ session_start();
 define('HESTIA_CMD', '/usr/bin/sudo /usr/local/hestia/bin/');
 
 if (!empty($_SESSION['look'])) {
-
     unset($_SESSION['look']);
+    # Remove current path for filemanager
+    unset($_SESSION['_sf2_attributes']);
+    unset($_SESSION['_sf2_meta']);
     header("Location: /");
 } else {
     if($_SESSION['MURMUR'] && $_SESSION['user']){


### PR DESCRIPTION
When not leaving FM via “Back to CP” those paths remain in place. Sugested changes removes those session files. Close  #994