### PR TITLE
Fix #1582 Improve stats exim

### DIFF
--- a/bin/v-list-sys-mail-status
+++ b/bin/v-list-sys-mail-status
@@ -41,9 +41,14 @@ else
     eximstats /var/log/exim/main.log 2>/dev/null
 fi
 
+if [ $? -ne 0 ]; then
+    echo "[Exim4] No valid log lines read"
+    exit 0;
+fi
+
 
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-exit
+exit 0


### PR DESCRIPTION
when mainlog is empty / no emails has been made it will give an exit 1 as default. Add error message + exit 0 so the system still works as intended

New:
<img width="646" alt="Screenshot 2021-01-24 at 21 07 38" src="https://user-images.githubusercontent.com/9754650/105642165-5801ac80-5e88-11eb-8fe5-00145c678712.png">
Old:
<img width="1073" alt="Screenshot 2021-01-24 at 15 34 08" src="https://user-images.githubusercontent.com/9754650/105642166-589a4300-5e88-11eb-88c0-3af2b388ab32.png">
