### PR TITLE
Fix - Webmail with Gateway Timeout

### DIFF
--- a/install/deb/php-fpm/www.conf
+++ b/install/deb/php-fpm/www.conf
@@ -11,3 +11,5 @@ pm = ondemand
 pm.max_children = 4
 pm.max_requests = 4000
 pm.process_idle_timeout = 10s
+
+request_terminate_timeout 30s


### PR DESCRIPTION
https://forum.hestiacp.com/t/webmail-with-gateway-timeout/2094/11

cat /var/log/apache2/error.log | grep timeout

Test: From one timeout every 1 to 5 minutes to 0.