### PR TITLE
[Bug] Restore preferred webmail client

### DIFF
--- a/bin/v-rebuild-mail-domains
+++ b/bin/v-rebuild-mail-domains
@@ -61,8 +61,12 @@ for domain in $(search_objects 'mail' 'SUSPENDED' "*" 'DOMAIN'); do
     rebuild_mail_domain_conf
     if [ ! -z "$WEB_SYSTEM" ] || [ ! -z "$PROXY_SYSTEM" ]; then
         if [ ! -z "$IMAP_SYSTEM" ]; then
+            WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
             $BIN/v-delete-sys-webmail $user $domain '' 'yes'
-            $BIN/v-add-sys-webmail $user $domain '' 'yes'
+            $BIN/v-add-sys-webmail $user $domain $WEBMAIL '' 'yes'
+            if [ $? -ne 0 ]; then
+                $BIN/v-add-sys-webmail $user $domain '' '' 'yes'    
+            fi
         fi
     fi
 done


### PR DESCRIPTION
Set the “prefered” webmail client on restore / v-rebuild-mail-domains
If not available server A has Rainloop -> server B not it will revert to the default option