### PR TITLE
Changing expect to be case insensitive in SFTP

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -49,7 +49,7 @@ sftpc() {
         set count 0
         spawn /usr/bin/sftp -o StrictHostKeyChecking=no -o Port=$port $user@$host
         expect {
-            "password:" {
+            -nocase "password:" {
                 send "$password\r"
                 exp_continue
             }

--- a/func/backup.sh
+++ b/func/backup.sh
@@ -194,7 +194,7 @@ sftpc() {
         spawn /usr/bin/sftp -o StrictHostKeyChecking=no \
             -o Port=$PORT $USERNAME@$HOST
         expect {
-            "password:" {
+            -nocase "password:" {
                 send "$PASSWORD\r"
                 exp_continue
             }


### PR DESCRIPTION
In some cases the sftp command will ask for Password rather than
password which is breaking both backups and adding an SFTP host.

This change uses the -nocase flag with expect to ensure case is ignored
during login and the host can be added and then used.