### PR TITLE
Fix mysql server wait_timeout regexp attribute

### DIFF
--- a/web/templates/admin/edit_server_mysql.html
+++ b/web/templates/admin/edit_server_mysql.html
@@ -80,7 +80,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="text" size="20" class="vst-input" regexp="memory_limit" prev_value="<?=htmlentities($v_wait_timeout)?>" name="v_wait_timeout" value="<?=htmlentities($v_wait_timeout)?>">
+                                    <input type="text" size="20" class="vst-input" regexp="wait_timeout" prev_value="<?=htmlentities($v_wait_timeout)?>" name="v_wait_timeout" value="<?=htmlentities($v_wait_timeout)?>">
                                     <br><br>
                                 </td>
                             </tr>


### PR DESCRIPTION
The regexp was incorrectly set as `memory_limit`. Thus, changing the value from the admin interface had no effect.