### PR TITLE
Fix issues with IDN Domains

### DIFF
--- a/bin/v-add-dns-domain
+++ b/bin/v-add-dns-domain
@@ -18,7 +18,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ip=$3
 ns1=$4
 ns2=$5
@@ -52,6 +52,8 @@ is_domain_new 'dns' "$domain"
 is_package_full 'DNS_DOMAINS'
 template=$(get_user_value '$DNS_TEMPLATE')
 is_dns_template_valid $template
+
+is_base_domain_owner "$domain"
 
 if [ ! -z "$ns1" ]; then
     ns1=$(echo $4 |sed -e 's/\.*$//g' -e 's/^\.*//g')

--- a/bin/v-add-dns-on-web-alias
+++ b/bin/v-add-dns-on-web-alias
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-alias=$2
+alias=$(idn -t --quiet -a "$2" )
 ip=$3
 restart=$4
 

--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -17,12 +17,11 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
-record=$(idn -t --quiet -u "$3" )
+domain=$(idn -t --quiet -a "$2" )
+record=$(idn -t --quiet -a "$3" )
 record=$(echo "$record" | tr '[:upper:]' '[:lower:]')
 rtype=$(echo "$4"| tr '[:lower:]' '[:upper:]')
-dvalue=$(idn -t --quiet -u "$5" )
+dvalue=$(idn -t --quiet -a "$5" )
 priority=$6
 id=$7
 restart=$8
@@ -67,8 +66,6 @@ fi
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-add-domain
+++ b/bin/v-add-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ip=$3
 restart="${4-yes}"
 

--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 aliases=$3
 mail=${4// }
 

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 password=$4; HIDE=4
 quota=${5-unlimited}

--- a/bin/v-add-mail-account-alias
+++ b/bin/v-add-mail-account-alias
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 malias=$4
 
@@ -27,8 +26,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-add-mail-account-autoreply
+++ b/bin/v-add-mail-account-autoreply
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 autoreply=$4
 
@@ -34,8 +33,6 @@ fi
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-add-mail-account-forward
+++ b/bin/v-add-mail-account-forward
@@ -15,7 +15,7 @@
 # Argument definition
 user=$1
 domain=$2
-domain_idn=$2
+domain_idn=$(idn -t --quiet -a "$2" )
 account=$3
 email_forward=$4
 

--- a/bin/v-add-mail-account-fwd-only
+++ b/bin/v-add-mail-account-fwd-only
@@ -15,7 +15,7 @@
 # Argument definition
 user=$1
 domain=$2
-domain_idn=$2
+domain_idn=$(idn -t --quiet -a "$2" )
 account=$3
 
 # Includes
@@ -33,8 +33,6 @@ fi
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 antispam=${3-yes}
 antivirus=${4-yes}
 dkim=${5-yes}
@@ -50,6 +50,8 @@ is_object_unsuspended 'user' 'USER' "$user"
 is_domain_new 'mail' "$domain"
 is_package_full 'MAIL_DOMAINS'
 is_dir_symlink $HOMEDIR/$user/mail
+
+is_base_domain_owner "$domain"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-add-mail-domain-antispam
+++ b/bin/v-add-mail-domain-antispam
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh
@@ -25,7 +24,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-add-mail-domain-antivirus
+++ b/bin/v-add-mail-domain-antivirus
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-add-mail-domain-catchall
+++ b/bin/v-add-mail-domain-catchall
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 email="$3"
 
 # Includes

--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 dkim_size=${3-1024}
 
 # Includes
@@ -33,8 +32,6 @@ fi
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-add-mail-domain-smtp-relay
+++ b/bin/v-add-mail-domain-smtp-relay
@@ -13,7 +13,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 host=$3
 username=$4
 password=$5

--- a/bin/v-add-mail-domain-ssl
+++ b/bin/v-add-mail-domain-ssl
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ssl_dir=$3
 restart="$3"
 

--- a/bin/v-add-remote-dns-domain
+++ b/bin/v-add-remote-dns-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 flush=$3
 
 

--- a/bin/v-add-remote-dns-record
+++ b/bin/v-add-remote-dns-record
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 
 # Includes

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -20,8 +20,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ip=$3
 restart=$4      # will be moved to the end soon
 aliases=$5
@@ -32,6 +31,18 @@ source $HESTIA/func/main.sh
 source $HESTIA/func/domain.sh
 source $HESTIA/func/ip.sh
 source $HESTIA/conf/hestia.conf
+
+# Rewrite all aliases as puni code 
+aliases_list=$(echo $aliases | tr "," "\n")
+aliases=''
+for alias in $aliases_list
+do
+    if [ -z "$aliases" ]; then
+        aliases=$(idn -t --quiet -a "$alias" )
+    else
+        aliases=$aliases,$(idn -t --quiet -a "$alias" )
+    fi
+done
 
 # Additional argument formatting
 format_domain
@@ -51,6 +62,9 @@ is_package_full 'WEB_DOMAINS' 'WEB_ALIASES'
 is_domain_new 'web' "$domain,$aliases"
 is_dir_symlink "$HOMEDIR/$user/web"
 is_dir_symlink "$HOMEDIR/$user/web/$domain"
+
+is_base_domain_owner "$domain,$aliases"
+
 if [ ! -z "$ip" ]; then
     is_ip_valid "$ip" "$user"
 else

--- a/bin/v-add-web-domain-alias
+++ b/bin/v-add-web-domain-alias
@@ -15,9 +15,8 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
-aliases=$3
+domain=$(idn -t --quiet -a "$2" )
+aliases=$(idn -t --quiet -a "$3" )
 restart="$4"
 
 # Includes
@@ -29,7 +28,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 format_aliases
 
 
@@ -50,6 +48,8 @@ is_object_valid 'web' 'DOMAIN' "$domain"
 is_object_unsuspended 'web' 'DOMAIN' "$domain"
 is_domain_new 'web' "$aliases"
 is_package_full 'WEB_ALIASES'
+
+is_base_domain_owner "$aliases"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-add-web-domain-allow-users
+++ b/bin/v-add-web-domain-allow-users
@@ -1,11 +1,13 @@
 #!/bin/bash
-# info: suspend all mail domain accounts
+# info: disables other users create subdomains
 # options: USER DOMAIN
-# labels: mail
+# labels: web hestia
 #
-# example: v-suspend-mail-accounts admin example.com
+# example: v-delete-web-domain-allow-users
 #
-# The function suspends all mail domain accounts.
+# Disallow other users to create a new subdomain.
+# eg: admin adds admin.com
+# user can't create user.admin.com
 
 
 #----------------------------------------------------------#
@@ -18,11 +20,13 @@ domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh
+source $HESTIA/func/domain.sh
+source $HESTIA/func/ip.sh
 source $HESTIA/conf/hestia.conf
 
 # Additional argument formatting
 format_domain
-format_domain_idn
+
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -30,31 +34,33 @@ format_domain_idn
 
 check_args '2' "$#" 'USER DOMAIN'
 is_format_valid 'user' 'domain'
-is_system_enabled "$MAIL_SYSTEM" 'MAIL_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
-is_object_valid 'mail' 'DOMAIN' "$domain"
-is_object_unsuspended 'mail' 'DOMAIN' "$domain"
+is_object_valid 'web' 'DOMAIN' "$domain"
+is_object_unsuspended 'web' 'DOMAIN' "$domain"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
-
 
 #----------------------------------------------------------#
 #                       Action                             #
 #----------------------------------------------------------#
 
-# Starting suspend loop
-for account in $(search_objects "mail/$domain" 'SUSPENDED' "no" 'ACCOUNT'); do
-    $BIN/v-suspend-mail-account "$user" "$domain" "$account"
-done
-
+# Load domain data
+parse_object_kv_list $(grep "DOMAIN='$domain'" $USER_DATA/web.conf)
 
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-# No Logging
-#log_event "$OK" "$ARGUMENTS"
+if [ -z "$ALLOW_USERS" ]; then
+    add_object_key "web" 'DOMAIN' "$domain" 'ALLOW_USERS' 'TIME'
+fi
+
+# Adding new alias
+update_object_value 'web' 'DOMAIN' "$domain" '$ALLOW_USERS' "yes"
+
+log_history "Allow users create subdomain for $domain"
+log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 template=${3-default}
 restart=$4
 

--- a/bin/v-add-web-domain-fast-cgi-cache
+++ b/bin/v-add-web-domain-fast-cgi-cache
@@ -15,7 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 debug=$3
 
 # Includes

--- a/bin/v-add-web-domain-ftp
+++ b/bin/v-add-web-domain-ftp
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ftp_user=${1}_${3}
 password=$4; HIDE=4
 ftp_path=$5
@@ -28,7 +27,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-add-web-domain-httpauth
+++ b/bin/v-add-web-domain-httpauth
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 auth_user=$3
 password=$4; HIDE=4
 restart=${5-yes}

--- a/bin/v-add-web-domain-proxy
+++ b/bin/v-add-web-domain-proxy
@@ -15,7 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 template=$3
 default_extentions="jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,\
 exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,html,htm"

--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -19,7 +19,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ssl_dir=$3
 ssl_home=${4-same}
 restart="$5"

--- a/bin/v-add-web-domain-ssl-force
+++ b/bin/v-add-web-domain-ssl-force
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-add-web-domain-ssl-hsts
+++ b/bin/v-add-web-domain-ssl-hsts
@@ -12,7 +12,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-add-web-domain-ssl-preset
+++ b/bin/v-add-web-domain-ssl-preset
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ssl=$3
 
 # Includes

--- a/bin/v-add-web-domain-stats
+++ b/bin/v-add-web-domain-stats
@@ -17,8 +17,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 type=$3
 
 # Includes

--- a/bin/v-add-web-domain-stats-user
+++ b/bin/v-add-web-domain-stats-user
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 stats_user=$3
 password=$4; HIDE=4
 restart=$5

--- a/bin/v-change-dns-domain-exp
+++ b/bin/v-change-dns-domain-exp
@@ -15,8 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 exp=$3
 
 # Includes
@@ -26,7 +25,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-dns-domain-ip
+++ b/bin/v-change-dns-domain-ip
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ip=$3
 restart=$4
 
@@ -27,7 +26,7 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
+
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-dns-domain-soa
+++ b/bin/v-change-dns-domain-soa
@@ -15,8 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 soa=$(echo $3 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 restart=$4
 
@@ -28,7 +27,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-dns-domain-tpl
+++ b/bin/v-change-dns-domain-tpl
@@ -16,8 +16,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 template=$3
 restart=$4
 

--- a/bin/v-change-dns-domain-ttl
+++ b/bin/v-change-dns-domain-ttl
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ttl=$3
 restart=$4
 

--- a/bin/v-change-dns-record
+++ b/bin/v-change-dns-record
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 record=$4
 type=$5

--- a/bin/v-change-dns-record-id
+++ b/bin/v-change-dns-record-id
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 newid=$4
 restart=$5
@@ -28,7 +27,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-domain-owner
+++ b/bin/v-change-domain-owner
@@ -13,7 +13,7 @@
 #----------------------------------------------------------#
 
 # Argument definition
-domain=$1
+domain=$(idn -t --quiet -a "$1" )
 user=$2
 
 # Includes

--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 password=$4; HIDE=4
 
@@ -27,7 +26,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-mail-account-quota
+++ b/bin/v-change-mail-account-quota
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 quota=$4
 
@@ -27,8 +26,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-change-mail-domain-catchall
+++ b/bin/v-change-mail-domain-catchall
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 email=$3
 
 # Includes

--- a/bin/v-change-mail-domain-sslcert
+++ b/bin/v-change-mail-domain-sslcert
@@ -13,8 +13,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-change-remote-dns-domain-exp
+++ b/bin/v-change-remote-dns-domain-exp
@@ -12,7 +12,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-change-remote-dns-domain-soa
+++ b/bin/v-change-remote-dns-domain-soa
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-change-remote-dns-domain-ttl
+++ b/bin/v-change-remote-dns-domain-ttl
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 template=$3
 restart=$4
 

--- a/bin/v-change-web-domain-dirlist
+++ b/bin/v-change-web-domain-dirlist
@@ -14,7 +14,7 @@
 
 # Argument defenition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 mode=$3
 
 # Includes

--- a/bin/v-change-web-domain-docroot
+++ b/bin/v-change-web-domain-docroot
@@ -21,7 +21,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Export target domain and directory
 # so they are correctly passed through to domain.sh

--- a/bin/v-change-web-domain-ftp-password
+++ b/bin/v-change-web-domain-ftp-password
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ftp_user=$3
 password=$4; HIDE=4
 

--- a/bin/v-change-web-domain-ftp-path
+++ b/bin/v-change-web-domain-ftp-path
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ftp_user=$3
 ftp_path=$4
 

--- a/bin/v-change-web-domain-httpauth
+++ b/bin/v-change-web-domain-httpauth
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 auth_user=$3
 password=$4; HIDE=4
 

--- a/bin/v-change-web-domain-ip
+++ b/bin/v-change-web-domain-ip
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ip=$3
 restart=$4
 
@@ -28,8 +27,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-change-web-domain-name
+++ b/bin/v-change-web-domain-name
@@ -14,9 +14,8 @@
 
 # Argument defenition
 user=$1
-domain=$2
-domain_idn=$2
-new_domain=$3
+domain=$(idn -t --quiet -a "$2" )
+new_domain=$(idn -t --quiet -a "$3" )
 restart=$4
 
 # Includes

--- a/bin/v-change-web-domain-proxy-tpl
+++ b/bin/v-change-web-domain-proxy-tpl
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 template=$3
 default_extentions="jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,\
 exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,html,htm"
@@ -31,8 +30,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-change-web-domain-sslcert
+++ b/bin/v-change-web-domain-sslcert
@@ -15,8 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ssl_dir=$3
 restart=$4
 
@@ -28,7 +27,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-change-web-domain-sslhome
+++ b/bin/v-change-web-domain-sslhome
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ssl_home=$3
 restart=$4
 
@@ -27,8 +26,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-change-web-domain-stats
+++ b/bin/v-change-web-domain-stats
@@ -15,8 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 type=$3
 
 # Includes

--- a/bin/v-change-web-domain-tpl
+++ b/bin/v-change-web-domain-tpl
@@ -15,8 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 template=$3
 restart=$4
 

--- a/bin/v-delete-dns-domain
+++ b/bin/v-delete-dns-domain
@@ -15,7 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart="$3"
 
 # Includes

--- a/bin/v-delete-dns-domains-src
+++ b/bin/v-delete-dns-domains-src
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-src=$2
+src=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-dns-on-web-alias
+++ b/bin/v-delete-dns-on-web-alias
@@ -15,7 +15,7 @@
 # Argument definition
 user=$1
 domain=$2
-domain_idn=$2
+domain_idn=$(idn -t --quiet -a "$2" )
 dom_alias=$(idn -t --quiet -u "$3" )
 dom_alias=$(echo $dom_alias |sed -e 's/\.*$//g' -e 's/^\.*//g')
 dom_alias=$(echo $dom_alias |tr '[:upper:]' '[:lower:]')

--- a/bin/v-delete-dns-record
+++ b/bin/v-delete-dns-record
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 restart=$4
 

--- a/bin/v-delete-domain
+++ b/bin/v-delete-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart="${3-yes}"
 
 # Includes

--- a/bin/v-delete-letsencrypt-domain
+++ b/bin/v-delete-letsencrypt-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 mail=$4
 

--- a/bin/v-delete-mail-account
+++ b/bin/v-delete-mail-account
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 
 # Includes

--- a/bin/v-delete-mail-account-alias
+++ b/bin/v-delete-mail-account-alias
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 malias=$4
 

--- a/bin/v-delete-mail-account-autoreply
+++ b/bin/v-delete-mail-account-autoreply
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 malias=$4
 

--- a/bin/v-delete-mail-account-forward
+++ b/bin/v-delete-mail-account-forward
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 forward=$4
 

--- a/bin/v-delete-mail-account-fwd-only
+++ b/bin/v-delete-mail-account-fwd-only
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 
 # Includes

--- a/bin/v-delete-mail-domain
+++ b/bin/v-delete-mail-domain
@@ -15,8 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-mail-domain-antispam
+++ b/bin/v-delete-mail-domain-antispam
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-mail-domain-antivirus
+++ b/bin/v-delete-mail-domain-antivirus
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-mail-domain-catchall
+++ b/bin/v-delete-mail-domain-catchall
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-mail-domain-dkim
+++ b/bin/v-delete-mail-domain-dkim
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 domain=$(echo $domain | tr '[:upper:]' '[:lower:]')
 
 # Includes

--- a/bin/v-delete-mail-domain-smtp-relay
+++ b/bin/v-delete-mail-domain-smtp-relay
@@ -13,7 +13,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-mail-domain-ssl
+++ b/bin/v-delete-mail-domain-ssl
@@ -13,7 +13,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-remote-dns-domain
+++ b/bin/v-delete-remote-dns-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-delete-remote-dns-record
+++ b/bin/v-delete-remote-dns-record
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 
 # Includes

--- a/bin/v-delete-web-domain
+++ b/bin/v-delete-web-domain
@@ -17,8 +17,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes
@@ -30,8 +29,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-delete-web-domain-alias
+++ b/bin/v-delete-web-domain-alias
@@ -15,8 +15,8 @@
 
 # Argument definition
 user=$1
-domain=$2
-dom_alias=$3
+domain=$(idn -t --quiet -a "$2" )
+dom_alias=$(idn -t --quiet -a "$3" )
 restart=$4
 
 # Includes

--- a/bin/v-delete-web-domain-allow-users
+++ b/bin/v-delete-web-domain-allow-users
@@ -1,11 +1,13 @@
 #!/bin/bash
-# info: suspend all mail domain accounts
+# info: disables other users create subdomains
 # options: USER DOMAIN
-# labels: mail
+# labels: web hestia
 #
-# example: v-suspend-mail-accounts admin example.com
+# example: v-delete-web-domain-allow-users
 #
-# The function suspends all mail domain accounts.
+# Disallow other users to create a new subdomain.
+# eg: admin adds admin.com
+# user can't create user.admin.com
 
 
 #----------------------------------------------------------#
@@ -18,11 +20,13 @@ domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh
+source $HESTIA/func/domain.sh
+source $HESTIA/func/ip.sh
 source $HESTIA/conf/hestia.conf
 
 # Additional argument formatting
 format_domain
-format_domain_idn
+
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -30,31 +34,34 @@ format_domain_idn
 
 check_args '2' "$#" 'USER DOMAIN'
 is_format_valid 'user' 'domain'
-is_system_enabled "$MAIL_SYSTEM" 'MAIL_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
-is_object_valid 'mail' 'DOMAIN' "$domain"
-is_object_unsuspended 'mail' 'DOMAIN' "$domain"
+is_object_valid 'web' 'DOMAIN' "$domain"
+is_object_unsuspended 'web' 'DOMAIN' "$domain"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
-
 
 #----------------------------------------------------------#
 #                       Action                             #
 #----------------------------------------------------------#
 
-# Starting suspend loop
-for account in $(search_objects "mail/$domain" 'SUSPENDED' "no" 'ACCOUNT'); do
-    $BIN/v-suspend-mail-account "$user" "$domain" "$account"
-done
 
+# Load domain data
+parse_object_kv_list $(grep "DOMAIN='$domain'" $USER_DATA/web.conf)
 
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-# No Logging
-#log_event "$OK" "$ARGUMENTS"
+if [ -z "$ALLOW_USERS" ]; then
+add_object_key "web" 'DOMAIN' "$domain" 'ALLOW_USERS' 'TIME'
+fi
+
+# Adding new alias
+update_object_value 'web' 'DOMAIN' "$domain" '$ALLOW_USERS' "no"
+
+log_history "Allow users create subdomain for $domain"
+log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-delete-web-domain-backend
+++ b/bin/v-delete-web-domain-backend
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-web-domain-fast-cgi-cache
+++ b/bin/v-delete-web-domain-fast-cgi-cache
@@ -13,7 +13,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-web-domain-ftp
+++ b/bin/v-delete-web-domain-ftp
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ftp_user=$3
 
 # Includes

--- a/bin/v-delete-web-domain-httpauth
+++ b/bin/v-delete-web-domain-httpauth
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 auth_user=$3
 restart=${4-yes}
 

--- a/bin/v-delete-web-domain-proxy
+++ b/bin/v-delete-web-domain-proxy
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-web-domain-ssl
+++ b/bin/v-delete-web-domain-ssl
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-web-domain-ssl-force
+++ b/bin/v-delete-web-domain-ssl-force
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-web-domain-ssl-hsts
+++ b/bin/v-delete-web-domain-ssl-hsts
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-delete-web-domain-stats
+++ b/bin/v-delete-web-domain-stats
@@ -15,7 +15,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 domain_idn=$2
 
 # Includes

--- a/bin/v-delete-web-domain-stats-user
+++ b/bin/v-delete-web-domain-stats-user
@@ -17,7 +17,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-get-mail-account-value
+++ b/bin/v-get-mail-account-value
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$domain" )
 account=$3
 key=$4
 
@@ -25,8 +24,6 @@ source $HESTIA/func/main.sh
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-get-mail-domain-value
+++ b/bin/v-get-mail-domain-value
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 key=$3
 
 # Includes

--- a/bin/v-insert-dns-record
+++ b/bin/v-insert-dns-record
@@ -12,7 +12,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 data=$3
 restart=$4
 

--- a/bin/v-insert-dns-records
+++ b/bin/v-insert-dns-records
@@ -12,7 +12,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 data_file=$3
 restart=$4
 

--- a/bin/v-list-dns-domain
+++ b/bin/v-list-dns-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-dns-records
+++ b/bin/v-list-dns-records
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-mail-account
+++ b/bin/v-list-mail-account
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 format=${4-shell}
 

--- a/bin/v-list-mail-account-autoreply
+++ b/bin/v-list-mail-account-autoreply
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 format=${4-shell}
 

--- a/bin/v-list-mail-accounts
+++ b/bin/v-list-mail-accounts
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-mail-domain
+++ b/bin/v-list-mail-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-mail-domain-dkim
+++ b/bin/v-list-mail-domain-dkim
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-mail-domain-dkim-dns
+++ b/bin/v-list-mail-domain-dkim-dns
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-mail-domain-ssl
+++ b/bin/v-list-mail-domain-ssl
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-web-domain
+++ b/bin/v-list-web-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-list-web-domain-accesslog
+++ b/bin/v-list-web-domain-accesslog
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ttl=${3-70}
 format=${4-shell}
 

--- a/bin/v-list-web-domain-errorlog
+++ b/bin/v-list-web-domain-errorlog
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 ttl=${3-70}
 format=${4-shell}
 

--- a/bin/v-list-web-domain-ssl
+++ b/bin/v-list-web-domain-ssl
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 format=${3-shell}
 
 # Includes

--- a/bin/v-rebuild-dns-domain
+++ b/bin/v-rebuild-dns-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 update_serial=$4
 

--- a/bin/v-rebuild-mail-domain
+++ b/bin/v-rebuild-mail-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-rebuild-web-domain
+++ b/bin/v-rebuild-web-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-schedule-letsencrypt-domain
+++ b/bin/v-schedule-letsencrypt-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 aliases=$3
 
 # Includes

--- a/bin/v-suspend-dns-domain
+++ b/bin/v-suspend-dns-domain
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart="$3"
 
 # Includes
@@ -25,8 +24,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-suspend-dns-record
+++ b/bin/v-suspend-dns-record
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 restart=$4
 
@@ -27,8 +26,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-suspend-domain
+++ b/bin/v-suspend-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart="${3-yes}"
 
 # Includes

--- a/bin/v-suspend-mail-account
+++ b/bin/v-suspend-mail-account
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 
 # Includes
@@ -26,8 +25,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-suspend-mail-domain
+++ b/bin/v-suspend-mail-domain
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh
@@ -25,8 +24,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-suspend-web-domain
+++ b/bin/v-suspend-web-domain
@@ -16,8 +16,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes
@@ -29,8 +28,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-unsuspend-dns-domain
+++ b/bin/v-unsuspend-dns-domain
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-unsuspend-dns-record
+++ b/bin/v-unsuspend-dns-record
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 id=$3
 restart=$4
 
@@ -27,7 +26,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-unsuspend-domain
+++ b/bin/v-unsuspend-domain
@@ -14,7 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
+domain=$(idn -t --quiet -a "$2" )
 restart="${3-yes}"
 
 # Includes

--- a/bin/v-unsuspend-mail-account
+++ b/bin/v-unsuspend-mail-account
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 account=$3
 
 # Includes
@@ -26,8 +25,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
-
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-unsuspend-mail-accounts
+++ b/bin/v-unsuspend-mail-accounts
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh
@@ -24,7 +23,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-unsuspend-mail-domain
+++ b/bin/v-unsuspend-mail-domain
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh
@@ -25,7 +24,6 @@ source $HESTIA/conf/hestia.conf
 # Additional argument formatting
 format_domain
 format_domain_idn
-# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
 
 #----------------------------------------------------------#

--- a/bin/v-unsuspend-web-domain
+++ b/bin/v-unsuspend-web-domain
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 restart=$3
 
 # Includes

--- a/bin/v-update-web-domain-disk
+++ b/bin/v-update-web-domain-disk
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-update-web-domain-ssl
+++ b/bin/v-update-web-domain-ssl
@@ -17,8 +17,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 ssl_dir=$3
 restart=$4
 

--- a/bin/v-update-web-domain-stat
+++ b/bin/v-update-web-domain-stat
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/bin/v-update-web-domain-traff
+++ b/bin/v-update-web-domain-traff
@@ -14,8 +14,7 @@
 
 # Argument definition
 user=$1
-domain=$2
-domain_idn=$2
+domain=$(idn -t --quiet -a "$2" )
 
 # Includes
 source $HESTIA/func/main.sh

--- a/test/test_idn.bats
+++ b/test/test_idn.bats
@@ -1,0 +1,618 @@
+#!/usr/bin/env bats
+
+# Extension for tests.bats to check for issues with IDN domains
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/bats-file/load'
+
+
+function random() {
+    head /dev/urandom | tr -dc 0-9 | head -c$1
+}
+
+function setup() {
+    # echo "# Setup_file" > &3
+    if [ $BATS_TEST_NUMBER = 1 ]; then
+        echo 'user=testidn-5285' > /tmp/hestia-test-env.sh
+        echo 'userbk=testbk-5285' >> /tmp/hestia-test-env.sh
+        echo 'userpass1=testidn-5285' >> /tmp/hestia-test-env.sh
+        echo 'userpass2=t3st-p4ssw0rd' >> /tmp/hestia-test-env.sh
+        echo 'HESTIA=/usr/local/hestia' >> /tmp/hestia-test-env.sh
+        echo 'domain=смместро.рф' >> /tmp/hestia-test-env.sh
+        echo 'domain2=xn--e1anajjcdi.xn--p1ai' >> /tmp/hestia-test-env.sh
+        echo 'ip=198.18.0.125' >> /tmp/hestia-test-env.sh
+        echo 'ip2=198.18.0.126' >> /tmp/hestia-test-env.sh
+        
+    fi
+
+    source /tmp/hestia-test-env.sh
+    source $HESTIA/func/main.sh
+    source $HESTIA/conf/hestia.conf
+    source $HESTIA/func/ip.sh
+}
+
+function validate_web_domain() {
+    local user=$1
+    local domain=$2
+    local webproof=$3
+    local webpath=${4}
+
+    refute [ -z "$user" ]
+    refute [ -z "$domain" ]
+    refute [ -z "$webproof" ]
+
+    source $HESTIA/func/ip.sh
+
+    run v-list-web-domain $user $domain
+    assert_success
+
+    USER_DATA=$HESTIA/data/users/$user
+    local domain_ip=$(get_object_value 'WEB' 'DOMAIN' "$domain" '$IP')
+    SSL=$(get_object_value 'WEB' 'DOMAIN' "$domain" '$SSL')
+    domain_ip=$(get_real_ip "$domain_ip")
+
+    if [ ! -z $webpath ]; then
+        domain_docroot=$(get_object_value 'WEB' 'DOMAIN' "$domain" '$CUSTOM_DOCROOT')
+        if [ -n "$domain_docroot" ] && [ -d "$domain_docroot" ]; then
+            assert_file_exist "${domain_docroot}/${webpath}"
+        else
+            assert_file_exist "${HOMEDIR}/${user}/WEB/${domain}/public_html/${webpath}"
+        fi
+    fi
+
+    # Test HTTP
+    run curl --location --silent --show-error --insecure --resolve "${domain}:80:${domain_ip}" "http://${domain}/${webpath}"
+    assert_success
+    assert_output --partial "$webproof"
+
+    # Test HTTPS
+    if [ "$SSL" = "yes" ]; then
+        run v-list-web-domain-ssl $user $domain
+        assert_success
+
+        run curl --location --silent --show-error --insecure --resolve "${domain}:443:${domain_ip}" "https://${domain}/${webpath}"
+        assert_success
+        assert_output --partial "$webproof"
+    fi
+}
+
+function validate_mail_domain() {
+    local user=$1
+    local domain=$(idn -t --quiet -a "$2" )
+
+    refute [ -z "$user" ]
+    refute [ -z "$domain" ]
+
+    run v-list-mail-domain $user $domain
+    assert_success
+
+    assert_dir_exist $HOMEDIR/$user/mail/$domain
+    assert_dir_exist $HOMEDIR/$user/conf/mail/$domain
+
+    assert_file_exist $HOMEDIR/$user/conf/mail/$domain/aliases
+    assert_file_exist $HOMEDIR/$user/conf/mail/$domain/antispam
+    assert_file_exist $HOMEDIR/$user/conf/mail/$domain/antivirus
+    assert_file_exist $HOMEDIR/$user/conf/mail/$domain/fwd_only
+    assert_file_exist $HOMEDIR/$user/conf/mail/$domain/ip
+    assert_file_exist $HOMEDIR/$user/conf/mail/$domain/passwd
+}
+
+function validate_webmail_domain() {
+    local user=$1
+    local domain=$2
+    local webproof=$3
+    local webpath=${4}
+
+    refute [ -z "$user" ]
+    refute [ -z "$domain" ]
+    refute [ -z "$webproof" ]
+
+    domain_idn=$(idn -t --quiet -a "$domain" )
+    source $HESTIA/func/ip.sh
+
+    USER_DATA=$HESTIA/data/users/$user
+    local domain_ip=$(get_object_value 'web' 'DOMAIN' "$domain_idn" '$IP')
+    SSL=$(get_object_value 'mail' 'DOMAIN' "$domain_idn" '$SSL')
+    domain_ip=$(get_real_ip "$domain_ip")
+
+    if [ ! -z "$webpath" ]; then
+        assert_file_exist /var/lib/roundcube/$webpath
+    fi
+    
+    # Test HTTP
+    run curl --location --silent --show-error --insecure --resolve "webmail.${domain_idn}:80:${domain_ip}" "http://webmail.${domain_idn}/${webpath}"
+    assert_success
+    assert_output --partial "$webproof"
+
+    # Test HTTP
+    run curl --location --silent --show-error --insecure --resolve "mail.${domain_idn}:80:${domain_ip}" "http://mail.${domain_idn}/${webpath}"
+    assert_success
+    assert_output --partial "$webproof"
+
+    # Test HTTPS
+    if [ "$SSL" = "yes" ]; then
+        run v-list-mail-domain-ssl $user $domain
+        assert_success
+
+        run curl --location --silent --show-error --insecure --resolve "webmail.${domain_idn}:443:${domain_ip}" "https://webmail.${domain_idn}/${webpath}"
+        assert_success
+        assert_output --partial "$webproof"
+
+        run curl --location --silent --show-error --insecure --resolve "mail.${domain_idn}:443:${domain_ip}" "https://mail.${domain_idn}/${webpath}"
+        assert_success
+        assert_output --partial "$webproof"
+    fi
+}
+
+#----------------------------------------------------------#
+#                         MAIN                             #
+#----------------------------------------------------------#
+
+# Add Test IP
+@test "IP: Add Test IP" {
+    interface=$(v-list-sys-interfaces plain | head -n 1)
+    run v-add-sys-ip $ip 255.255.255.255 $interface
+    assert_success
+    refute_output
+}
+
+@test "IP: Add 2nd Test IP" {
+    interface=$(v-list-sys-interfaces plain | head -n 1)
+    run v-add-sys-ip $ip2 255.255.255.255 $interface
+    assert_success
+    refute_output
+}
+
+# create test user
+@test "User: Add test user" {
+    run v-add-user $user $user "test@idn.nu" default $ip
+    assert_success
+    refute_output
+}
+
+#----------------------------------------------------------#
+#                   WEB (смместро.рф)                      #
+#----------------------------------------------------------#
+
+@test "WEB: Add WEB domain IDN" {
+    run v-add-web-domain $user $domain $ip
+    assert_success
+    refute_output
+}
+
+@test "WEB: List WEB domain IDN" {
+    run  v-list-web-domain $user $domain2
+    assert_success
+    assert_output --partial $domain2
+}
+@test "WEB: Delete WEB domain IDN" {
+    run  v-delete-web-domain $user $domain
+    assert_success
+    refute_output
+}
+@test "WEB: List WEB domain IDN (Fail)" {
+    run  v-list-web-domain $user $domain
+    assert_failure $E_NOTEXIST   
+}
+@test "WEB: Add WEB domain + Alias IDN" {
+    run v-add-web-domain $user $domain $ip yes  "test.${domain},test2.${domain},www.${domain}"
+    assert_success
+    refute_output
+}
+@test "WEB: List WEB domain (Alias) IDN" {
+    run  v-list-web-domain $user $domain2
+    assert_success
+    assert_output --partial "test2.${domain2}"
+}
+@test "WEB: Delete Alias IDN" {
+    run v-delete-web-domain-alias $user $domain "test.${domain}"
+    assert_success
+    refute_output
+}
+@test "WEB: Add Alias IDN" {
+    run v-add-web-domain-alias $user $domain "test.${domain}"
+    assert_success
+    refute_output
+}
+
+@test "WEB: Add Alias (Wildcard) IDN" {
+    run v-add-web-domain-alias $user $domain "*.${domain}"
+    assert_success
+    refute_output
+}
+@test "WEB: Delete Alias (Wildcard) IDN" {
+    run v-delete-web-domain-alias $user $domain "*.${domain}"
+    assert_success
+    refute_output
+}
+
+@test "WEB: Add FTP user" {
+    run v-add-web-domain-ftp $user $domain "test" "test_${domain}"
+    assert_success
+    refute_output
+}
+
+@test "WEB: Delete FTP user" {
+    run v-delete-web-domain-ftp $user $domain "${user}_test"
+    assert_success
+    refute_output
+}
+
+@test "WEB: Add ssl" {
+    cp -f $HESTIA/ssl/certificate.crt /tmp/$domain2.crt
+    cp -f $HESTIA/ssl/certificate.key /tmp/$domain2.key
+
+    run v-add-web-domain-ssl $user $domain /tmp
+    assert_success
+    refute_output
+}
+
+@test "WEB: Add force ssl" {
+    run v-add-web-domain-ssl-force $user $domain
+    assert_success
+    refute_output
+}
+
+@test "WEB: Change Web IP" {
+    run v-change-web-domain-ip $user $domain $ip2
+    assert_success
+    refute_output
+}
+
+@test "WEB: Change Web IP (back to first)" {
+    run v-change-web-domain-ip $user $domain $ip
+    assert_success
+    refute_output
+}
+
+
+#----------------------------------------------------------#
+#                   MAIL (смместро.рф)                     #
+#----------------------------------------------------------#
+
+@test "MAIL:  Add mail domain" {
+    run v-add-mail-domain $user $domain
+    assert_success
+    refute_output
+    # We convert IDN always to punicode to verify it
+    validate_mail_domain $user "$domain"
+
+    # echo -e "<?php\necho 'Server: ' . \$_SERVER['SERVER_SOFTWARE'];" > /var/lib/roundcube/check_server.php
+    validate_webmail_domain $user $domain 'Welcome to Roundcube Webmail'
+    # rm /var/lib/roundcube/check_server.php
+}
+
+@test "MAIL: Add domain (duplicate)" {
+    run v-add-mail-domain $user $domain
+    assert_failure $E_EXISTS
+}
+
+@test "MAIL: Add account" {
+    run v-add-mail-account $user $domain test t3st-p4ssw0rd
+    assert_success
+    refute_output
+}
+
+@test "MAIL: Add account (duplicate)" {
+    run v-add-mail-account $user $domain test t3st-p4ssw0rd
+    assert_failure $E_EXISTS
+}
+
+@test "MAIL: Delete account" {
+    run v-delete-mail-account $user $domain test
+    assert_success
+    refute_output
+}
+
+@test "MAIL: Delete missing account" {
+    run v-delete-mail-account $user $domain test
+    assert_failure $E_NOTEXIST
+}
+
+#----------------------------------------------------------#
+#                         DNS                              #
+#----------------------------------------------------------#
+
+@test "DNS: Add domain" {
+    run v-add-dns-domain $user $domain $ip
+    assert_success
+    refute_output
+}
+
+@test "DNS: Add domain (duplicate)" {
+    run v-add-dns-domain $user $domain $ip
+    assert_failure $E_EXISTS
+}
+
+@test "DNS: Add domain record" {
+    run v-add-dns-record $user $domain test A $ip
+    assert_success
+    refute_output
+}
+
+@test "DNS: Delete domain record" {
+    run v-delete-dns-record $user $domain 20
+    assert_success
+    refute_output
+}
+
+@test "DNS: Delete missing domain record" {
+    run v-delete-dns-record $user $domain 20
+    assert_failure $E_NOTEXIST
+}
+
+@test "DNS: Change domain expire date" {
+    run v-change-dns-domain-exp $user $domain "2021-04-04"
+    assert_success
+    refute_output
+}
+
+@test "DNS: Change domain ip" {
+    run v-change-dns-domain-ip $user $domain 127.0.0.1
+    assert_success
+    refute_output
+}
+
+@test "DNS: Suspend domain" {
+    run v-suspend-dns-domain $user $domain
+    assert_success
+    refute_output
+}
+
+@test "DNS: Unsuspend domain" {
+    run v-unsuspend-dns-domain $user $domain
+    assert_success
+    refute_output
+}
+
+@test "DNS: Rebuild" {
+    run v-rebuild-dns-domains $user
+    assert_success
+    refute_output
+}
+
+#----------------------------------------------------------#
+#                  RESET USER                              #
+#----------------------------------------------------------#
+
+@test "User: Delete test user IDN" {
+    run v-delete-user $user
+    assert_success
+    refute_output
+}
+# create test user
+@test "User: Add test user IDN" {
+    run v-add-user $user $user "test@idn.nu" default $ip
+    assert_success
+    refute_output
+}
+
+#----------------------------------------------------------#
+#             WEB (xn--e1aaujjcdi.xn--p1ai)                #
+#----------------------------------------------------------#
+
+@test "2WEB: Add WEB domain IDN" {
+    run v-add-web-domain $user $domain2 $ip
+    assert_success
+    refute_output
+}
+
+@test "2WEB: List WEB domain IDN" {
+    run  v-list-web-domain $user $domain2
+    assert_success
+    assert_output --partial $domain2
+}
+@test "2WEB: Delete WEB domain IDN" {
+    run  v-delete-web-domain $user $domain2
+    assert_success
+    refute_output
+}
+@test "2WEB: List WEB domain IDN (Fail)" {
+    run  v-list-web-domain $user $domain2
+    assert_failure $E_NOTEXIST   
+}
+@test "2WEB: Add WEB domain + Alias IDN" {
+    run v-add-web-domain $user $domain2 $ip yes  "test.${domain},test2.${domain},www.${domain}"
+    assert_success
+    refute_output
+}
+@test "2WEB: List WEB domain (Alias) IDN" {
+    run  v-list-web-domain $user $domain2
+    assert_success
+    assert_output --partial "test2.${domain2}"
+}
+@test "2WEB: Delete Alias IDN" {
+    run v-delete-web-domain-alias $user $domain2 "test.${domain}"
+    assert_success
+    refute_output
+}
+@test "2WEB: Add Alias IDN" {
+    run v-add-web-domain-alias $user $domain2 "test.${domain}"
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Add Alias (Wildcard) IDN" {
+    run v-add-web-domain-alias $user $domain2 "*.${domain}"
+    assert_success
+    refute_output
+}
+@test "2WEB: Delete Alias (Wildcard) IDN" {
+    run v-delete-web-domain-alias $user $domain2 "*.${domain}"
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Add FTP user" {
+    run v-add-web-domain-ftp $user $domain2 "test" "test_${domain}"
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Delete FTP user" {
+    run v-delete-web-domain-ftp $user $domain2 "${user}_test"
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Add ssl" {
+    cp -f $HESTIA/ssl/certificate.crt /tmp/$domain2.crt
+    cp -f $HESTIA/ssl/certificate.key /tmp/$domain2.key
+
+    run v-add-web-domain-ssl $user $domain2 /tmp
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Add force ssl" {
+    run v-add-web-domain-ssl-force $user $domain2
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Change Web IP" {
+    run v-change-web-domain-ip $user $domain2 $ip2
+    assert_success
+    refute_output
+}
+
+@test "2WEB: Change Web IP (back to first)" {
+    run v-change-web-domain-ip $user $domain2 $ip
+    assert_success
+    refute_output
+}
+
+
+#----------------------------------------------------------#
+#                   MAIL (смместро.рф)                     #
+#----------------------------------------------------------#
+
+@test "2MAIL:  Add mail domain" {
+    run v-add-mail-domain $user $domain2
+    assert_success
+    refute_output
+    # We convert IDN always to punicode to verify it
+    validate_mail_domain $user "$domain2"
+
+    # echo -e "<?php\necho 'Server: ' . \$_SERVER['SERVER_SOFTWARE'];" > /var/lib/roundcube/check_server.php
+    validate_webmail_domain $user $domain2 'Welcome to Roundcube Webmail'
+    # rm /var/lib/roundcube/check_server.php
+}
+
+@test "2MAIL: Add domain (duplicate)" {
+    run v-add-mail-domain $user $domain2
+    assert_failure $E_EXISTS
+}
+
+@test "2MAIL: Add account" {
+    run v-add-mail-account $user $domain2 test t3st-p4ssw0rd
+    assert_success
+    refute_output
+}
+
+@test "2MAIL: Add account (duplicate)" {
+    run v-add-mail-account $user $domain2 test t3st-p4ssw0rd
+    assert_failure $E_EXISTS
+}
+
+@test "2MAIL: Delete account" {
+    run v-delete-mail-account $user $domain2 test
+    assert_success
+    refute_output
+}
+
+@test "2MAIL: Delete missing account" {
+    run v-delete-mail-account $user $domain2 test
+    assert_failure $E_NOTEXIST
+}
+
+#----------------------------------------------------------#
+#                         DNS                              #
+#----------------------------------------------------------#
+
+@test "2DNS: Add domain" {
+    run v-add-dns-domain $user $domain2 $ip
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Add domain (duplicate)" {
+    run v-add-dns-domain $user $domain2 $ip
+    assert_failure $E_EXISTS
+}
+
+@test "2DNS: Add domain record" {
+    run v-add-dns-record $user $domain2 test A $ip
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Delete domain record" {
+    run v-delete-dns-record $user $domain2 20
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Delete missing domain record" {
+    run v-delete-dns-record $user $domain2 20
+    assert_failure $E_NOTEXIST
+}
+
+@test "2DNS: Change domain expire date" {
+    run v-change-dns-domain-exp $user $domain2 "2021-04-04"
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Change domain ip" {
+    run v-change-dns-domain-ip $user $domain2 127.0.0.1
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Suspend domain" {
+    run v-suspend-dns-domain $user $domain2
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Unsuspend domain" {
+    run v-unsuspend-dns-domain $user $domain2
+    assert_success
+    refute_output
+}
+
+@test "2DNS: Rebuild" {
+    run v-rebuild-dns-domains $user
+    assert_success
+    refute_output
+}
+
+#----------------------------------------------------------#
+#                         CLEANUP                          #
+#----------------------------------------------------------#
+
+@test "User: Delete test user" {
+    run v-delete-user $user
+    assert_success
+    refute_output
+}
+
+
+@test "Ip: Delete the test IP" {
+    run v-delete-sys-ip $ip
+    assert_success
+    refute_output
+}
+
+@test "Ip: Delete 2nd test IP" { 
+    run v-delete-sys-ip $ip2
+    assert_success
+    refute_output
+}
+
+@test 'assert()' {
+  touch '/var/log/test.log'
+  assert [ -e '/var/log/test.log' ]
+}


### PR DESCRIPTION
When entering all domains convert all domains to 
xn-xxxxxx.tld (or xxxx.xn-tld ) format

The "old" (Based on VestaCP) system allowed both format with the use of special chars of the use of xn-- and then the the domain. Causing multiple issues with restore and so on. How ever if xn--xxxxx was used the import went fine. To stream line it the future I suggest to use 1 format. 

Suggestion is to "convert" all entered domains with the command:
domain=$(idn -t --quiet -a "domain.tld" ) on default  preventing any issues with domains in the future. For Latin / non special chars will remain the same and only apply on domains containing special chars

The "old" suggestion https://github.com/hestiacp/hestiacp/pull/1067 converted all domains to the "special chars" format causing issues with Nginx / DNS And I don't know where ever..
 