### PR TITLE
Fix/2021 03 upgrade filemanager to last version

### DIFF
--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -19,7 +19,6 @@ MODE=$1
 user="admin"
 
 FM_INSTALL_DIR="$HESTIA/web/fm"
-#FM_V="7.4.1"
 FM_FILE="filegator_v${FM_V}.zip"
 FM_URL="https://github.com/filegator/filegator/releases/download/v${FM_V}/${FM_FILE}"
 COMPOSER_BIN="$HOMEDIR/$user/.composer/composer"

--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -13,12 +13,13 @@
 # Includes
 source $HESTIA/func/main.sh
 source $HESTIA/conf/hestia.conf
+source $HESTIA/install/upgrade/upgrade.conf
 
 MODE=$1
 user="admin"
 
 FM_INSTALL_DIR="$HESTIA/web/fm"
-FM_V="7.4.1"
+#FM_V="7.4.1"
 FM_FILE="filegator_v${FM_V}.zip"
 FM_URL="https://github.com/filegator/filegator/releases/download/v${FM_V}/${FM_FILE}"
 COMPOSER_BIN="$HOMEDIR/$user/.composer/composer"

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -61,11 +61,26 @@ $dist_config['services']['Filegator\Services\View\ViewInterface']['config'] = [
     'add_to_body' => '
 <script>
     var checkVueLoaded = setInterval(function() {
-        if (document.getElementsByClassName("navbar-item").length) {
+        if (document.getElementsByClassName("container").length) {
             clearInterval(checkVueLoaded);
             var navProfile = document.getElementsByClassName("navbar-item profile")[0]; navProfile.replaceWith(navProfile.cloneNode(true))
             document.getElementsByClassName("navbar-item logout")[0].text="Exit to Control Panel \u00BB";
-        }
+            div = document.getElementsByClassName("container")[0];
+            callback = function(){
+                if (document.getElementsByClassName("navbar-item logout")[0]){
+                    if ( document.getElementsByClassName("navbar-item logout")[0].text != "Exit to Control Panel \u00BB" ){
+                        //var navProfile = document.getElementsByClassName("navbar-item profile")[0]; navProfile.replaceWith(navProfile.cloneNode(true))
+                        //document.getElementsByClassName("navbar-item logout")[0].text="Exit to Control Panel \u00BB";
+                    }
+                }
+            }
+            config = {
+                childList:true,
+                subtree:true
+            }
+            observer = new MutationObserver(callback);
+            observer.observe(div,config);
+        }    
     }, 200);
 </script>',
 ];

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -69,8 +69,8 @@ $dist_config['services']['Filegator\Services\View\ViewInterface']['config'] = [
             callback = function(){
                 if (document.getElementsByClassName("navbar-item logout")[0]){
                     if ( document.getElementsByClassName("navbar-item logout")[0].text != "Exit to Control Panel \u00BB" ){
-                        //var navProfile = document.getElementsByClassName("navbar-item profile")[0]; navProfile.replaceWith(navProfile.cloneNode(true))
-                        //document.getElementsByClassName("navbar-item logout")[0].text="Exit to Control Panel \u00BB";
+                        var navProfile = document.getElementsByClassName("navbar-item profile")[0]; navProfile.replaceWith(navProfile.cloneNode(true))
+                        document.getElementsByClassName("navbar-item logout")[0].text="Exit to Control Panel \u00BB";
                     }
                 }
             }

--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -59,4 +59,4 @@ rc_v="1.4.11"
 rl_v="1.15.0"
 
 # Set version of File manager to update during upgrade if not already installed
-rl_v="1.15.0"
+FM_V="1.5.0"

--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -57,3 +57,6 @@ rc_v="1.4.11"
 
 # Set version of Rainloop (Webmail) to update during upgrade if not already installed
 rl_v="1.15.0"
+
+# Set version of File manager to update during upgrade if not already installed
+rl_v="1.15.0"

--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -59,4 +59,4 @@ rc_v="1.4.11"
 rl_v="1.15.0"
 
 # Set version of File manager to update during upgrade if not already installed
-FM_V="1.5.0"
+FM_V="7.5.0"


### PR DESCRIPTION
- Update version Filemanager to 7.5.0
- Move version Filemanager to /install/upgrade/upgrade.conf instead v-add-sys-filemager allowing easier updating version number
- Fix #1669 Issue is caused by vue.JS reload DOM and our "Automated" change link text script run only on load after Dom structure has been loaded the script stops. Added an script that listen to Dom changes and change the text back to the correct text. 