### PR TITLE
Update jquery 3.5.1 and correct html code

### DIFF
--- a/web/list/server/index.php
+++ b/web/list/server/index.php
@@ -19,7 +19,7 @@ if (isset($_GET['cpu'])) {
     foreach($output as $file) {
         echo $file . "\n";
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 
@@ -31,7 +31,7 @@ if (isset($_GET['mem'])) {
     foreach($output as $file) {
         echo $file . "\n";
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 
@@ -43,7 +43,7 @@ if (isset($_GET['disk'])) {
     foreach($output as $file) {
         echo $file . "\n";
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 
@@ -55,7 +55,7 @@ if (isset($_GET['net'])) {
     foreach($output as $file) {
         echo $file . "\n";
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 
@@ -68,13 +68,12 @@ if (isset($_GET['web'])) {
         $file=str_replace('border="0"', 'border="1"', $file);
         $file=str_replace('bgcolor="#ffffff"', '', $file);
         $file=str_replace('bgcolor="#000000"', 'bgcolor="#282828"', $file);
-        
+
         echo $file . "\n";
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
-
 
 // DNS info
 if (isset($_GET['dns'])) {
@@ -84,7 +83,7 @@ if (isset($_GET['dns'])) {
     foreach($output as $file) {
         echo $file . "\n";
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 
@@ -98,7 +97,7 @@ if (isset($_GET['mail'])) {
             echo $file . "\n";
         }
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 
@@ -112,7 +111,7 @@ if (isset($_GET['db'])) {
             echo $file . "\n";
         }
     }
-    echo "    </pre>\n</body>\n</html>\n";
+    echo "  </pre>\n</div>\n</body>\n</html>\n";
     exit();
 }
 

--- a/web/templates/admin/list_server_info.html
+++ b/web/templates/admin/list_server_info.html
@@ -15,7 +15,7 @@
   <link type="text/css" href="/css/dependencies/animate.min.css?<?=JS_LATEST_UPDATE?>" rel="stylesheet" />
   <link type="text/css" href="/css/dependencies/jquery-custom-dialogs.css?<?=JS_LATEST_UPDATE?>" rel="stylesheet" />
   <link type="text/css" href="/css/dependencies/fontawesome.min.css?<?=JS_LATEST_UPDATE?>" rel="stylesheet" />
-  <script src="/inc/jquery/jquery-3.4.1.min.js"></script>
+  <script type="text/javascript" src="/inc/jquery/jquery-3.5.1.min.js"></script>
   <script type="text/javascript" src="/js/jquery/jquery-1.7.2.min.js"></script>
   <script type="text/javascript" src="/js/jquery/jquery.cookie.js"></script>
   <script type="text/javascript" src="/js/jquery/jquery-ui-1.8.20.custom.min.js"></script>
@@ -46,5 +46,6 @@
     </div>
   </div>
 
-  <div class="server-info-output">.</div><div class="l-center">
+  <div class="server-info-output">.</div>
+  <div class="l-center">
   <pre class="console-output animated fadeIn">


### PR DESCRIPTION
The page  **Server > Task Monitor > View Advanced Details** does not use the header template like the other pages, there is the inclusion of jQuery 3.4.1 which causes a 404 error.

![image](https://user-images.githubusercontent.com/1089510/114004217-b969d280-985e-11eb-9a51-d6ed2f557675.png)

Without going into the details of why there are two versions of jQuery in the Hestia panel and without refactoring this page to use the header template as for the others page, I made a quick fix by correcting the jQuery version and closing a missing html tag.

If it can be useful in the near future I would try to refactor the page using the header template and create a submenu for navigating the items (CPU, RAM, etc ...)