### PR TITLE
Preform config check before restarting web / proxy

### DIFF
--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -24,7 +24,7 @@ send_email_report() {
     email=$(echo "$email" | cut -f 2 -d "'")
     tmpfile=$(mktemp)
     subj="$(hostname): $PROXY_SYSTEM restart failed"
-    service $PROXY_SYSTEM configtest >> $tmpfile 2>&1
+    nginx -t >> $tmpfile 2>&1
     service $PROXY_SYSTEM restart >> $tmpfile 2>&1
     cat $tmpfile |$SENDMAIL -s "$subj" $email
     rm -f $tmpfile
@@ -70,6 +70,14 @@ if [ -f "$HESTIA/web/inc/nginx_proxy" ]; then
         nohup $BIN/v-restart-proxy 'background' &>/dev/null &
     else
     # Default behaviour
+    
+    # Preform an check if Nginx is valid as reload doesn't throw an error / exit
+    result=$(service $WEB_SYSTEM $PROXY_SYSTEM  >> /dev/null 2>&1 )
+    if [ $? -ne 0 ]; then
+        send_email_report
+        check_result $E_RESTART "$PROXY_SYSTEM restart failed"
+    fi
+    
     # Restart system
     $BIN/v-restart-service $PROXY_SYSTEM > /dev/null 2>&1
 

--- a/bin/v-restart-web
+++ b/bin/v-restart-web
@@ -24,7 +24,11 @@ send_email_report() {
     email=$(echo "$email" | cut -f 2 -d "'")
     tmpfile=$(mktemp)
     subj="$(hostname): $WEB_SYSTEM restart failed"
-    service $WEB_SYSTEM configtest >> $tmpfile 2>&1
+    if [ $WEB_SYSTEM = "apache2" ]; then 
+        apache2ctl configtest >> $tmpfile 2>&1
+    else 
+        nginx -t >> $tmpfile 2>&1
+    fi
     service $WEB_SYSTEM restart >> $tmpfile 2>&1
     cat $tmpfile |$SENDMAIL -s "$subj" $email
     rm -f $tmpfile
@@ -49,6 +53,19 @@ fi
 
 if [ -z "$WEB_SYSTEM" ] || [ "$WEB_SYSTEM" = 'remote' ]; then
     exit
+fi
+if [ $WEB_SYSTEM = 'nginx' ]; then 
+    result=$(service $WEB_SYSTEM configtest  >> /dev/null 2>&1 )
+    if [ $? -ne 0 ]; then
+        send_email_report
+        check_result $E_RESTART "$WEB_SYSTEM restart failed"
+    fi
+elif [ $WEB_SYSTEM = 'apache2' ]; then 
+    result=$(apache2ctl configtest  >> /dev/null 2>&1 )
+    if [ $? -ne 0 ]; then
+        send_email_report
+        check_result $E_RESTART "$WEB_SYSTEM restart failed"
+    fi
 fi
 
 $BIN/v-restart-service $WEB_SYSTEM > /dev/null 2>&1


### PR DESCRIPTION
To ensure the config is still valid causing issues with Nginx not working as expected. 