### PR TITLE
Fix 'no type is invalid' on rebuild mail domains

### DIFF
--- a/bin/v-rebuild-mail-domain
+++ b/bin/v-rebuild-mail-domain
@@ -68,6 +68,7 @@ rebuild_mail_domain_conf
 if [ ! -z "$WEB_SYSTEM" ] || [ ! -z "$PROXY_SYSTEM" ]; then
     if [ ! -z "$IMAP_SYSTEM" ]; then
         WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
+        if [ -z "$WEBMAIL" ]; then WEBMAIL='roundcube'; fi
         $BIN/v-delete-mail-domain-webmail $user $domain '' $restart 'yes'
         $BIN/v-add-mail-domain-webmail $user $domain $WEBMAIL '' $restart 'yes'
     fi

--- a/bin/v-rebuild-mail-domain
+++ b/bin/v-rebuild-mail-domain
@@ -68,9 +68,10 @@ rebuild_mail_domain_conf
 if [ ! -z "$WEB_SYSTEM" ] || [ ! -z "$PROXY_SYSTEM" ]; then
     if [ ! -z "$IMAP_SYSTEM" ]; then
         WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
-        if [ -z "$WEBMAIL" ]; then WEBMAIL='roundcube'; fi
-        $BIN/v-delete-mail-domain-webmail $user $domain '' $restart 'yes'
-        $BIN/v-add-mail-domain-webmail $user $domain $WEBMAIL '' $restart 'yes'
+        if [ ! -z "$WEBMAIL" ]; then
+            $BIN/v-delete-mail-domain-webmail $user $domain '' $restart 'yes'
+            $BIN/v-add-mail-domain-webmail $user $domain $WEBMAIL '' $restart 'yes'
+        fi
     fi
 fi
 

--- a/bin/v-rebuild-mail-domains
+++ b/bin/v-rebuild-mail-domains
@@ -68,17 +68,7 @@ U_DISK_MAIL=0
 
 # Starting loop
 for domain in $(search_objects 'mail' 'SUSPENDED' "*" 'DOMAIN'); do
-    rebuild_mail_domain_conf
-    if [ ! -z "$WEB_SYSTEM" ] || [ ! -z "$PROXY_SYSTEM" ]; then
-        if [ ! -z "$IMAP_SYSTEM" ]; then
-            WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
-            $BIN/v-delete-mail-domain-webmail $user $domain $restart 'yes'
-            $BIN/v-add-mail-domain-webmail $user $domain $WEBMAIL $restart 'yes'
-            if [ $? -ne 0 ]; then
-                $BIN/v-add-mail-domain-webmail $user $domain '' $restart 'yes'
-            fi
-        fi
-    fi
+    $BIN/v-rebuild-mail-domain $user $domain
 done
 
 

--- a/install/upgrade/versions/1.4.0.sh
+++ b/install/upgrade/versions/1.4.0.sh
@@ -110,6 +110,15 @@ if [ "$MAIL_SYSTEM" == "exim4" ]; then
     fi
 fi
 
+# Set default webmail system for mail domains
+if [ ! -z "$WEBMAIL_SYSTEM" ]; then
+    for user in $($BIN/v-list-users plain | cut -f1); do
+        for domain in $($BIN/v-list-mail-domains $user plain | cut -f1); do
+            $BIN/v-add-mail-domain-webmail $user $domain
+        done 
+    done
+fi
+
 # Fix PostgreSQL repo
 if [ -f /etc/apt/sources.list.d/postgresql.list ]; then
     echo "[ * ] Updating PostgreSQL repository..."


### PR DESCRIPTION
- fixes 1.4 upgrade bug
- calls v-rebuild-mail-domain from v-rebuild-mail-domains to reduce code redundancy 