### PR TITLE
Block access to webmail.domain.com/data/ with Rainloop

### DIFF
--- a/install/deb/templates/mail/nginx/default_rainloop.stpl
+++ b/install/deb/templates/mail/nginx/default_rainloop.stpl
@@ -11,6 +11,11 @@ ssl_certificate_key %ssl_key%;
 ssl_stapling on;
 ssl_stapling_verify on;
 
+location ^~ /data {
+    deny all;
+    return 404;
+}
+
 location ~ ^/(README.md|config|temp|logs|bin|SQL|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ {
     deny all;
     return 404;

--- a/install/deb/templates/mail/nginx/default_rainloop.tpl
+++ b/install/deb/templates/mail/nginx/default_rainloop.tpl
@@ -13,7 +13,12 @@ location ~ /\.(?!well-known\/) {
     return 404;
 }
 
-location ~ /data/ {
+location ^~ /data {
+    deny all;
+    return 404;
+}
+
+location ~ ^/(README.md|config|temp|logs|bin|SQL|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ {
     deny all;
     return 404;
 }

--- a/install/deb/templates/mail/nginx/rainloop.stpl
+++ b/install/deb/templates/mail/nginx/rainloop.stpl
@@ -16,6 +16,11 @@ location ~ /\.(?!well-known\/) {
     return 404;
 }
 
+location ^~ /data {
+    deny all;
+    return 404;
+}
+
 location ~ ^/(README.md|config|temp|logs|bin|SQL|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ {
     deny all;
     return 404;

--- a/install/deb/templates/mail/nginx/rainloop.tpl
+++ b/install/deb/templates/mail/nginx/rainloop.tpl
@@ -13,6 +13,11 @@ location ~ /\.(?!well-known\/) {
     return 404;
 }
 
+location ^~ /data {
+    deny all;
+    return 404;
+}
+
 location ~ ^/(README.md|config|temp|logs|bin|SQL|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ {
     deny all;
     return 404;


### PR DESCRIPTION
According their notice:
https://www.rainloop.net/docs/installation/#notice