### PR TITLE
fix/000_allow-dots-in-ftp-username

### DIFF
--- a/web/js/pages/add_web.js
+++ b/web/js/pages/add_web.js
@@ -43,7 +43,7 @@ App.Actions.WEB.update_ftp_username_hint = function(elm, hint) {
         $(elm).parent().find('.hint').html('');
     }
     
-    hint = hint.replace(/[^\w\d]/gi, '');
+    hint = hint.replace(/[^\w\d\.]/gi, '');
 
     $(elm).parent().find('.v-ftp-user').val(hint);
     $(elm).parent().find('.hint').text(GLOBAL.FTP_USER_PREFIX + hint);

--- a/web/templates/pages/edit_web.html
+++ b/web/templates/pages/edit_web.html
@@ -561,7 +561,6 @@
 														<td class="step-left">
 															<input type="text" size="20" class="vst-input v-ftp-user" <?=$ftp_user['is_new'] != 1 ? 'disabled="disabled"' : '' ?>
 																name="v_ftp_user[<?=$i ?>][v_ftp_user]" value="<?=htmlentities(trim($v_ftp_user, "'"))?>">
-															<small class="hint"></small>
 														</td>
 													</tr>
 													<tr>


### PR DESCRIPTION
Just a small fix for deleting/updating FTP users when using account names with a dot in it. E.g. an account called 'cooluser.com' would get a FTP username as 'cooluser.com_ftp'. Creating works, but deleting and updating the FTP user wasn't possible.