### PR TITLE
#1844 "public_html" field in "Custom document root" not load his state

### DIFF
--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -98,6 +98,13 @@ if(!empty($v_custom_doc_root) &&
     if(!empty($matches[2]))
         $v_custom_doc_folder = rtrim($matches[2], '/');
 
+    #1844 "public_html" field in "Custom document root" not load his state
+    $public_html_custom_doc = strpos($v_custom_doc_domain,'/public_html');
+    if($public_html_custom_doc > 0){
+        $v_custom_doc_domain = substr($v_custom_doc_domain,0,$public_html_custom_doc);
+        $v_custom_doc_folder = 'public_html';
+    }
+    
     if($v_custom_doc_domain && !in_array($v_custom_doc_domain, $user_domains)) {
         $v_custom_doc_domain = '';
         $v_custom_doc_folder = '';

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -91,6 +91,7 @@ if(!empty($data[$v_domain]['CUSTOM_DOCROOT']))
 
 if(!empty($v_custom_doc_root) &&
     false !== preg_match('/\/home\/'.$v_username.'\/web\/([[:alnum:]].*?)\/public_html\/([[:alnum:]].*)?/', $v_custom_doc_root, $matches) ) {
+	// Regex for extracting target web domain and custom document root. Regex test: https://regex101.com/r/2CLvIF/1
 
     if(!empty($matches[1]))
         $v_custom_doc_domain = $matches[1];

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -90,20 +90,13 @@ if(!empty($data[$v_domain]['CUSTOM_DOCROOT']))
     $v_custom_doc_root = realpath($data[$v_domain]['CUSTOM_DOCROOT']) . DIRECTORY_SEPARATOR;
 
 if(!empty($v_custom_doc_root) &&
-    false !== preg_match('/\/home\/'.$v_username.'\/web\/([[:alnum:]].*)\/public_html\/([[:alnum:]].*)?/', $v_custom_doc_root, $matches) ) {
+    false !== preg_match('/\/home\/'.$v_username.'\/web\/([[:alnum:]].*?)\/public_html\/([[:alnum:]].*)?/', $v_custom_doc_root, $matches) ) {
 
     if(!empty($matches[1]))
         $v_custom_doc_domain = $matches[1];
 
     if(!empty($matches[2]))
         $v_custom_doc_folder = rtrim($matches[2], '/');
-
-    #1844 "public_html" field in "Custom document root" not load his state
-    $public_html_custom_doc = strpos($v_custom_doc_domain,'/public_html');
-    if($public_html_custom_doc > 0){
-        $v_custom_doc_domain = substr($v_custom_doc_domain,0,$public_html_custom_doc);
-        $v_custom_doc_folder = 'public_html';
-    }
     
     if($v_custom_doc_domain && !in_array($v_custom_doc_domain, $user_domains)) {
         $v_custom_doc_domain = '';


### PR DESCRIPTION
regex in line 93 
/\/home\/'.$v_username.'\/web\/([[:alnum:]].*)\/public_html\/([[:alnum:]].*)?/

Doesn't work properly when custom docroot is 
/home/user/web/hestiacp.com/public_html/public_html

return is  hestiacp.com/public_html  as domain instead of 
hestiacp.com as domain and  and public_html as folder