### PR TITLE
[Bug Fix] Optimize loading firewall rules

### DIFF
--- a/bin/v-stop-firewall
+++ b/bin/v-stop-firewall
@@ -82,7 +82,7 @@ else
             IFS='%'
             echo '#!/bin/sh' > $preup
             echo '' >> $preup
-            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            echo 'if [ "$IFACE" = "'$(ip route list | awk '/default .+/ {print $5}' | uniq)'" ]; then' >> $preup
             [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
             echo '    sleep 3' >> $preup
             echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
@@ -96,7 +96,7 @@ else
             IFS='%'
             echo '#!/bin/sh' > $preup
             echo '' >> $preup
-            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            echo 'if [ "$IFACE" = "'$(ip route list | awk '/default .+/ {print $5}' | uniq)'" ]; then' >> $preup
             [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
             echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
             echo 'fi' >> $preup

--- a/bin/v-stop-firewall
+++ b/bin/v-stop-firewall
@@ -76,20 +76,14 @@ if [ -d "/etc/sysconfig" ]; then
     fi
 else
     /sbin/iptables-save > /etc/iptables.rules
-    if dpkg-query -W -f'${Status}' "netplan*" 2>/dev/null | grep -q "ok installed"; then
-        preup="/usr/lib/networkd-dispatcher/routable.d/50-ifup-hooks"
+    if dpkg-query -W -f'${Status}' "netplan*" 2>/dev/null | grep -q "ok installed" && [ -d /etc/netplan ] && [ -n "$(ls -A /etc/netplan 2>/dev/null)" ]; then
+        preup="/usr/lib/networkd-dispatcher/routable.d/10-hestia-iptables"
         if [ ! -e "$preup" ]; then
-            for iface in $(ip token | awk -F 'dev ' '{print $2}'); do 
-                if [ -z "$interfaces" ]; then
-                    interfaces=" \"\$IFACE\"==\"$iface\""
-                else
-                    interfaces="$interfaces || \"\$IFACE\"==\"$iface\" ";
-                fi
-            done
             IFS='%'
-            echo '#!/bin/bash' > $preup
+            echo '#!/bin/sh' > $preup
             echo '' >> $preup
-            echo 'if [['$interfaces']]; then' >> $preup
+            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
             echo '    sleep 3' >> $preup
             echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
             echo 'fi' >> $preup
@@ -97,10 +91,15 @@ else
             chmod +x $preup
         fi
     else
-        preup="/etc/network/if-pre-up.d/iptables"
+        preup="/etc/network/if-pre-up.d/hestia-iptables"
         if [ ! -e "$preup" ]; then
+            IFS='%'
             echo '#!/bin/sh' > $preup
-            echo "/sbin/iptables-restore < /etc/iptables.rules" >> $preup
+            echo '' >> $preup
+            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
+            echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
+            echo 'fi' >> $preup
             echo "exit 0" >> $preup
             chmod +x $preup
         fi

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -189,7 +189,7 @@ else
             IFS='%'
             echo '#!/bin/sh' > $preup
             echo '' >> $preup
-            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            echo 'if [ "$IFACE" = "'$(ip route list | awk '/default .+/ {print $5}' | uniq)'" ]; then' >> $preup
             [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
             echo '    sleep 3' >> $preup
             echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
@@ -203,7 +203,7 @@ else
             IFS='%'
             echo '#!/bin/sh' > $preup
             echo '' >> $preup
-            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            echo 'if [ "$IFACE" = "'$(ip route list | awk '/default .+/ {print $5}' | uniq)'" ]; then' >> $preup
             [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
             echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
             echo 'fi' >> $preup

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -183,15 +183,14 @@ if [ -d "/etc/sysconfig" ]; then
     fi
 else
     /sbin/iptables-save > /etc/iptables.rules
-    if dpkg-query -W -f'${Status}' "netplan*" 2>/dev/null | grep -q "ok installed"; then
-        preup="/usr/lib/networkd-dispatcher/routable.d/50-ifup-hooks"
+    if dpkg-query -W -f'${Status}' "netplan*" 2>/dev/null | grep -q "ok installed" && [ -d /etc/netplan ] && [ -n "$(ls -A /etc/netplan 2>/dev/null)" ]; then
+        preup="/usr/lib/networkd-dispatcher/routable.d/10-hestia-iptables"
         if [ ! -e "$preup" ]; then
             IFS='%'
-            echo '#!/bin/bash' > $preup
+            echo '#!/bin/sh' > $preup
             echo '' >> $preup
-            echo "${HESTIA}/bin/v-update-firewall-ipset" >> $preup
-            echo '' >> $preup
-            echo 'if [ "$IFACE" == "'$(/bin/ip token | awk -F 'dev ' '{print $2}')'" ]; then' >> $preup
+            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
             echo '    sleep 3' >> $preup
             echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
             echo 'fi' >> $preup
@@ -199,11 +198,15 @@ else
             chmod +x $preup
         fi
     else
-        preup="/etc/network/if-pre-up.d/iptables"
+        preup="/etc/network/if-pre-up.d/hestia-iptables"
         if [ ! -e "$preup" ]; then
+            IFS='%'
             echo '#!/bin/sh' > $preup
-            echo "${HESTIA}/bin/v-update-firewall-ipset" >> $preup
-            echo "/sbin/iptables-restore < /etc/iptables.rules" >> $preup
+            echo '' >> $preup
+            echo 'if [ "$IFACE" = "'$(route | awk '/default .+/ {print $8}' | uniq)'" ]; then' >> $preup
+            [ -x "$(which ipset)" ] && echo "    ${HESTIA}/bin/v-update-firewall-ipset" >> $preup
+            echo '    /sbin/iptables-restore < /etc/iptables.rules' >> $preup
+            echo 'fi' >> $preup
             echo "exit 0" >> $preup
             chmod +x $preup
         fi

--- a/install/upgrade/versions/1.4.2.sh
+++ b/install/upgrade/versions/1.4.2.sh
@@ -9,6 +9,8 @@
 # Optimize loading firewall rules
 if [ "$FIREWALL_SYSTEM" = "iptables" ]; then
     echo "[ * ] Fix the issue of loading firewall rules..."
+    # Add rule to ensure the rule will be added when we update the firewall / /etc/iptables.rules
+    iptables -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
     rm -f /usr/lib/networkd-dispatcher/routable.d/50-ifup-hooks /etc/network/if-pre-up.d/iptables
     $BIN/v-update-firewall
 fi

--- a/install/upgrade/versions/1.4.2.sh
+++ b/install/upgrade/versions/1.4.2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.4.2
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+
+# Optimize loading firewall rules
+if [ "$FIREWALL_SYSTEM" = "iptables" ]; then
+    echo "[ * ] Fix the issue of loading firewall rules..."
+    rm -f /usr/lib/networkd-dispatcher/routable.d/50-ifup-hooks /etc/network/if-pre-up.d/iptables
+    $BIN/v-update-firewall
+fi


### PR DESCRIPTION
Improve loading script:

1. More checks for netplan
Some Xen VMs managed by OnApp, the default Ubuntu template has installed the netplan.io package, but the network is not configured by it, so the script will not be executed in "/usr/lib/networkd-dispatcher/routable.d/".

2. Change script name
Indicates the script was created by Hestia.
Also, "50-ifup-hooks" is just as example, specification: "priority-name".
However, many people use "50-ifup-hooks" directly, so change the name also avoid accidental modify the script.

3. Add check for IPSet

Bug Fix:

New solution for https://github.com/hestiacp/hestiacp/issues/1689, because https://github.com/hestiacp/hestiacp/pull/1724 will cause the script  repeatedly executed in short time, iptables will return many "xtables lock" errors.

Now only get the default interface, make sure the script is executed only once.

The point is https://github.com/hestiacp/hestiacp/pull/1724 ignores "v-update-firewall", so multi-NIC devices will still generate incorrect script after upgrading to Hestia 1.4.0+.

Once reboot these devices, firewall rules can't be restored, It is recommended to release a service update as soon as possible to resolve this issue.