### PR TITLE
fix: set PHP sys_temp_dir to the user tmp directory

### DIFF
--- a/install/deb/templates/web/apache2/default.stpl
+++ b/install/deb/templates/web/apache2/default.stpl
@@ -23,6 +23,7 @@
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/deb/templates/web/apache2/default.tpl
+++ b/install/deb/templates/web/apache2/default.tpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/deb/templates/web/apache2/hosting.stpl
+++ b/install/deb/templates/web/apache2/hosting.stpl
@@ -30,6 +30,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/deb/templates/web/apache2/hosting.tpl
+++ b/install/deb/templates/web/apache2/hosting.tpl
@@ -32,6 +32,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/deb/templates/web/apache2/phpcgi.stpl
+++ b/install/deb/templates/web/apache2/phpcgi.stpl
@@ -23,6 +23,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/deb/templates/web/apache2/phpcgi.tpl
+++ b/install/deb/templates/web/apache2/phpcgi.tpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/deb/templates/web/apache2/phpfcgid.stpl
+++ b/install/deb/templates/web/apache2/phpfcgid.stpl
@@ -23,6 +23,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/deb/templates/web/apache2/phpfcgid.tpl
+++ b/install/deb/templates/web/apache2/phpfcgid.tpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/rhel/templates/web/httpd/default.stpl
+++ b/install/rhel/templates/web/httpd/default.stpl
@@ -31,6 +31,7 @@
             php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
         </IfDefine>
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/templates/web/httpd/default.tpl
+++ b/install/rhel/templates/web/httpd/default.tpl
@@ -33,6 +33,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
         </IfDefine>
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/templates/web/httpd/hosting.stpl
+++ b/install/rhel/templates/web/httpd/hosting.stpl
@@ -38,6 +38,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
         </IfDefine>
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/templates/web/httpd/hosting.tpl
+++ b/install/rhel/templates/web/httpd/hosting.tpl
@@ -39,6 +39,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
         </IfDefine>
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/templates/web/httpd/phpcgi.stpl
@@ -26,6 +26,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
             Action phpcgi-script /cgi-bin/php
             <Files *.php>
                 SetHandler phpcgi-script

--- a/install/rhel/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/templates/web/httpd/phpcgi.tpl
@@ -27,6 +27,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
             Action phpcgi-script /cgi-bin/php
             <Files *.php>
                 SetHandler phpcgi-script

--- a/install/rhel/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/templates/web/httpd/phpfcgid.stpl
@@ -26,6 +26,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
             <Files *.php>
             SetHandler fcgid-script
             </Files>

--- a/install/rhel/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/templates/web/httpd/phpfcgid.tpl
@@ -27,6 +27,7 @@
             php_admin_value open_basedir %docroot%:%home%/%user%/tmp
             php_admin_value upload_tmp_dir %home%/%user%/tmp
             php_admin_value session.save_path %home%/%user%/tmp
+            php_admin_value sys_temp_dir %home%/%user%/tmp
             <Files *.php>
             SetHandler fcgid-script
             </Files>


### PR DESCRIPTION
php function `sys_get_temp_dir()` is returning _/tmp_ which is not writeable, this PR makes php return the proper tmp directory for the user by applying the fix found [here](https://forum.vestacp.com/viewtopic.php?f=11&t=18902) 