### PR TITLE
Fixes issue in `v-change-user-php-cli` example

### DIFF
--- a/bin/v-change-user-php-cli
+++ b/bin/v-change-user-php-cli
@@ -3,7 +3,7 @@
 # options: USER VERSION
 # labels: hestia
 #
-# example: v-change-user-php-cli user php7.4
+# example: v-change-user-php-cli user 7.4
 #
 # add line to .bash_aliases to set default php command line
 # version when multi-php is enabled.


### PR DESCRIPTION
This script requires the PHP version as the second argument e.g. `7.4`, not `php7.4`.

PR for example in the docs: [#17](https://github.com/hestiacp/hestiacp-docs/pull/17)