### PR TITLE
Fix possible error occur for v-rebuild-cron-jobs

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -610,7 +610,7 @@ sync_cron_jobs() {
     else
         crontab="/var/spool/cron/$user"
     fi
-    rm -f $crontab
+    >$crontab
     if [ "$CRON_REPORTS" = 'yes' ]; then
         echo "MAILTO=$CONTACT" > $crontab
         echo 'CONTENT_TYPE="text/plain; charset=utf-8"' >> $crontab


### PR DESCRIPTION
Since crontab was removed on line 613, if no cronjob being added during the process, it will trigger error on line 626, 627 for No such file or directory