### PR TITLE
Make /etc/phpmyadmin/ not accessable for users 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Add nginx user_agent separation to desktop/mobile (e.g. for fastcgi cache)
+- Run phpmyadmin folder under www-data user instead of "user" improving security. (Reported via Discord)
+- Added new template for mod php users to access phpmymyadmin
 
 ### Bugfixes
 

--- a/bin/v-add-sys-pma-sso
+++ b/bin/v-add-sys-pma-sso
@@ -84,9 +84,10 @@ sed -i "s/%API_HESTIA_PORT%/$BACKEND_PORT/g" $PMA_INSTALL/hestia-sso.php
 
 
 # Check if config already contains the keys 
-
 touch $PMA_CONFIG/hestia-sso.inc.php
-chmod 644 $PMA_CONFIG/hestia-sso.inc.php
+chmod 640 $PMA_CONFIG/hestia-sso.inc.php
+chown root:www-data $PMA_CONFIG/hestia-sso.inc.php
+
 echo "<?php
 if(isset(\$_GET['hestia_token']) || isset(\$_COOKIE['SignonSession'])){
 \$cfg['Servers'][\$i]['auth_type'] = 'signon';

--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -483,7 +483,8 @@ upgrade_phpmyadmin() {
                 echo "[ ! ] Verifying phpMyAdmin v${pma_release_file##*-} installation..."
                 # Update permissions
                 if [ -e /var/lib/phpmyadmin/blowfish_secret.inc.php ]; then
-                    chmod 0644 /var/lib/phpmyadmin/blowfish_secret.inc.php
+                    chown root:www-data /var/lib/phpmyadmin/blowfish_secret.inc.php
+                    chmod 0640 /var/lib/phpmyadmin/blowfish_secret.inc.php
                 fi
             else
                 # Display upgrade information
@@ -497,7 +498,7 @@ upgrade_phpmyadmin() {
                 tar xzf phpMyAdmin-$pma_v-all-languages.tar.gz
 
                 # Delete file to prevent error
-                rm -fr /usr/share/phpmyadmin/doc/html
+                rm -rf /usr/share/phpmyadmin/doc/html
 
                 # Overwrite old files
                 cp -rf phpMyAdmin-$pma_v-all-languages/* /usr/share/phpmyadmin
@@ -509,11 +510,14 @@ upgrade_phpmyadmin() {
                 # Create temporary folder and change permissions
                 if [ ! -d /usr/share/phpmyadmin/tmp ]; then
                     mkdir /usr/share/phpmyadmin/tmp
-                    chmod 777 /usr/share/phpmyadmin/tmp
+                    chown root:www-data /usr/share/phpmyadmin/tmp
+                    chmod 770 /usr/share/phpmyadmin/tmp
+                    
                 fi
 
                 if [ -e /var/lib/phpmyadmin/blowfish_secret.inc.php ]; then
-                    chmod 0644 /var/lib/phpmyadmin/blowfish_secret.inc.php
+                    chown root:www-data /var/lib/phpmyadmin/blowfish_secret.inc.php
+                    chmod 0640 /var/lib/phpmyadmin/blowfish_secret.inc.php
                 fi
 
                 # Clean up source files

--- a/install/deb/php-fpm/multiphp.tpl
+++ b/install/deb/php-fpm/multiphp.tpl
@@ -17,7 +17,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
-php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
+php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 env[PATH] = /usr/local/bin:/usr/bin:/bin

--- a/install/deb/pma/apache.conf
+++ b/install/deb/pma/apache.conf
@@ -17,7 +17,12 @@ Alias /%pma_alias% /usr/share/phpmyadmin
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
-
+    <IfModule mpm_event_module>
+        # Use www.conf instead
+        <FilesMatch \.php$>
+            SetHandler "proxy:fcgi://127.0.0.1:9000"
+        </FilesMatch>
+    </IfModule>
 </Directory>
 
 # Authorize for setup

--- a/install/deb/templates/web/apache2/www-data.stpl
+++ b/install/deb/templates/web/apache2/www-data.stpl
@@ -1,0 +1,41 @@
+#=======================================================================#
+# Default Web Domain Template                                           #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS #
+#=======================================================================#
+
+# PHPMyAdmin and phppgadmin require access as www-data instead of user for security reasons
+<VirtualHost %ip%:%web_ssl_port%>
+
+    ServerName %domain_idn%
+    %alias_string%
+    ServerAdmin %email%
+    DocumentRoot %sdocroot%
+    ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
+    Alias /vstats/ %home%/%user%/web/%domain%/stats/
+    Alias /error/ %home%/%user%/web/%domain%/document_errors/
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
+    <Directory %sdocroot%>
+        AllowOverride All
+        SSLRequireSSL
+        Options +Includes -Indexes +ExecCGI
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
+    </Directory>
+    <Directory %home%/%user%/web/%domain%/stats>
+        AllowOverride All
+    </Directory>
+    SSLEngine on
+    SSLVerifyClient none
+    SSLCertificateFile %ssl_crt%
+    SSLCertificateKeyFile %ssl_key%
+    %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
+
+    IncludeOptional %home%/%user%/conf/web/%domain%/%web_system%.ssl.conf_*
+
+</VirtualHost>
+

--- a/install/deb/templates/web/apache2/www-data.tpl
+++ b/install/deb/templates/web/apache2/www-data.tpl
@@ -1,0 +1,38 @@
+#=======================================================================#
+# Default Web Domain Template                                           #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS #
+#=======================================================================#
+
+# PHPMyAdmin and phppgadmin require access as www-data instead of user for security reasons
+<VirtualHost %ip%:%web_port%>
+
+    ServerName %domain_idn%
+    %alias_string%
+    ServerAdmin %email%
+    DocumentRoot %docroot%
+    ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
+    Alias /vstats/ %home%/%user%/web/%domain%/stats/
+    Alias /error/ %home%/%user%/web/%domain%/document_errors/
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
+        
+    IncludeOptional %home%/%user%/conf/web/%domain%/forcessl.apache2.conf*
+    
+    <Directory %docroot%>
+        AllowOverride All
+        Options +Includes -Indexes +ExecCGI
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
+    </Directory>
+    <Directory %home%/%user%/web/%domain%/stats>
+        AllowOverride All
+    </Directory>
+
+    IncludeOptional %home%/%user%/conf/web/%domain%/%web_system%.conf_*
+
+</VirtualHost>
+

--- a/install/deb/templates/web/php-fpm/default.tpl
+++ b/install/deb/templates/web/php-fpm/default.tpl
@@ -17,7 +17,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
-php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/etc/rainloop:/var/lib/rainloop:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
+php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 env[HOSTNAME] = $HOSTNAME

--- a/install/deb/templates/web/php-fpm/no-php.tpl
+++ b/install/deb/templates/web/php-fpm/no-php.tpl
@@ -17,7 +17,7 @@
 
 ;php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 ;php_admin_value[session.save_path] = /home/%user%/tmp
-;php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
+;php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 ;env[HOSTNAME] = $HOSTNAME

--- a/install/deb/templates/web/php-fpm/socket.tpl
+++ b/install/deb/templates/web/php-fpm/socket.tpl
@@ -17,7 +17,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
-php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
+php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt
 php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f admin@%domain%
 
 env[HOSTNAME] = $HOSTNAME

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1474,7 +1474,8 @@ if [ "$mysql" = 'yes' ]; then
     # Create copy of config file
     cp -f $HESTIA_INSTALL_DIR/phpmyadmin/config.inc.php /etc/phpmyadmin/
     mkdir -p /var/lib/phpmyadmin/tmp
-    chmod 777 /var/lib/phpmyadmin/tmp
+    chmod 770 /var/lib/phpmyadmin/tmp
+    chown root:www-data /usr/share/phpmyadmin/tmp
 
     # Set config and log directory
     sed -i "s|define('CONFIG_DIR', ROOT_PATH);|define('CONFIG_DIR', '/etc/phpmyadmin/');|" /usr/share/phpmyadmin/libraries/vendor_config.php

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1481,8 +1481,9 @@ if [ "$mysql" = 'yes' ]; then
     sed -i "s|define('TEMP_DIR', ROOT_PATH . 'tmp/');|define('TEMP_DIR', '/var/lib/phpmyadmin/tmp/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
 
     # Create temporary folder and change permission
-    chmod 777 /usr/share/phpmyadmin/tmp
-
+    chmod 770 /usr/share/phpmyadmin/tmp
+    chown root:www-data /usr/share/phpmyadmin/tmp
+    
     # Generate blow fish
     blowfish=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)
     sed -i "s|%blowfish_secret%|$blowfish|" /etc/phpmyadmin/config.inc.php
@@ -1497,6 +1498,11 @@ if [ "$mysql" = 'yes' ]; then
     # Special thanks to Pavel Galkin (https://skurudo.ru)
     # https://github.com/skurudo/phpmyadmin-fixer
     source $HESTIA_INSTALL_DIR/phpmyadmin/pma.sh > /dev/null 2>&1
+    
+    # limit access to /etc/phpmyadmin/ 
+    chown -R root:www-data /etc/phpmyadmin/
+    chmod -R 640  /etc/phpmyadmin/*
+    chmod 750 /etc/phpmyadmin/conf.d/
 fi
 
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1508,15 +1508,16 @@ if [ "$mysql" = 'yes' ]; then
     # Create copy of config file
     cp -f $HESTIA_INSTALL_DIR/phpmyadmin/config.inc.php /etc/phpmyadmin/
     mkdir -p /var/lib/phpmyadmin/tmp
-    chmod 777 /var/lib/phpmyadmin/tmp
-
+    chmod 770 /var/lib/phpmyadmin/tmp
+    chown root:www-data /usr/share/phpmyadmin/tmp
+    
     # Set config and log directory
     sed -i "s|define('CONFIG_DIR', ROOT_PATH);|define('CONFIG_DIR', '/etc/phpmyadmin/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
     sed -i "s|define('TEMP_DIR', ROOT_PATH . 'tmp/');|define('TEMP_DIR', '/var/lib/phpmyadmin/tmp/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
 
     # Create temporary folder and change permission
-    chmod 777 /usr/share/phpmyadmin/tmp
-
+    chmod 770 /usr/share/phpmyadmin/tmp
+    chown root:www-data /usr/share/phpmyadmin/tmp
     # Generate blow fish
     blowfish=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)
     sed -i "s|%blowfish_secret%|$blowfish|" /etc/phpmyadmin/config.inc.php
@@ -1531,6 +1532,11 @@ if [ "$mysql" = 'yes' ]; then
     # Special thanks to Pavel Galkin (https://skurudo.ru)
     # https://github.com/skurudo/phpmyadmin-fixer
     source $HESTIA_INSTALL_DIR/phpmyadmin/pma.sh > /dev/null 2>&1
+    
+    # limit access to /etc/phpmyadmin/ 
+    chown -R root:www-data /etc/phpmyadmin/
+    chmod -R 640  /etc/phpmyadmin/*
+    chmod 750 /etc/phpmyadmin/conf.d/
 fi
 
 

--- a/install/upgrade/versions/1.4.4.sh
+++ b/install/upgrade/versions/1.4.4.sh
@@ -18,3 +18,20 @@ if [ "$PHPMYADMIN_KEY" != "" ]; then
     $BIN/v-delete-sys-pma-sso 
     $BIN/v-add-sys-pma-sso 
 fi
+
+if [ -d "/etc/phpmyadmin/" ]; then 
+    # limit access to /etc/phpmyadmin/ and /usr/share/phpmyadmin/tmp and so on
+    chown -R root:www-data /etc/phpmyadmin/
+    chmod -R 640  /etc/phpmyadmin/*
+    if [ -d "/etc/phpmyadmin/conf.d/" ]; then 
+        chmod 750 /etc/phpmyadmin/conf.d/
+    fi
+    if [ -d "/var/lib/phpmyadmin/tmp" ]; then 
+        chown root:www-data /usr/share/phpmyadmin/tmp
+        chmod 770 /usr/share/phpmyadmin/tmp
+    fi
+    if [ -d "/var/lib/phpmyadmin/tmp" ]; then 
+        chmod 770 /var/lib/phpmyadmin/tmp
+        chown root:www-data /usr/share/phpmyadmin/tmp
+    fi
+fi

--- a/install/upgrade/versions/1.4.4.sh
+++ b/install/upgrade/versions/1.4.4.sh
@@ -12,14 +12,8 @@ if [ -d "/etc/nginx/conf.d/" ]; then
     cp -f $HESTIA_INSTALL_DIR/nginx/agents.conf /etc/nginx/conf.d/
 fi
 
-# Reset PMA SSO to fix bug with Nginx + Apache2 
-if [ "$PHPMYADMIN_KEY" != "" ]; then
-    echo "[ * ] Refressh hestia-sso for PMA..."
-    $BIN/v-delete-sys-pma-sso 
-    $BIN/v-add-sys-pma-sso 
-fi
-
 if [ -d "/etc/phpmyadmin/" ]; then 
+    echo "[ * ] Secure PHPmyAdmin"
     # limit access to /etc/phpmyadmin/ and /usr/share/phpmyadmin/tmp and so on
     chown -R root:www-data /etc/phpmyadmin/
     chmod -R 640  /etc/phpmyadmin/*
@@ -34,4 +28,11 @@ if [ -d "/etc/phpmyadmin/" ]; then
         chmod 770 /var/lib/phpmyadmin/tmp
         chown root:www-data /usr/share/phpmyadmin/tmp
     fi
+fi
+
+# Reset PMA SSO to fix bug with Nginx + Apache2 
+if [ "$PHPMYADMIN_KEY" != "" ]; then
+    echo "[ * ] Refressh hestia-sso for PMA..."
+    $BIN/v-delete-sys-pma-sso 
+    $BIN/v-add-sys-pma-sso 
 fi


### PR DESCRIPTION
- Run /phpmyadmin/ under www-data for Apache2 + PHP-FPM Users
- Limit access to /etc/phpmyadmin
- Added new template for modphp5 users
