### PR TITLE
Check firewall enabled before restart iptables

### DIFF
--- a/bin/v-change-sys-port
+++ b/bin/v-change-sys-port
@@ -77,7 +77,9 @@ else
     sed -i "/COMMENT='HESTIA'/c\RULE='2' ACTION='ACCEPT' PROTOCOL='TCP' PORT='$PORT' IP='0.0.0.0/0' COMMENT='HESTIA' SUSPENDED='no' TIME='07:40:16' DATE='2014-05-25'" $HESTIA/data/firewall/rules.conf
     
     # Restart services
-    $HESTIA/bin/v-restart-service iptables
+    if [ -n "$FIREWALL_SYSTEM" ] && [ "$FIREWALL_SYSTEM" != no ]; then
+        $HESTIA/bin/v-restart-service iptables
+    fi
 
     # Check if Hestia is running
     if [[ $(ps -eaf | grep -i hestia |sed '/^$/d' | wc -l) > 1 ]]; then


### PR DESCRIPTION
This error was found during apt package upgrade

Reading package lists... Done
Building dependency tree
Reading state information... Done
Calculating upgrade... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] y
Setting up hestia-nginx (1.19.10) ...
Error: FIREWALL_SYSTEM is not enabled
Error: ERROR: Restart of iptables failed.