### PR TITLE
[Fix] Explicitly disable cron reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - Revert #1943 and rework it to fix possible errors occuring on v-rebuild-cron-jobs.
 - Fixed #1956 to prevent reset of defined webmail client.
+- Explicitly disable cron reports #1978
 
 ## [1.4.4] - Service release
 

--- a/func/main.sh
+++ b/func/main.sh
@@ -622,6 +622,8 @@ sync_cron_jobs() {
     if [ "$CRON_REPORTS" = 'yes' ]; then
         echo "MAILTO=$CONTACT" > $crontab
         echo 'CONTENT_TYPE="text/plain; charset=utf-8"' >> $crontab
+    else
+        echo 'MAILTO=""' > $crontab
     fi
     
     while read line; do


### PR DESCRIPTION
Currently missing MAILTO variable defaults user@hostname and floods the email server in case of errors, reaching exim rate limits in some cases (4 cron rules with output executed every minute)

ref: https://manpages.ubuntu.com/manpages/bionic/man5/crontab.5.html