### PR TITLE
Debian 10 Fix

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -64,7 +64,7 @@ shell_conf=$(echo "$pkg_data" | grep 'SHELL' | cut -f 2 -d \')
 shell=$(grep -w "$shell_conf" /etc/shells |head -n1)
 
 # Adding user
-/usr/sbin/useradd "$user" -s "$shell" -c "$email" -m -d "$HOMEDIR/$user"
+/usr/sbin/useradd "$user" -s "$shell" -c "$email" -m -d "$HOMEDIR/$user" -U
 check_result $? "user creation failed" $E_INVALID
 
 # Adding password


### PR DESCRIPTION
Always install VestaCP on Ubuntu but by customer request it had to be Debian 10 ...
In order to install it correctly I had to make that change for fix setfacl errors

```
[ * ] Enable SFTP jail...
setfacl: Option -m: Invalid argument near character 3
chown: invalid group: ‘admin:admin’
chown: invalid group: ‘admin:admin’
```