### PR TITLE
Fix invalid regex for WebApp name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Resolve issue with double ENFORCE_SUBDOMAIN_OWNERSHIP keys in hestia.conf
 - Resolve issue with create new user during install in some cases #2000
+- Fix an issue with Quick Install apps named Test123 
 
 ## [1.4.7] - Service release 
 

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -91,7 +91,7 @@ if(!empty($installer)) {
     $v_web_apps = array();
     foreach($appInstallers as $app){
         $hestia = new \Hestia\System\HestiaApp();
-        if( preg_match('/Installers\/([a-zA-Z0-9].*)\/([a-zA-Z0-9].*).php/', $app, $matches)){
+        if( preg_match('/Installers\/([a-zA-Z][a-zA-Z0,9].*)\/([a-zA-Z][a-zA-Z0,9].*).php/', $app, $matches)){
             if ($matches[1] != "Resources"){
                 $app_installer_class = '\Hestia\WebApp\Installers\\'.$matches[1].'\\' . $matches[1] . 'Setup';
                 $app_installer = new $app_installer_class($v_domain, $hestia);

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -91,7 +91,7 @@ if(!empty($installer)) {
     $v_web_apps = array();
     foreach($appInstallers as $app){
         $hestia = new \Hestia\System\HestiaApp();
-        if( preg_match('/Installers\/([a-zA-Z0-0].*)\/([a-zA-Z0-0].*).php/', $app, $matches)){
+        if( preg_match('/Installers\/([a-zA-Z0-9].*)\/([a-zA-Z0-9].*).php/', $app, $matches)){
             if ($matches[1] != "Resources"){
                 $app_installer_class = '\Hestia\WebApp\Installers\\'.$matches[1].'\\' . $matches[1] . 'Setup';
                 $app_installer = new $app_installer_class($v_domain, $hestia);


### PR DESCRIPTION
This fixes an issue where WebApp Installers with numbers in the name wouldn't show up in the overview.