### PR TITLE
Delete old configuration before changing to "caching" template

### DIFF
--- a/install/deb/templates/web/nginx/caching.sh
+++ b/install/deb/templates/web/nginx/caching.sh
@@ -13,10 +13,5 @@ if [ -e "$conf" ]; then
     if [ -n "$(grep "=${domain}:" $conf)" ]; then
         sed -i "/=${domain}:/d" $conf
     fi
-    if [ -z "$(grep "=${domain}:" $conf)" ]; then
-        echo "$str" >> $conf
-    fi
-else
-    echo "$str" >> $conf
 fi
-
+echo "$str" >> $conf

--- a/install/deb/templates/web/nginx/caching.sh
+++ b/install/deb/templates/web/nginx/caching.sh
@@ -10,6 +10,9 @@ str="proxy_cache_path /var/cache/nginx/$domain levels=2"
 str="$str keys_zone=$domain:10m inactive=60m max_size=512m;" 
 conf='/etc/nginx/conf.d/01_caching_pool.conf'
 if [ -e "$conf" ]; then
+    if [ -n "$(grep "=${domain}:" $conf)" ]; then
+        sed -i "/=${domain}:/d" $conf
+    fi
     if [ -z "$(grep "=${domain}:" $conf)" ]; then
         echo "$str" >> $conf
     fi


### PR DESCRIPTION
When we want to change nginx template. The current hestiacp will only check if there is already 'proxy_cache_path' setting for this domain in '/etc/nginx/conf.d/01_caching_pool.conf'. if there is, hestia will skip adding config again. Because hestia will assume the configuration still the same. Remember, Other  template can also change this config.

We need to delete previous config and reinstall our config again. Just to make sure if other template changing "proxy_cache_path" configuration. for example:
-) previous template changed " keys_zone" parameter, when we changed to 'caching' template. it will cause: "new_name" zone "example.com" is unknown
-) previous template changed "levels" parameter, when we changed to 'caching' template. it will cause: "example.com" had previously different levels