### PR TITLE
Fix release number in changelog to the actual for 1.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfixes
 
-## [1.4.9] - Service release 
+## [1.4.10] - Service release 
 
 ### Features
 


### PR DESCRIPTION
Apparently when the release notes were updated the release version number was not.