### PR TITLE
Improve the list mail dns page

### DIFF
--- a/web/templates/pages/list_mail_dns.html
+++ b/web/templates/pages/list_mail_dns.html
@@ -34,64 +34,65 @@
 
 	<div class="l-unit animated fadeIn">
 		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="mail.<?=htmlspecialchars($_GET['domain']);?>" /></b> </div>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="mail.<?=htmlspecialchars($_GET['domain']);?>" /></b></div>
 			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>A</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>0</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
 			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
 			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ?  array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>" /></b></div>
 		</div>
 	</div>
-    <div class="l-unit animated fadeIn">
-        <div class="l-unit__col l-unit__col--right">
-            <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=htmlspecialchars($_GET['domain']);?>" /></b> </div>
-            <div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>MX</b></div>
-            <div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>10</b></div>
-            <div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
-            <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="mail.<?=htmlspecialchars($_GET['domain']);?>." /></b></div>
-        </div>
-    </div>
 	<?php if($_SESSION['WEBMAIL_SYSTEM']){?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain']);?>" /></b> </div>
-				<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>A</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ?  array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>" /></b></div>
-			</div>
+	<div class="l-unit animated fadeIn">
+		<div class="l-unit__col l-unit__col--right">
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain']);?>" /></b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>A</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ?  array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>" /></b></div>
 		</div>
+	</div>
 	<?php } ?>
 	<div class="l-unit animated fadeIn">
 		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="@" /></b> </div>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=htmlspecialchars($_GET['domain']);?>" /></b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>MX</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>10</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="mail.<?=htmlspecialchars($_GET['domain']);?>." /></b></div>
+		</div>
+	</div>
+	<div class="l-unit animated fadeIn">
+		<div class="l-unit__col l-unit__col--right">
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=htmlspecialchars($_GET['domain']);?>" /></b></div>
 			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>TXT</b></div>
 			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
 			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
-            <?php $ip = (empty($ips[array_key_first($ips)]['NAT'])) ?  array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>
-			<div class="clearfix l-unit__stat-col--left  wide-3 "><b><input type="text" class="vst-input" value="<?=htmlspecialchars('v=spf1 a mx ip4:'.$ip.' -all');?>" /></b></div>
+			<?php $ip = (empty($ips[array_key_first($ips)]['NAT'])) ?  array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="<?=htmlspecialchars('v=spf1 a mx ip4:'.$ip.' -all');?>" /></b></div>
 		</div>
 	</div>
-    <div class="l-unit animated fadeIn">
-        <div class="l-unit__col l-unit__col--right">
-            <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="_dmarc" /></b> </div>
-            <div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>TXT</b></div>
-            <div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
-            <div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
-            <div class="clearfix l-unit__stat-col--left  wide-3 "><b><input type="text" class="vst-input" value="<?=htmlspecialchars('v=DMARC1; p=quarantine; pct=100');?>" /></b></div>
-        </div>
-    </div>
-	<?php foreach($dkim as $key => $value){ ?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=htmlspecialchars($key);?>" /></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>TXT</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>3600</b></div>
-				<div class="clearfix l-unit__stat-col--left  wide-3 "><b><input type="text" class="vst-input" value="<?=htmlspecialchars(str_replace(array('"',"'"),'',$dkim[$key]['TXT']));?>" /></b></div>
-			</div>
+	<div class="l-unit animated fadeIn">
+		<div class="l-unit__col l-unit__col--right">
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="_dmarc" /></b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>TXT</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>14400</b></div>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="<?=htmlspecialchars('v=DMARC1; p=quarantine; pct=100');?>" /></b></div>
 		</div>
+	</div>
+	<?php foreach($dkim as $key => $value){ ?>
+	<div class="l-unit animated fadeIn">
+		<div class="l-unit__col l-unit__col--right">
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" style="width:200px !important;" value="<?=htmlspecialchars($key);?>" /></b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>TXT</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>&nbsp;</b></div>
+			<div class="clearfix l-unit__stat-col--left text-center step-top-small"><b>3600</b></div>
+			<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="vst-input" value="<?=htmlspecialchars(str_replace(array('"',"'"),'',$dkim[$key]['TXT']));?>" /></b></div>
+		</div>
+	</div>
 	<?php } ?>
 </div>
+
 <div id="vstobjects">
 	<div class="l-separator"></div>
 	<div class="l-center">


### PR DESCRIPTION
1. Reorder according to record type.

2. Remove the "priority" of Type A record.

3. Change the name of the SPF record from "@" to the full domain, which is consistent with the MX record.
It's also to support subdomain. If add a custom subdomain as mail domain, "@" is incorrect.