### PR TITLE
Fix for one cause of Letsencrypt 400 Authorization Pending Error

### DIFF
--- a/install/deb/templates/web/nginx/caching.stpl
+++ b/install/deb/templates/web/nginx/caching.stpl
@@ -13,6 +13,7 @@ server {
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
@@ -60,6 +61,4 @@ server {
     location ~ /\.bzr/  {return 404;}
 
     proxy_hide_header Upgrade;
-
-    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 }

--- a/install/deb/templates/web/nginx/caching.tpl
+++ b/install/deb/templates/web/nginx/caching.tpl
@@ -6,9 +6,10 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-        
-    include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
 
+    include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
+    
     location / {
         proxy_pass      http://%ip%:%web_port%;
 
@@ -53,6 +54,4 @@ server {
     location ~ /\.git/  {return 404;}
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
-
-    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 }

--- a/install/deb/templates/web/nginx/default.stpl
+++ b/install/deb/templates/web/nginx/default.stpl
@@ -13,6 +13,7 @@ server {
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
@@ -40,7 +41,5 @@ server {
     location ~ /\.bzr/  {return 404;}
 
     proxy_hide_header Upgrade;
-
-    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 }
 

--- a/install/deb/templates/web/nginx/default.tpl
+++ b/install/deb/templates/web/nginx/default.tpl
@@ -8,6 +8,7 @@ server {
     server_name %domain_idn% %alias_idn%;
         
     include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
@@ -33,7 +34,5 @@ server {
     location ~ /\.git/  {return 404;}
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
-
-    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 }
 

--- a/install/deb/templates/web/nginx/hosting.stpl
+++ b/install/deb/templates/web/nginx/hosting.stpl
@@ -13,6 +13,7 @@ server {
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
@@ -42,7 +43,5 @@ server {
     disable_symlinks if_not_owner from=%docroot%;
 
     proxy_hide_header Upgrade;
-
-    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 }
 

--- a/install/deb/templates/web/nginx/hosting.tpl
+++ b/install/deb/templates/web/nginx/hosting.tpl
@@ -6,8 +6,9 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-        
+
     include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
@@ -35,7 +36,5 @@ server {
     location ~ /\.bzr/  {return 404;}
 
     disable_symlinks if_not_owner from=%docroot%;
-
-    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 }
 

--- a/install/rhel/templates/web/nginx/caching.stpl
+++ b/install/rhel/templates/web/nginx/caching.stpl
@@ -8,6 +8,7 @@ server {
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
@@ -42,6 +43,4 @@ server {
     location ~ /\.git/  {return 404;}
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
-
-    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 }

--- a/install/rhel/templates/web/nginx/caching.tpl
+++ b/install/rhel/templates/web/nginx/caching.tpl
@@ -1,8 +1,9 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-        
+
     include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
@@ -37,6 +38,4 @@ server {
     location ~ /\.git/  {return 404;}
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
-
-    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 }

--- a/install/rhel/templates/web/nginx/default.stpl
+++ b/install/rhel/templates/web/nginx/default.stpl
@@ -8,6 +8,7 @@ server {
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
@@ -33,7 +34,5 @@ server {
     location ~ /\.git/  {return 404;}
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
-
-    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 }
 

--- a/install/rhel/templates/web/nginx/default.tpl
+++ b/install/rhel/templates/web/nginx/default.tpl
@@ -3,6 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
         
     include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
@@ -28,7 +29,5 @@ server {
     location ~ /\.git/  {return 404;}
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
-
-    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 }
 

--- a/install/rhel/templates/web/nginx/hosting.stpl
+++ b/install/rhel/templates/web/nginx/hosting.stpl
@@ -8,6 +8,7 @@ server {
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
@@ -35,7 +36,5 @@ server {
     location ~ /\.bzr/  {return 404;}
 
     disable_symlinks if_not_owner from=%docroot%;
-
-    include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
 }
 

--- a/install/rhel/templates/web/nginx/hosting.tpl
+++ b/install/rhel/templates/web/nginx/hosting.tpl
@@ -1,8 +1,9 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-        
+
     include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
@@ -30,7 +31,5 @@ server {
     location ~ /\.bzr/  {return 404;}
 
     disable_symlinks if_not_owner from=%docroot%;
-
-    include %home%/%user%/conf/web/%domain%/nginx.conf_*;
 }
 


### PR DESCRIPTION
Forces nginx to serve .well-known when obtaining LE certificates even when .htaccess urlrewrite is used to rewrite .well-known somewhere it shouldn't be, like:
RewriteRule ^(.*)$ /index.php [L]
which would otherwise result in fail
