### PR TITLE
Limit search to only letsencrypt in CAA records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Improve handling upgrade of Roundcube #1917
 - Fix an issue with sorting the update scripts when version goes higher then 1.x.10 
+- Allow the use of multiple CAA records for domain. #2073
 
 ## [1.4.10] - Service release 
 

--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -78,7 +78,7 @@ fi
 # Set DNS CAA record retrieval commands
 if [ ! -z "$DNS_SYSTEM" ]; then
     dns_domain=$($BIN/v-list-dns-domains $user | grep $domain | cut -d' ' -f1)
-    caa_record=$($BIN/v-list-dns-records $user $domain | grep -i "CAA" | cut -d' ' -f1)
+    caa_record=$($BIN/v-list-dns-records $user $domain | grep -i "CAA" | grep -i "letsencrypt.org" | cut -d' ' -f1 )    
 fi
 
 if [ -z "$mail" ] || [ "$mail" = 'no' ]; then


### PR DESCRIPTION
Closes #2073

v-add-letsencrypt-domain searches for all CAA records and if multiple exists only  the first one will get deleted. See line https://github.com/hestiacp/hestiacp/blob/0bdfb3ed84703ae6f2f7bf0343ecd5925b5df846/bin/v-add-letsencrypt-domain#L188-L193

This pull request limit the search to only letsencrypt CAA and leave any others intact as they can be used for other authentication "jobs"
