### PR TITLE
Update migrate_phpmyadmin.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Improve handling upgrade of Roundcube #1917
 - Fix an issue with sorting the update scripts when version goes higher then 1.x.10 
 - Allow the use of multiple CAA records for domain. #2073
+- Add missing group (www-data) to migrate_phpmyadmin script #2077 @bet0x
 
 ## [1.4.10] - Service release 
 

--- a/install/upgrade/manual/migrate_phpmyadmin.sh
+++ b/install/upgrade/manual/migrate_phpmyadmin.sh
@@ -53,6 +53,7 @@ then
    mkdir -p /etc/phpmyadmin/conf.d/  
    mkdir /usr/share/phpmyadmin/tmp
    chmod 770 /usr/share/phpmyadmin/tmp/
+   chown root:www-data /usr/share/phpmyadmin/tmp/
    mkdir -p /etc/phpmyadmin/conf.d/  
    
    # Configuring Apache2 for PHPMYADMIN


### PR DESCRIPTION
Missing group (www-data) for phpMyAdmin and Twig templates.