### PR TITLE
Replace tabulation with \u0009 in v-list-dns-records

### DIFF
--- a/bin/v-list-dns-records
+++ b/bin/v-list-dns-records
@@ -31,7 +31,7 @@ json_list() {
         unset TTL
         parse_object_kv_list "$str"
         [ -z "$TTL" ] && TTL="$zone_ttl"
-        VALUE=$(echo "$VALUE" |sed -e 's/"/\\"/g' -e "s/%quote%/'/g")
+        VALUE=$(echo "$VALUE" |sed -e 's/"/\\"/g' -e "s/%quote%/'/g" -e 's/     /\\u0009/g')
         echo -n '    "'$ID'": {
         "RECORD": "'$RECORD'",
         "TYPE": "'$TYPE'",


### PR DESCRIPTION
Tabulators in the value field will break the list of records. This probably should be made in a more global scale, as the json_decode function in my php server (PHP Version 7.4.22, running on Debian 10.10 4.19.0-17-amd64 #1 SMP Debian 4.19.194-2 (2021-06-21) x86_64 ) is returning an empty value if a value contains a tabulator (in my case a user introduced a TXT record that had a leading tab character), so this issue could appear in lists other than list-dns-records.

Maybe it could also be implemented in the php code, changing the following line in web/list/dns/index.php with a more appropiate function.

`$data = json_decode(implode('', $output), true);` 


I have read that the json spec wants tabulations represented by \t or \u0009. https://datatracker.ietf.org/doc/html/rfc7159#section-7