### PR TITLE
Improve Nginx reload after update SSL

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -505,12 +505,12 @@ if [ -z "$mail" ]; then
     ssl_enabled="$(get_object_value 'web' 'DOMAIN' "$domain" '$SSL')"
     ssl_force="$(get_object_value 'web' 'DOMAIN' "$domain" '$SSL_FORCE')"
     [[ "$ssl_enabled" = "yes" ]] && $BIN/v-delete-web-domain-ssl $user $domain > /dev/null 2>&1
-    $BIN/v-add-web-domain-ssl $user $domain $ssl_dir $ssl_home
+    $BIN/v-add-web-domain-ssl $user $domain $ssl_dir $ssl_home updatessl
     [[ "$ssl_force" = "yes" ]] && $BIN/v-add-web-domain-ssl-force $user $domain > /dev/null 2>&1
 else
     ssl_enabled="$(get_object_value 'mail' 'DOMAIN' "$root_domain" '$SSL')"
     [[ "$ssl_enabled" = "yes" ]] && $BIN/v-delete-mail-domain-ssl $user $root_domain > /dev/null 2>&1
-    $BIN/v-add-mail-domain-ssl $user $root_domain $ssl_dir
+    $BIN/v-add-mail-domain-ssl $user $root_domain $ssl_dir updatessl
 fi
 
 if [ "$?" -ne '0' ]; then

--- a/bin/v-add-mail-domain-ssl
+++ b/bin/v-add-mail-domain-ssl
@@ -16,7 +16,7 @@
 user=$1
 domain=$2
 ssl_dir=$3
-restart="$3"
+restart="$4"
 
 # Additional argument formatting
 if [[ "$domain" =~ [[:upper:]] ]]; then

--- a/bin/v-restart-cron
+++ b/bin/v-restart-cron
@@ -36,6 +36,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$CRON_SYSTEM" ] || [ "$CRON_SYSTEM" = 'remote' ]; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -44,10 +48,6 @@ fi
 if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
     echo "$BIN/$SCRIPT now" >> $HESTIA/data/queue/restart.pipe
-    exit
-fi
-
-if [ -z "$CRON_SYSTEM" ] || [ "$CRON_SYSTEM" = 'remote' ]; then
     exit
 fi
 

--- a/bin/v-restart-dns
+++ b/bin/v-restart-dns
@@ -41,6 +41,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$DNS_SYSTEM" ] || [ "$DNS_SYSTEM" = 'remote' ] ; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -49,10 +53,6 @@ fi
 if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
     echo "$BIN/$SCRIPT now" >> $HESTIA/data/queue/restart.pipe
-    exit
-fi
-
-if [ -z "$DNS_SYSTEM" ] || [ "$DNS_SYSTEM" = 'remote' ] ; then
     exit
 fi
 

--- a/bin/v-restart-ftp
+++ b/bin/v-restart-ftp
@@ -36,6 +36,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$FTP_SYSTEM" ] || [ "$FTP_SYSTEM" = 'remote' ]; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -44,10 +48,6 @@ fi
 if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
     echo "$BIN/$SCRIPT now" >> $HESTIA/data/queue/restart.pipe
-    exit
-fi
-
-if [ -z "$FTP_SYSTEM" ] || [ "$FTP_SYSTEM" = 'remote' ]; then
     exit
 fi
 

--- a/bin/v-restart-mail
+++ b/bin/v-restart-mail
@@ -35,6 +35,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$MAIL_SYSTEM" ] || [ "$MAIL_SYSTEM" = 'remote' ]; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -43,10 +47,6 @@ fi
 if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
     echo "$BIN/$SCRIPT now" >> $HESTIA/data/queue/restart.pipe
-    exit
-fi
-
-if [ -z "$MAIL_SYSTEM" ] || [ "$MAIL_SYSTEM" = 'remote' ]; then
     exit
 fi
 

--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -36,6 +36,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$PROXY_SYSTEM" ] || [ "$PROXY_SYSTEM" = 'remote' ]; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -47,7 +51,9 @@ if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     exit
 fi
 
-if [ -z "$PROXY_SYSTEM" ] || [ "$PROXY_SYSTEM" = 'remote' ]; then
+if [ "$1" = "updatessl" ]; then
+    sed -i "/\/$SCRIPT ssl/d" $HESTIA/data/queue/restart.pipe
+    echo "$BIN/$SCRIPT ssl" >> $HESTIA/data/queue/restart.pipe
     exit
 fi
 
@@ -72,18 +78,22 @@ if [ -f "$HESTIA/web/inc/nginx_proxy" ]; then
     # Default behaviour
     
     # Preform an check if Nginx is valid as reload doesn't throw an error / exit
-    service $PROXY_SYSTEM configtest  >> /dev/null 2>&1
+    service $PROXY_SYSTEM configtest > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         send_email_report
         check_result $E_RESTART "$PROXY_SYSTEM restart failed"
     fi
-    
+
     # Restart system
-    $BIN/v-restart-service $PROXY_SYSTEM > /dev/null 2>&1
+    if [ "$1" = "ssl" ]; then
+        restart="ssl"
+    fi
+    $BIN/v-restart-service $PROXY_SYSTEM $restart > /dev/null 2>&1
 
     # Update restart queue
     if [ -e "$HESTIA/data/queue/restart.pipe" ]; then
         sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
+        sed -i "/\/$SCRIPT ssl/d" $HESTIA/data/queue/restart.pipe
     fi
 fi
 

--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -52,6 +52,8 @@ for service in $service_list; do
         # Run the restart rules for iptables firewall
         $BIN/v-stop-firewall
         $BIN/v-update-firewall
+    elif [ "$restart" = "ssl" ] && [ "$service" = "nginx" ]; then
+        service $service upgrade > /dev/null 2>&1
     elif [ -z "$restart" -o "$restart" = "no" ] && [ \
             "$service" = "nginx" -o     \
             "$service" = "apache2" -o   \

--- a/bin/v-restart-web
+++ b/bin/v-restart-web
@@ -40,6 +40,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$WEB_SYSTEM" ] || [ "$WEB_SYSTEM" = 'remote' ]; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -51,33 +55,40 @@ if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     exit
 fi
 
-if [ -z "$WEB_SYSTEM" ] || [ "$WEB_SYSTEM" = 'remote' ]; then
+if [ "$1" = "updatessl" ]; then
+    sed -i "/\/$SCRIPT ssl/d" $HESTIA/data/queue/restart.pipe
+    echo "$BIN/$SCRIPT ssl" >> $HESTIA/data/queue/restart.pipe
     exit
 fi
-if [ $WEB_SYSTEM = 'nginx' ]; then 
-    service $WEB_SYSTEM configtest  >> /dev/null 2>&1
+
+if [ $WEB_SYSTEM = 'nginx' ]; then
+    if [ "$1" = "ssl" ]; then
+        restart="ssl"
+    fi
+    service $WEB_SYSTEM configtest > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         send_email_report
         check_result $E_RESTART "$WEB_SYSTEM restart failed"
     fi
-elif [ $WEB_SYSTEM = 'apache2' ]; then 
-    apache2ctl configtest  >> /dev/null 2>&1
+elif [ $WEB_SYSTEM = 'apache2' ]; then
+    apache2ctl configtest > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         send_email_report
         check_result $E_RESTART "$WEB_SYSTEM restart failed"
     fi
 fi
 
-$BIN/v-restart-service $WEB_SYSTEM > /dev/null 2>&1
+$BIN/v-restart-service $WEB_SYSTEM $restart > /dev/null 2>&1
 
 if [ $? -ne 0 ]; then
     send_email_report
     check_result $E_RESTART "$WEB_SYSTEM restart failed"
- fi
+fi
 
 # Update restart queue
 if [ -e "$HESTIA/data/queue/restart.pipe" ]; then
     sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
+    sed -i "/\/$SCRIPT ssl/d" $HESTIA/data/queue/restart.pipe
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-restart-web-backend
+++ b/bin/v-restart-web-backend
@@ -33,6 +33,10 @@ send_email_report() {
 #----------------------------------------------------------#
 
 # Exit
+if [ -z "$WEB_BACKEND" ] || [ "$WEB_BACKEND" = 'remote' ]; then
+    exit
+fi
+
 if [ "$1" = "no" ]; then
     exit
 fi
@@ -41,10 +45,6 @@ fi
 if [ "$1" = 'scheduled' ] || [ -z "$1" -a "$SCHEDULED_RESTART" = 'yes' ]; then
     sed -i "/\/$SCRIPT now/d" $HESTIA/data/queue/restart.pipe
     echo "$BIN/$SCRIPT now" >> $HESTIA/data/queue/restart.pipe
-    exit
-fi
-
-if [ -z "$WEB_BACKEND" ] || [ "$WEB_BACKEND" = 'remote' ]; then
     exit
 fi
 

--- a/bin/v-update-host-certificate
+++ b/bin/v-update-host-certificate
@@ -84,15 +84,10 @@ if [ -z "$UPDATE_HOSTNAME_SSL" ]; then
 fi
 
 # Restart services
-$BIN/v-restart-web
-$BIN/v-restart-proxy
-if [ ! -z "$MAIL_SYSTEM" ]; then
-    # Restart exim (and dovecot if applicable)
-    $BIN/v-restart-mail
-fi
-if [ "$FTP_SYSTEM" = "vsftpd" ]; then
-    $BIN/v-restart-ftp
-fi
+$BIN/v-restart-web updatessl
+$BIN/v-restart-proxy updatessl
+$BIN/v-restart-mail
+$BIN/v-restart-ftp
 $BIN/v-restart-service hestia
 
 #----------------------------------------------------------#


### PR DESCRIPTION
1. Add "updatessl" restart queue for Nginx
Avoid frequent restart causing issue.

2. Nginx uses "upgrade" init script to reload new certificate
"Restart" without downtime, but will make sure reload new certificate.

3. Fix the logic error of "v-restart-*" exit check

These fixes are for https://github.com/hestiacp/hestiacp/issues/2114 etc. It may also be helpful for some Let's Encrypt errors.