### PR TITLE
Improve grep match for hst_scan_i18n.sh

### DIFF
--- a/web/locale/hst_scan_i18n.sh
+++ b/web/locale/hst_scan_i18n.sh
@@ -15,7 +15,7 @@ find ../.. \( -name '*.php' -o -name '*.html' -o -name '*.sh' \) | xgettext --ou
 OLDIFS=$IFS
 IFS=$'\n'
 for string in $(awk -F'SYSTEM=' '/data=".+ SYSTEM=[^"]/ {print $2}' $HESTIA/bin/v-list-sys-services | cut -d\' -f2); do
-    if [ -z "$(grep "$string" hestiacp.pot)" ]; then
+    if [ -z "$(grep "\"$string\"" hestiacp.pot)" ]; then
         echo -e "\n#: ../../bin/v-list-sys-services:"$(grep -n "$string" $HESTIA/bin/v-list-sys-services | cut -d: -f1)"\nmsgid \"$string\"\nmsgstr \"\"" >> hestiacp.pot
     fi
 done

--- a/web/templates/pages/edit_server.html
+++ b/web/templates/pages/edit_server.html
@@ -725,7 +725,7 @@
 														<select class="vst-list" name="v_backup_type" id="backup_type">
 															<option value='ftp'><?=_('ftp'); ?></option>
 															<option value='sftp' <?php if((!empty($v_backup_type)) && (trim($v_backup_type,"'")  == 'sftp' )) echo 'selected="selected"'; ?>><?=_('sftp'); ?></option>
-															<option value="b2" <?php if((!empty($v_backup_type)) && (trim($v_backup_type,"'")  == 'b2' )) echo 'selected="selected"'; ?>><?=_('Backblaze '); ?>
+															<option value="b2" <?php if((!empty($v_backup_type)) && (trim($v_backup_type,"'")  == 'b2' )) echo 'selected="selected"'; ?>><?=_('Backblaze'); ?>
 														</select>
 														<br><br>
 													</td>
@@ -1035,7 +1035,7 @@
 												</tr>
 												<tr>
 													<td class="vst-text input-label">
-														<?=_('Prevent CSRF ');?>
+														<?=_('Prevent CSRF');?>
 													</td>
 												</tr>
 												<tr>


### PR DESCRIPTION
Because grep match is not strict enough, "firewall" string is lost.

@jaapmarcus Please rescan and update GlotPress, thanks!