### PR TITLE
Update phpmyadmin.inc

### DIFF
--- a/install/deb/nginx/phpmyadmin.inc
+++ b/install/deb/nginx/phpmyadmin.inc
@@ -1,4 +1,4 @@
-location /%pma_alias% {
+location /%pma_alias%/ {
     alias /usr/share/phpmyadmin/;
 
     location ~ /(libraries|setup) {


### PR DESCRIPTION
fixed trailing slash in PHPMyAdmin Nginx configuration.