### PR TITLE
Fix sshd configuration error on Ubuntu 20.04.3 LTS

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -970,9 +970,11 @@ fi
 sed -i "s/[#]LoginGraceTime [[:digit:]]m/LoginGraceTime 1m/g" /etc/ssh/sshd_config
 
 # Disable SSH suffix broadcast
-if [ -z "$(grep "^DebianBanner no" /etc/ssh/sshd_config)" ]; then
-    echo '' >> /etc/ssh/sshd_config
-    echo 'DebianBanner no' >> /etc/ssh/sshd_config
+if [ "$release" != '20.04' ]; then
+    if [ -z "$(grep "^DebianBanner no" /etc/ssh/sshd_config)" ]; then
+        echo '' >> /etc/ssh/sshd_config
+        echo 'DebianBanner no' >> /etc/ssh/sshd_config
+    fi
 fi
 
 # Restart SSH daemon


### PR DESCRIPTION
"DebianBanner no" breaks sshd daemon after install on Ubuntu 20.04.3 LTS 