### PR TITLE
Improve detection of port used

### DIFF
--- a/bin/v-list-sys-sshd-port
+++ b/bin/v-list-sys-sshd-port
@@ -1,0 +1,82 @@
+#!/bin/bash
+# info: list sshd port
+# options: [FORMAT]
+# labels: panel
+# 
+# example: v-list-sys-sshd-port
+#
+# The function for obtainings the port of sshd listens to
+
+# Argument definition
+
+# Argument definition
+format=${1-shell}
+
+# Includes
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+
+json_list() {
+    sh_counter=$(echo "$ports" | wc -l)
+    i=1
+    echo '['
+    for port in $ports; do
+        if [ "$i" -lt "$sh_counter" ]; then
+            echo -e  "\t\"$port\","
+        else
+            echo -e  "\t\"$port\""
+        fi
+        (( ++i))
+    done
+    echo "]"
+}
+
+# SHELL list function
+shell_list() {
+    echo "PORT"
+    echo "-----"
+    for port in $ports; do
+        echo "$port"
+    done
+}
+
+# PLAIN list function
+plain_list() {
+    for port in $ports; do
+        echo "$port"
+    done
+}
+
+# CSV list function
+csv_list() {
+    echo "SHELL"
+    for port in $ports; do
+        echo "$port"
+    done
+}
+
+#----------------------------------------------------------#
+#                    Variable&Function                     #
+#----------------------------------------------------------#
+
+ports=$(sshd -T | grep '^port'| cut -d ' ' -f2);
+
+# Listing data
+case $format in
+    json)   json_list ;;
+    plain)  plain_list ;;
+    csv)    csv_list ;;
+    shell)  shell_list ;;
+esac
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+exit

--- a/bin/v-list-sys-sshd-port
+++ b/bin/v-list-sys-sshd-port
@@ -49,7 +49,7 @@ plain_list() {
 
 # CSV list function
 csv_list() {
-    echo "SHELL"
+    echo "PORT"
     for port in $ports; do
         echo "$port"
     done

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -11,38 +11,39 @@ $dist_config['frontend_config']['guest_redirection'] = '/login/' ;
 $dist_config['frontend_config']['upload_max_size'] = 1024 * 1024 * 1024;
 
 $dist_config['services']['Filegator\Services\Storage\Filesystem']['config']['adapter'] = function () {
+    if (isset($_SESSION['user'])) {
+        $v_user = $_SESSION['user'];
+    }
+    if (isset($_SESSION['look']) && ($_SESSION['userContext'] === 'admin')) {
+        $v_user = $_SESSION['look'];
+    }
+    if ((isset($_SESSION['look']) && ($_SESSION['look'] == 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] == 'yes'))) {
+        header('Location: /');
+    }
+    # Create filemanager sftp key if missing and trash it after 30 min
+    if (! file_exists('/home/'.basename($v_user).'/.ssh/hst-filemanager-key')) {
+        exec("sudo /usr/local/hestia/bin/v-add-user-sftp-key " . escapeshellarg(basename($v_user)) . " 30", $output, $return_var);
+    }
 
-        if (isset($_SESSION['user'])) {
-            $v_user = $_SESSION['user'];
+    if (!isset($_SESSION['SFTP_PORT'])) {
+        exec("sudo /usr/local/hestia/bin/v-list-sys-sshd-port json", $output, $result);
+        if ($output) {
+            $port=json_decode(implode('', $output));
+            $_SESSION['SFTP_PORT'] = $port[0];
+        } else {
+            $_SESSION['SFTP_PORT'] = 22;
         }
-        if (isset($_SESSION['look']) && ($_SESSION['userContext'] === 'admin')) {
-            $v_user = $_SESSION['look'];
-        }
-        if ((isset($_SESSION['look']) && ($_SESSION['look'] == 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] == 'yes') )) {
-            header('Location: /');
-        }
-        # Create filemanager sftp key if missing and trash it after 30 min
-        if (! file_exists('/home/'.basename($v_user).'/.ssh/hst-filemanager-key')) {
-            exec ("sudo /usr/local/hestia/bin/v-add-user-sftp-key " . escapeshellarg(basename($v_user)) . " 30", $output, $return_var);
-        }
+    }
 
-        if ( !isset($_SESSION['SFTP_PORT']) ) {
-            if( preg_match('/^\s*Port\s+(\d+)$/im', file_get_contents('/etc/ssh/sshd_config'), $matches) ) {
-                $_SESSION['SFTP_PORT'] = $matches[1] ?? 22;
-            } else {
-                $_SESSION['SFTP_PORT'] = 22;
-            }
-        }
+    preg_match('/(Hestia SFTP Chroot\nMatch User)(.*)/i', file_get_contents('/etc/ssh/sshd_config'), $matches);
+    $user_list = explode(',', $matches[2]);
+    if (in_array($v_user, $user_list)) {
+        $root = '/';
+    } else {
+        $root = '/home/'.$v_user;
+    }
 
-        preg_match('/(Hestia SFTP Chroot\nMatch User)(.*)/i', file_get_contents('/etc/ssh/sshd_config'), $matches);
-        $user_list = explode(',', $matches[2]);
-        if(in_array($v_user,$user_list)){
-            $root = '/';
-        }else{
-            $root = '/home/'.$v_user;
-        }
-      
-        return new \League\Flysystem\Sftp\SftpAdapter([
+    return new \League\Flysystem\Sftp\SftpAdapter([
             'host' => '127.0.0.1',
             'port' => intval($_SESSION['SFTP_PORT']),
             'username' => basename($v_user),
@@ -51,7 +52,7 @@ $dist_config['services']['Filegator\Services\Storage\Filesystem']['config']['ada
             'timeout' => 10,
             'directoryPerm' => 0755,
         ]);
-    };
+};
 
 $dist_config['services']['Filegator\Services\Archiver\ArchiverInterface'] = [
     'handler' => '\Filegator\Services\Archiver\Adapters\HestiaZipArchiver',


### PR DESCRIPTION
Use instead of grep function over sshd_config the command sshd -T | grep '^port' | cut -d ' ' -f2 to see the ports used 
