### PR TITLE
Added max_allowed_packet parameter to mysql dump

### DIFF
--- a/func/db.sh
+++ b/func/db.sh
@@ -89,7 +89,7 @@ mysql_query() {
 
 mysql_dump() {
     err="/tmp/e.mysql"
-    mysqldump --defaults-file=$mycnf --single-transaction --routines -r $1 $2 2> $err
+    mysqldump --defaults-file=$mycnf --single-transaction --max_allowed_packet=128M --routines -r $1 $2 2> $err
     if [ '0' -ne "$?" ]; then
         rm -rf $tmpdir
         if [ "$notify" != 'no' ]; then

--- a/func/db.sh
+++ b/func/db.sh
@@ -89,7 +89,7 @@ mysql_query() {
 
 mysql_dump() {
     err="/tmp/e.mysql"
-    mysqldump --defaults-file=$mycnf --single-transaction --max_allowed_packet=128M --routines -r $1 $2 2> $err
+    mysqldump --defaults-extra-file=$mycnf --single-transaction --routines -r $1 $2 2> $err
     if [ '0' -ne "$?" ]; then
         rm -rf $tmpdir
         if [ "$notify" != 'no' ]; then


### PR DESCRIPTION
At 10.5.10-MariaDB, I got backup error when mysql dump.

```
mysqldump: Error 2020: Got packet bigger than 'max_allowed_packet' when dumping table ...
```
my.cnf value is 1G.

```
max_allowed_packet = 1G
```
I added,

```
[mysqldump]
max_allowed_packet = 1G
```
not worked.
These are not fix the problem.

When I added --max_allowed_packet=128M to the command line, it works without any problem.

I am not sure it is a configuration error or a bug. When I checked vestacp, it uses a command line like this.