### PR TITLE
Bats testing for Letsencrypt domain

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -76,6 +76,10 @@ steps:
 - name: Run restore tests
   commands:
   - bats ./test/restore.bats
+- name: Run Letsencrypt test against Staging
+  commands:
+  - cp /root/le-env.sh /tmp/hestia-le-env.sh
+  - bats ./test/letsencrypt.bats
 - name: Run config tests 
   commands:
   - bats ./test/config-tests.bats
@@ -105,4 +109,4 @@ trigger:
 
 ---
 kind: signature
-hmac: 48d34d11001c99b470114f50c4284fa107a5e61ad08ada38307493b9e9b2883f
+hmac: da6a96c077ec55ccfb27ec8a3250eeb0700153078adf088dc70998b2cd033b28

--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -30,6 +30,11 @@ check_hestia_demo_mode
 # Set LE counter
 lecounter=0
 max_LE_failures=30
+days_valid_setting=31
+if [ "$LE_STAGING" = "yes" ]; then 
+    # Overwrite setting to allow testing for renewal to be done easier
+    days_valid_setting=181
+fi
 
 # Checking user certificates
 for user in $($HESTIA/bin/v-list-sys-users plain); do
@@ -53,7 +58,7 @@ for user in $($HESTIA/bin/v-list-sys-users plain); do
         now=$(date +%s)
         seconds_valid=$((expiration - now))
         days_valid=$((seconds_valid / 86400))
-        if [[ "$days_valid" -lt 31 ]]; then
+        if [[ "$days_valid" -lt "$days_valid_setting" ]]; then
             if [ $lecounter -gt 0 ]; then
                 sleep 10
             fi

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -70,12 +70,12 @@ function setup() {
 
 #Check if CAA records hasn't been deleted
 @test "Check if CAA record hasn't been deleted" {
-    run v-list-dns-records $user $domain csv | grep CAA
-    assert_output --partial 'letsencrypt.org'
+    run v-list-dns-records $user $domain csv | grep letsencrypt.org
+    assert_output --partial letsencrypt.org
 }
 
 @test "Delete user" {
-    skip
+    #skip
     run v-delete-user $user
     assert_success
     refute_output

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -27,13 +27,13 @@ function setup() {
 }
 
 @test "Create DNS domain" {
-    run v-add-dns-domain $user $domain
+    run v-add-dns-domain $user $domain $ip
     assert_success
     refute_output
 }
 
 @test "Create web domain" {
-    run v-add-web-domain $user $domain
+    run v-add-web-domain $user $domain $ip yes "www.$domain,renewal.$domain"
     assert_success
     refute_output
 }

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -63,19 +63,18 @@ function setup() {
 }
 
 @test Delete mail ssl" {
-    run v-delete-letsencrypt-domain $user $domain "no" "yes"
+    v-delete-letsencrypt-domain $user $domain "yes" "yes"
     assert_success
     refute_output
 }
 
-#Check if CAA records hasn't been deleted
-@test "Check if CAA record hasn't been deleted" {
-    run v-list-dns-records $user $(idn -a $domain) csv | grep letsencrypt.org
+@test Delete web ssl" {
+    v-delete-letsencrypt-domain $user $domain "yes" "no"
     assert_success
+    refute_output
 }
 
 @test "Delete user" {
-    #skip
     run v-delete-user $user
     assert_success
     refute_output

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -15,7 +15,6 @@ function random() {
 
 function setup() {
     source /tmp/hestia-le-env.sh
-    source /etc/hestiacp/hestia.conf
     source $HESTIA/func/main.sh
     source $HESTIA/conf/hestia.conf
     source $HESTIA/func/ip.sh

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -63,7 +63,7 @@ function setup() {
     refute_output
 }
 
-@test "Run renewal script for LE" {
+@test Delete mail ssl" {
     run v-delete-letsencrypt-domain $user $domain "no" "yes"
     assert_success
     refute_output

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -75,6 +75,7 @@ function setup() {
 }
 
 @test "Delete user" {
+    skip
     run v-delete-user $user
     assert_success
     refute_output

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -71,7 +71,7 @@ function setup() {
 #Check if CAA records hasn't been deleted
 @test "Check if CAA record hasn't been deleted" {
     run v-list-dns-records $user $domain csv | grep letsencrypt.org
-    assert_output --partial letsencrypt.org
+    assert_success
 }
 
 @test "Delete user" {

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -70,7 +70,7 @@ function setup() {
 
 #Check if CAA records hasn't been deleted
 @test "Check if CAA record hasn't been deleted" {
-    run v-list-dns-records $user $domain csv | grep letsencrypt.org
+    run v-list-dns-records $user $(idn -a $domain) csv | grep letsencrypt.org
     assert_success
 }
 

--- a/test/letsencrypt.bats
+++ b/test/letsencrypt.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+if [ "${PATH#*/usr/local/hestia/bin*}" = "$PATH" ]; then
+    . /etc/profile.d/hestia.sh
+fi
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/bats-file/load'
+
+
+function random() {
+    head /dev/urandom | tr -dc 0-9 | head -c$1
+}
+
+function setup() {
+    source /tmp/hestia-le-env.sh
+    source /etc/hestiacp/hestia.conf
+    source $HESTIA/func/main.sh
+    source $HESTIA/conf/hestia.conf
+    source $HESTIA/func/ip.sh
+}
+
+@test "Create new user" {
+    run v-add-user $user $user $user@hestiacp.com default "Super Test"
+    assert_success
+    refute_output
+}
+
+@test "Create DNS domain" {
+    run v-add-dns-domain $user $domain
+    assert_success
+    refute_output
+}
+
+@test "Create web domain" {
+    run v-add-web-domain $user $domain
+    assert_success
+    refute_output
+}
+
+@test "Request new certificate for web domain" {
+    run v-add-letsencrypt-domain $user $domain "www.$domain,renewal.$domain"
+    assert_success
+    refute_output
+}
+
+@test "Create mail domain" {
+    run v-add-mail-domain $user $domain
+    assert_success
+    refute_output
+}
+
+@test "Request new Certificate for Mail Domain" {
+    run v-add-letsencrypt-domain $user $domain "" "yes"
+    assert_success
+    refute_output
+}
+
+@test "Run renewal script for LE" {
+    run v-update-letsencrypt-ssl
+    assert_success
+    refute_output
+}
+
+@test "Run renewal script for LE" {
+    run v-delete-letsencrypt-domain $user $domain "no" "yes"
+    assert_success
+    refute_output
+}
+
+#Check if CAA records hasn't been deleted
+@test "Check if CAA record hasn't been deleted" {
+    run v-list-dns-records $user $domain csv | grep CAA
+    assert_output --partial 'letsencrypt.org'
+}
+
+@test "Delete user" {
+    run v-delete-user $user
+    assert_success
+    refute_output
+}


### PR DESCRIPTION
Add testing with Bats for Letsencrypt domain + mail domain

```
root@drone-2:~# cat le-env.sh 
#!/bin/bash

user="hestia-122001"
domain="domain..com"
ip="ipofserver"
```

Test are currently active for only Debian 10 + Nginx 
