### PR TITLE
Grant access to /home/user folder for Quick installer

### DIFF
--- a/src/deb/php/php-fpm.conf
+++ b/src/deb/php/php-fpm.conf
@@ -41,4 +41,4 @@ php_admin_value[upload_max_filesize] = 256M
 php_admin_value[max_execution_time] = 300
 php_admin_value[max_input_time] = 300
 php_admin_value[session.save_path] = /usr/local/hestia/data/sessions
-php_admin_value[open_basedir] = /usr/local/hestia/:/tmp/:/dev/
+php_admin_value[open_basedir] = /usr/local/hestia/:/tmp/:/dev/:/home/


### PR DESCRIPTION
hestia-php is currently not able to access /home/ for config manipulation and checking if the folder is empty