### PR TITLE
Added pma_v back

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -32,6 +32,7 @@ VERBOSE='no'
 
 # Define software versions
 HESTIA_INSTALL_VER='1.5.3'
+pma_v='5.1.1'
 rc_v="1.5.1"
 multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1")
 fpm_v="8.0"


### PR DESCRIPTION
I guess this was a mistake but with this commit https://github.com/hestiacp/hestiacp/commit/e74ed953842f10e982b9b1752375b2ecd445b0e2

He accidentally removed the pma_v variable for the ubuntu install script thus resulting in phpmyadmin failing to install.