### PR TITLE
Bump b2 cli to latest official version

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -21,17 +21,16 @@ path=${5-/backup}
 port=$6
 
 # Includes
-# shellcheck source=/etc/hestiacp/hestia.conf
-source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
 source $HESTIA/func/main.sh
-
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
+# Fetch current verison B2 CLI tool
+source_conf "$HESTIA/install/upgrade/upgrade.conf"
 
 # Paths
 b2cli="/usr/local/bin/b2"
-b2lnk="https://github.com/Backblaze/B2_Command_Line_Tool/releases/latest/download/b2-linux"
+b2lnk="https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v$b2_v/b2-linux"
 
 # Defining ftp command function
 ftpc() {

--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -31,7 +31,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 
 # Paths
 b2cli="/usr/local/bin/b2"
-b2lnk="https://f000.backblazeb2.com/file/backblazefiles/b2/cli/linux/b2"
+b2lnk="https://github.com/Backblaze/B2_Command_Line_Tool/releases/latest/download/b2-linux"
 
 # Defining ftp command function
 ftpc() {

--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -580,7 +580,7 @@ upgrade_phpmyadmin() {
                 chmod 0640 /var/lib/phpmyadmin/blowfish_secret.inc.php
             fi
         else
-            # Display upgrade infob2     rmation
+            # Display upgrade information
             echo "[ * ] Upgrading phpMyAdmin to version v$pma_v..."
             [ -d /usr/share/phpmyadmin ] || mkdir -p /usr/share/phpmyadmin
 

--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -545,6 +545,11 @@ upgrade_start_routine() {
     #####################################################################
 }
 
+clean_up_downloaded_binaries() {
+    # Backblaze B2 CLI
+    rm -f /usr/local/bin/b2
+}
+
 upgrade_phpmyadmin() {
     # Check if MariaDB/MySQL is installed on the server before attempting to install or upgrade phpMyAdmin
     if [ -n "$(echo $DB_SYSTEM | grep -w 'mysql')" ]; then

--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -14,6 +14,9 @@ source $HESTIA/func/syshealth.sh
 #######                Functions & Initialization             #######
 #####################################################################
 
+# Define version check function
+function version_ge(){ test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" -o -n "$1" -a "$1" = "$2"; }
+
 add_upgrade_message (){ 
     if [ -f "$HESTIA_BACKUP/message.log" ]; then 
         echo -e $1 >> $HESTIA_BACKUP/message.log
@@ -545,17 +548,29 @@ upgrade_start_routine() {
     #####################################################################
 }
 
-clean_up_downloaded_binaries() {
-    # Backblaze B2 CLI
-    rm -f /usr/local/bin/b2
+upgrade_b2_tool(){
+    b2cli="/usr/local/bin/b2"
+    b2lnk="https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v$b2_v/b2-linux"
+    if [ -f "$b2cli" ]; then
+        b2_version=$(b2 version | grep -o -E '[0-9].[0-9].[0-9]+' | head -1);
+        if version_ge "$b2_version" "$b2_v"; then
+            echo "[ * ] Backblaze CLI tool is up to date ($b2_v)..."
+        else
+            echo "[ * ] Upgrading Backblaze CLI tool to version v$b2_v..."
+            rm $b2cli
+            wget -O $b2cli $b2lnk > /dev/null 2>&1
+            chmod +x $b2cli > /dev/null 2>&1
+            if [ ! -f "$b2cli" ]; then
+                echo "Error: Binary download failed, b2 doesnt work as expected."
+                exit 3
+            fi
+        fi
+    fi   
 }
 
 upgrade_phpmyadmin() {
     # Check if MariaDB/MySQL is installed on the server before attempting to install or upgrade phpMyAdmin
     if [ -n "$(echo $DB_SYSTEM | grep -w 'mysql')" ]; then
-        # Define version check function
-        function version_ge(){ test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" -o -n "$1" -a "$1" = "$2"; }
-
         pma_release_file=$(ls /usr/share/phpmyadmin/RELEASE-DATE-* 2>/dev/null |tail -n 1)
         if version_ge "${pma_release_file##*-}" "$pma_v"; then
             echo "[ * ] phpMyAdmin is up to date (${pma_release_file##*-})..."
@@ -565,7 +580,7 @@ upgrade_phpmyadmin() {
                 chmod 0640 /var/lib/phpmyadmin/blowfish_secret.inc.php
             fi
         else
-            # Display upgrade information
+            # Display upgrade infob2     rmation
             echo "[ * ] Upgrading phpMyAdmin to version v$pma_v..."
             [ -d /usr/share/phpmyadmin ] || mkdir -p /usr/share/phpmyadmin
 

--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -54,3 +54,6 @@ fm_v='7.7.0'
 
 # Set version of PHPMailer to update during upgrade if not already installed
 pm_v='6.5.3'
+
+# Backblaze
+b2_v='3.2.0'

--- a/src/deb/hestia/postinst
+++ b/src/deb/hestia/postinst
@@ -89,6 +89,9 @@ upgrade_phpmailer | tee -a $LOG
 # Upgrade phpMyAdmin if applicable
 upgrade_phpmyadmin | tee -a $LOG
 
+# Upgrade blackblaze-cli-took if applicable
+upgrade_b2_tool | tee -a $LOG
+
 # Set new version number in hestia.conf
 upgrade_set_version $new_version
 upgrade_set_branch $new_version

--- a/src/rpm/hestia/hestia.spec
+++ b/src/rpm/hestia/hestia.spec
@@ -88,6 +88,9 @@ if [ -e "/usr/local/hestia/data/users/admin" ]; then
 
     # Upgrade phpMyAdmin if applicable
     upgrade_phpmyadmin
+    
+    # Delete downloaded binaries to get latest version in the next run
+    clean_up_downloaded_binaries
 
     # Set new version number in hestia.conf
     upgrade_set_version

--- a/src/rpm/hestia/hestia.spec
+++ b/src/rpm/hestia/hestia.spec
@@ -86,11 +86,32 @@ if [ -e "/usr/local/hestia/data/users/admin" ]; then
     # Execute version-specific upgrade scripts
     upgrade_start_routine
 
-    # Upgrade phpMyAdmin if applicable
-    upgrade_phpmyadmin
+    # Update Web domain templates
+    upgrade_rebuild_web_templates | tee -a $LOG
     
-    # Delete downloaded binaries to get latest version in the next run
-    clean_up_downloaded_binaries
+    # Update Mail domain templates
+    upgrade_rebuild_mail_templates | tee -a $LOG
+    
+    # Update DNS zone templates
+    upgrade_rebuild_dns_templates | tee -a $LOG
+    
+    # Upgrade File Manager and update configuration
+    upgrade_filemanager | tee -a $LOG
+    
+    # Upgrade Rainloop if applicable
+    upgrade_rainloop | tee -a $LOG
+    
+    # Upgrade Roundcube if applicable
+    upgrade_roundcube | tee -a $LOG
+    
+    # Upgrade PHPMailer if applicable
+    upgrade_phpmailer | tee -a $LOG
+    
+    # Upgrade phpMyAdmin if applicable
+    upgrade_phpmyadmin | tee -a $LOG
+    
+    # Upgrade blackblaze-cli-took if applicable
+    upgrade_b2_tool | tee -a $LOG
 
     # Set new version number in hestia.conf
     upgrade_set_version


### PR DESCRIPTION
Bump b2 cli to latest official version. This will fix the issue that Backblaze backup fail to run with /tmp noexec