### PR TITLE
Fix/update bugs

### DIFF
--- a/install/upgrade/versions/1.5.5.sh
+++ b/install/upgrade/versions/1.5.5.sh
@@ -22,7 +22,7 @@ upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'true'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 
 # Update php-fpm.conf
-for version in /etc/php/*/fpm/php-fpm.conf; do
+for version in $($BIN/v-list-sys-php plain); do
     cp -f $HESTIA_INSTALL_DIR/php-fpm/php-fpm.conf /etc/php/$version/fpm/
     sed -i "s/fpm_v/$version/g" /etc/php/$version/fpm/php-fpm.conf
 done

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -6,7 +6,8 @@ use PHPMailer\PHPMailer\Exception;
 
 if(!file_exists('vendor/autoload.php')){
     trigger_error('Unable able to load required libaries. Please run v-add-sys-phpmailer in command line');
-    exit('Unable able to load required libaries. Please run v-add-sys-phpmailer in command line');
+    echo 'Unable able to load required libaries. Please run v-add-sys-phpmailer in command line';
+    exit(1);
 }
 
 require 'vendor/autoload.php';

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -4,8 +4,12 @@ use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\PHPMailer\Exception;
 
-require 'vendor/autoload.php';
+if(!file_exists('vendor/autoload.php')){
+    trigger_error('Unable able to load required libaries. Please run v-add-sys-phpmailer in command line');
+    exit('Unable able to load required libaries. Please run v-add-sys-phpmailer in command line');
+}
 
+require 'vendor/autoload.php';
 session_start();
 
 


### PR DESCRIPTION
Solve multiple bug that happens during update

- $version was set to /etc/php/x.x/fpm/php-fpm.conf instead of version number
- When update of oh-mailer fails it returned a 500 error . Now a nice message to install it again