### PR TITLE
Fixed /root/.gnupg permissions

### DIFF
--- a/install/upgrade/versions/1.5.5.sh
+++ b/install/upgrade/versions/1.5.5.sh
@@ -29,7 +29,7 @@ done
 
 echo "[ * ] Updating apt keyring configuration..."
 
-mkdir /root/.gnupg && chmod 700 /root/.gnupg
+mkdir -p /root/.gnupg && chmod 700 /root/.gnupg
 
 if [ ! -f "/usr/share/keyrings/nginx-keyring.gpg" ]; then 
     # Get Architecture

--- a/install/upgrade/versions/1.5.5.sh
+++ b/install/upgrade/versions/1.5.5.sh
@@ -29,7 +29,7 @@ done
 
 echo "[ * ] Updating apt keyring configuration..."
 
-mkdir /root/.gnupg
+mkdir /root/.gnupg && chmod 700 /root/.gnupg
 
 if [ ! -f "/usr/share/keyrings/nginx-keyring.gpg" ]; then 
     # Get Architecture


### PR DESCRIPTION
Set /root/.gnupg permissions to 700 when the directory is created