### PR TITLE
Fixed /root/.gnupg permissions in hst-install-ubuntu.sh

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -663,7 +663,7 @@ fi
 apt=/etc/apt/sources.list.d
 
 # Create new folder if not all-ready exists
-mkdir /root/.gnupg/ && chmod 700 /root/.gnupg/
+mkdir -p /root/.gnupg/ && chmod 700 /root/.gnupg/
 
 # Updating system
 echo "Adding required repositories to proceed with installation:"

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -662,6 +662,9 @@ fi
 # Define apt conf location
 apt=/etc/apt/sources.list.d
 
+# Create new folder if not all-ready exists
+mkdir /root/.gnupg/ && chmod 700 /root/.gnupg/
+
 # Updating system
 echo "Adding required repositories to proceed with installation:"
 echo


### PR DESCRIPTION
Set /root/.gnupg permissions to 700 when the directory is created in hst-install-ubuntu.sh