### PR TITLE
Update v-list-sys-services

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -230,7 +230,7 @@ if [ -n "$DB_SYSTEM" ] && [ "$DB_SYSTEM" != 'remote' ]; then
         service="$db"
         proc_name=''
         if [ "$service" = 'mysql' ]; then
-            if [ -d "/etc/sysconfig" ]; then
+            if [ -f "/etc/mysql/mysql.cnf" ]; then
                 service='mysqld'
                 proc_name='mysqld'
             fi


### PR DESCRIPTION
This is a more accurate check of the existence of mysql (5.7.x), as opposed to mariadb.  Fixes the false "not running" state reported by HestiaCP, even though mysql is running.

Checking for the existence of the directory, /etc/sysconfig/ is no longer a valid check.