### PR TITLE
Update v-list-sys-services

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -230,19 +230,24 @@ if [ -n "$DB_SYSTEM" ] && [ "$DB_SYSTEM" != 'remote' ]; then
         service="$db"
         proc_name=''
         if [ "$service" = 'mysql' ]; then
-            if [ -d "/etc/sysconfig" ]; then
+            mysql_version=$(mysql -V)
+            mariadb_string="MariaDB"
+            if [[ ! $mysql_version =~ $mariadb_string ]]; then
+                # MySQL
                 service='mysqld'
                 proc_name='mysqld'
-            fi
-            if [ -e "/lib/systemd/system/mariadb.service" ]; then
-                service='mariadb'
-                proc_name='mysqld'
-            fi
-            if [ -f /usr/bin/mysql ]; then
-                mariadb_v=`mysql -V | awk 'NR==1{print $5}' | head -c 4`
-                if [ $mariadb_v = "10.5" ] || [ $mariadb_v = "10.6" ]; then
+            else
+                # MariaDB
+                if [ -e "/lib/systemd/system/mariadb.service" ]; then
                     service='mariadb'
-                    proc_name='mariadbd'
+                    proc_name='mysqld'
+                fi
+                if [ -f /usr/bin/mysql ]; then
+                    mariadb_v=`mysql -V | awk 'NR==1{print $5}' | head -c 4`
+                    if [ $mariadb_v = "10.5" ] || [ $mariadb_v = "10.6" ]; then
+                        service='mariadb'
+                        proc_name='mariadbd'
+                    fi
                 fi
             fi
         fi


### PR DESCRIPTION
Inspired by Jaap Marcus, I rewrote the check to discover DB System between MySQL and MariaDB.  Now using "mysql -V" to determine existence of each DB variant, subordinate to service type "mysql".  This check looks for the substring "MariaDB" to be contained within the version string (mysql -V) of the currently running database.  Far more foolproof than relying on the existence of a file or folder.

I tested this code on two live HestiaCP installations, one running under MySQL 5.7 and another running under MariaDB 10.5 -- works correctly in both instances.

Hope this helps.