### PR TITLE
Fix cpu architecture compatibility with b2 host

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -192,10 +192,8 @@ if [ "$type" = 'b2' ]; then
     # Download b2 binary
     if [ ! -f "$b2cli" ]; then
         if [ "$arch" = 'aarch64' ] || [ "$arch" = 'arm64' ]; then
-            if ! [ -x "$(command -v pip3)" ]; then
-                apt install python3-pip
-            fi
-            pip3 install b2 > /dev/null 2>&1
+            echo "Error: B2 binary for arm64 must be downloaded manually."
+            exit 3
         else
             wget -O $b2cli $b2lnk > /dev/null 2>&1
             chmod +x $b2cli > /dev/null 2>&1

--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -20,6 +20,9 @@ password=$(perl -e 'print quotemeta shift(@ARGV)' "${raw_password}")
 path=${5-/backup}
 port=$6
 
+# CPU Architecture
+arch=$(uname -m)
+
 # Includes
 # shellcheck source=/usr/local/hestia/func/main.sh
 source $HESTIA/func/main.sh
@@ -188,8 +191,12 @@ fi
 if [ "$type" = 'b2' ]; then
     # Download b2 binary
     if [ ! -f "$b2cli" ]; then
-        wget -O $b2cli $b2lnk > /dev/null 2>&1
-        chmod +x $b2cli > /dev/null 2>&1
+        if [ "$arch" = 'aarch64' ] || [ "$arch" = 'arm64' ]; then
+                pip install b2 > /dev/null 2>&1
+        else
+                wget -O $b2cli $b2lnk > /dev/null 2>&1
+                chmod +x $b2cli > /dev/null 2>&1
+        fi
         if [ ! -f "$b2cli" ]; then
             echo "Error: Binary download failed, b2 doesnt work as expected."
             exit 3

--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -192,10 +192,13 @@ if [ "$type" = 'b2' ]; then
     # Download b2 binary
     if [ ! -f "$b2cli" ]; then
         if [ "$arch" = 'aarch64' ] || [ "$arch" = 'arm64' ]; then
-                pip install b2 > /dev/null 2>&1
+            if ! [ -x "$(command -v pip3)" ]; then
+                apt install python3-pip
+            fi
+            pip3 install b2 > /dev/null 2>&1
         else
-                wget -O $b2cli $b2lnk > /dev/null 2>&1
-                chmod +x $b2cli > /dev/null 2>&1
+            wget -O $b2cli $b2lnk > /dev/null 2>&1
+            chmod +x $b2cli > /dev/null 2>&1
         fi
         if [ ! -f "$b2cli" ]; then
             echo "Error: Binary download failed, b2 doesnt work as expected."


### PR DESCRIPTION
Add check for cpu architecture and use the python b2 package instead of Github for arm64 architecture as the GitHub version doesn't exist and will produce an error.