### PR TITLE
Create .bash_history if a user sets bash shell.

### DIFF
--- a/bin/v-change-user-shell
+++ b/bin/v-change-user-shell
@@ -45,6 +45,12 @@ shell_path=$(grep -w "$shell" /etc/shells | head -n1)
 /usr/bin/chsh -s "$shell_path" "$user" >/dev/null 2>&1
 shell=$(basename "$shell_path")
 
+# Add .bash_history
+if [[ "$shell" =~ bash ]] && [[ ! -f /home/$user/.bash_history ]]; then
+    touch /home/$user/.bash_history
+    chown $user:$user /home/$user/.bash_history
+fi
+
 # Adding jailed sftp env
 if [[ "$shell" =~ nologin ]] || [[ "$shell" =~ rssh ]]; then
     $BIN/v-add-user-sftp-jail "$user" >/dev/null 2>&1

--- a/install/upgrade/versions/1.5.8.sh
+++ b/install/upgrade/versions/1.5.8.sh
@@ -31,3 +31,13 @@ for user in $(grep "$HOMEDIR" /etc/passwd |egrep "$shells" |cut -f 1 -d:); do
     $BIN/v-add-user-sftp-jail "$user" "no"
     fi
 done
+
+echo "[ * ] Add .bash_history for existing bash shell users"
+for user in $($BIN/v-list-users plain | cut -f1); do
+    for shell in $($BIN/v-list-user $user plain | cut -f20); do
+        if [[ "$shell" =~ bash ]] && [[ ! -f /home/$user/.bash_history ]]; then
+            touch /home/$user/.bash_history
+            chown $user:$user /home/$user/.bash_history
+        fi
+    done
+done


### PR DESCRIPTION
.bash_history can't be created, due to the user home folder ownership. This change will create the file if bash shell is used and sets the propper permission.