### PR TITLE
Chown /home/user to user:user after v-delete-user-sftp

### DIFF
--- a/bin/v-delete-user-sftp-jail
+++ b/bin/v-delete-user-sftp-jail
@@ -60,7 +60,10 @@ done
 users=$(IFS=',';echo "${new_users[*]// /|}";IFS=$' \t\n')
 sed -i "s/$ssh_users/$users/g" /etc/ssh/sshd_config
 
-
+# chown permissions back to user:user
+if [ -d "/home/$user" ]; then
+    chown $user:$user /home/$user
+fi
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
@@ -70,6 +73,6 @@ service ssh restart > /dev/null 2>&1
 service sshd restart > /dev/null 2>&1
 
 # Logging
-#log_event "$OK" "$ARGUMENTS"
+log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/test/test.bats
+++ b/test/test.bats
@@ -348,6 +348,9 @@ function check_ip_not_banned(){
     run v-change-user-shell $user bash
     assert_success
     refute_output
+    
+    run stat -c '%U' /home/$user
+    assert_output --partial "$user"
 }
 
 @test "Change user invalid shell" {
@@ -355,6 +358,16 @@ function check_ip_not_banned(){
     assert_failure $E_INVALID
     assert_output --partial 'shell bashinvalid is not valid'
 }
+
+@test "Change user nologin" {
+    run v-change-user-shell $user nologin
+    assert_success
+    refute_output
+    
+    run stat -c '%U' /home/$user
+    assert_output --partial 'root'
+}
+
 
 @test "Change user default ns" {
     run v-change-user-ns $user ns0.com ns1.com ns2.com ns3.com


### PR DESCRIPTION
When SFTP is enabled /home/user ownership to allow for jail. However permissions are not reset when disabled
