### PR TITLE
Fix for large number of host in nginx

### DIFF
--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -52,8 +52,9 @@ for service in $service_list; do
         $BIN/v-update-firewall
     elif [ "$restart" = "ssl" ] && [ "$service" = "nginx" ]; then
         service $service upgrade > /dev/null 2>&1
+    elif [ "$service" = "nginx" ]; then
+        systemctl restart nginx > /dev/null 2>&1
     elif [ -z "$restart" -o "$restart" = "no" ] && [ \
-            "$service" = "nginx" -o     \
             "$service" = "apache2" -o   \
             "$service" = "exim4" -o     \
             "$service" = "dovecot" -o   \


### PR DESCRIPTION
On large number of host nginx can't do 
`systemctl reload-or-restart nginx`
Getting error
`[emerg] 2724394#2724394: open() "/var/log/nginx/domains/xxx.error.log" failed (24: Too many open files)`