### PR TITLE
Update hst-install-debian.sh

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1898,14 +1898,6 @@ fi
 #                   Configure IP                           #
 #----------------------------------------------------------#
 
-# Roundcube permissions fix
-if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
-    if [ ! -d "/var/log/roundcube" ]; then
-        mkdir /var/log/roundcube
-    fi
-    chown admin:admin /var/log/roundcube
-fi
-
 # Configuring system IPs
 echo "[ * ] Configuring System IP..."
 $HESTIA/bin/v-update-sys-ip > /dev/null 2>&1

--- a/install/upgrade/versions/1.5.11.sh
+++ b/install/upgrade/versions/1.5.11.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Hestia Control Panel upgrade script for target version 1.5.10
+# Hestia Control Panel upgrade script for target version 1.5.11
 
 #######################################################################################
 #######                      Place additional commands below.                   #######

--- a/install/upgrade/versions/1.5.11.sh
+++ b/install/upgrade/versions/1.5.11.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.5.10
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+# Fix Roundcube logdir permission
+
+if [ -d "/var/log/roundcube" ]; then
+    chown www-data:www-data /var/log/roundcube
+fi


### PR DESCRIPTION
Roundcube logfiles are created under www-data:www-data user/group, so this block is no longer needed in the installer.

Directory is already chowned with the right user/group in the script `v-add-sys-roundcube`. See: [v-add-sys-roundcube#L135](https://github.com/hestiacp/hestiacp/blob/main/bin/v-add-sys-roundcube#L135)

Upgrade script is needed to fix folder permissions, because the wrong `chown admin:admin` line is executing after `v-add-sys-roundcube` during the installation procedure.