### PR TITLE
Allow the use of yescrypt

### DIFF
--- a/bin/v-check-user-hash
+++ b/bin/v-check-user-hash
@@ -62,7 +62,9 @@ if echo "$shadow" | grep -qE '^\$[0-9a-z]+\$[^\$]+\$'
 then
     salt=$(echo "$shadow" |cut -f 3 -d \$)
     method=$(echo "$shadow" |cut -f 2 -d \$)
-    if [ "$method" -eq '1' ]; then
+    if [ "$method" = "y" ]; then 
+        method="yescrypt"
+    elif [ "$method" -eq '1' ]; then
         method='md5'
     elif [ "$method" -eq '6' ]; then
         method='sha-512'

--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -35,7 +35,7 @@ check_args '2' "$#" 'USER PASSWORD'
 is_format_valid 'user'
 
 # Checking user
-if [ ! -d "$HESTIA/data/users/$user" ] && [ "$user" != 'root' ]; then
+if [ ! -d "$HESTIA/data/users/$user" ]; then
     echo "Error: password missmatch"
     echo "$date $time $user $ip failed to login" >> $HESTIA/log/auth.log
     exit 9
@@ -63,8 +63,7 @@ then
     salt=$(echo "$shadow" |cut -f 3 -d \$)
     method=$(echo "$shadow" |cut -f 2 -d \$)
     if [ "$method" = "y" ]; then
-        echo "Unsuported hash method";
-        exit 1;   
+        method="yescrypt" 
     elif [ "$method" -eq '1' ]; then
         method='md5'
     elif [ "$method" -eq '6' ]; then
@@ -85,13 +84,22 @@ if [ -z "$salt" ]; then
     exit 9
 fi
 
-# Generating hash
-set -o noglob
-hash=$($BIN/v-generate-password-hash "$method" "$salt" <<< "$password")
-if [[ -z "$hash" ]]; then
-    echo "Error: password missmatch"
-    echo "$date $time $user $ip failed to login" >> $HESTIA/log/auth.log
-    exit 9
+if [ "$method" = "yescrypt" ]; then
+    hash=$(mkpasswd "$password" "$shadow")
+    if [ $? -ne 0 ]; then 
+        echo "Error: password missmatch"
+        echo "$date $time $user $ip failed to login" >> $HESTIA/log/auth.log
+        exit 9
+    fi
+else
+    # Generating hash
+    set -o noglob
+    hash=$($BIN/v-generate-password-hash "$method" "$salt" <<< "$password")
+    if [[ -z "$hash" ]]; then
+        echo "Error: password missmatch"
+        echo "$date $time $user $ip failed to login" >> $HESTIA/log/auth.log
+        exit 9
+    fi
 fi
 
 # Checking hash
@@ -106,6 +114,7 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
+echo $hash;
 # Logging
 echo "$date $time $user $ip successfully logged in" >> $HESTIA/log/auth.log
 

--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: check user password
-# options: USER PASSWORD [IP]
+# options: USER PASSWORD [IP] [RETURN_HASH]
 #
 # example: v-check-user-password admin qwerty1234
 #
@@ -14,6 +14,7 @@
 user=$1
 password=$2; HIDE=2
 ip=${3-127.0.0.1}
+return_hash=$4
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -31,7 +32,7 @@ date=$(echo "$time_n_date" |cut -f 2 -d \ )
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'USER PASSWORD'
+check_args '2' "$#" 'USER PASSWORD RETURN_HASH'
 is_format_valid 'user'
 
 # Checking user
@@ -114,7 +115,9 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-echo $hash;
+if [ -n "$return_hash" ]; then 
+    echo $hash;
+fi
 # Logging
 echo "$date $time $user $ip successfully logged in" >> $HESTIA/log/auth.log
 

--- a/bin/v-get-user-salt
+++ b/bin/v-get-user-salt
@@ -84,7 +84,10 @@ if echo "$shadow" | grep -qE '^\$[0-9a-z]+\$[^\$]+\$'
 then
     salt=$(echo "$shadow" |cut -f 3 -d \$)
     method=$(echo "$shadow" |cut -f 2 -d \$)
-    if [ "$method" -eq '1' ]; then
+    if [ "$method" = "y" ]; then 
+        method='yescrypt'
+        salt=$(echo "$shadow" |cut -f 4 -d \$)
+    elif [ "$method" -eq '1' ]; then
         method='md5'
     elif [ "$method" -eq '6' ]; then
         method='sha-512'

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1292,12 +1292,6 @@ echo "[ * ] Enable SFTP jail..."
 $HESTIA/bin/v-add-sys-sftp-jail > /dev/null 2>&1
 check_result $? "can't enable sftp jail"
 
-# Switch to sha512 for deb11.
-if [ "$release" -eq 11 ]; then
-    # Switching to sha512
-    sed -i "s/ yescrypt/ sha512/g" /etc/pam.d/common-password
-fi
-
 # Adding Hestia admin account
 $HESTIA/bin/v-add-user admin $vpass $email "system" "System Administrator"
 check_result $? "can't create admin user"

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -134,7 +134,7 @@ function authenticate_user($user, $password, $twofa = '')
                 $fp = fopen($v_password, "w");
                 fwrite($fp, $_POST['password']."\n");
                 fclose($fp);
-                exec(HESTIA_CMD . 'v-check-user-password '. $v_user.' '. $v_password, $output, $return_var);
+                exec(HESTIA_CMD . 'v-check-user-password '. $v_user.' '. $v_password, ' '.$v_ip.' yes', $output, $return_var);
                 $hash = $output[0];
                 unset($output);
             }

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -134,7 +134,7 @@ function authenticate_user($user, $password, $twofa = '')
                 $fp = fopen($v_password, "w");
                 fwrite($fp, $_POST['password']."\n");
                 fclose($fp);
-                exec(HESTIA_CMD . 'v-check-user-password '. $v_user.' '. $v_password, ' '.$v_ip.' yes', $output, $return_var);
+                exec(HESTIA_CMD . 'v-check-user-password '. $v_user.' '. $v_password. ' '.$v_ip.' yes', $output, $return_var);
                 $hash = $output[0];
                 unset($output);
             }


### PR DESCRIPTION
Default encryption method used for Debian  and Ubuntu 22.04 is / will be come yescrypt. Currently Hestia doesn't support it.

Changes suggested add support for login with yescrypt  encoded hash. 

As PHP 8.1 doesn't support yescrypt yet verifcation is build  mkpasswd $password $shadow if the password matches hash is returnedn an used for v-check-user hash 

When PHP add it in the future hopefully we can use php crypt function again

Note: This feature will break import from Debian 11 and Ubuntu 22.04 to older versions. Users are required to use v-change-user-password again to use sha512 hashes