### PR TITLE
Restart mail v-update-lets-encrypt-ssl

### DIFF
--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -176,6 +176,9 @@ for user in $($HESTIA/bin/v-list-sys-users plain); do
 done
 
 $HESTIA/bin/v-restart-web yes
+
+$HESTIA/bin/v-restart-mail yes
+
 if [ -n "$PROXY_SYSTEM" ]; then
     $HESTIA/bin/v-restart-proxy yes
 fi

--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -175,8 +175,8 @@ for user in $($HESTIA/bin/v-list-sys-users plain); do
 
 done
 
+# Restart related services
 $HESTIA/bin/v-restart-web yes
-
 $HESTIA/bin/v-restart-mail yes
 
 if [ -n "$PROXY_SYSTEM" ]; then


### PR DESCRIPTION
Changes in https://github.com/hestiacp/hestiacp/blob/6860594c732179e4118c3a8603400c2b4acf0f65/bin/v-add-letsencrypt-domain#L514

caused mail not be restarted after v-update-letsencrypt ran. 

Add restart after completion will solve the issue

To be picked for intermediate release
