### PR TITLE
Fix incomming mail rate limit Deb 11 / Ubuntu 22.04

### DIFF
--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -37,6 +37,8 @@ fi
 
 format_domain
 format_domain_idn
+
+
 #----------------------------------------------------------#
 #                    Verifications                         #
 #----------------------------------------------------------#
@@ -57,6 +59,7 @@ is_password_valid
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
+
 
 #----------------------------------------------------------#
 #                       Action                             #
@@ -86,6 +89,7 @@ fi
  mkdir $HOMEDIR/$user/mail/$domain/$account
  chown $user:mail $HOMEDIR/$user/mail/$domain/$account
  chmod 700 $HOMEDIR/$user/mail/$domain/$account
+
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -18,9 +18,6 @@ account=$3
 password=$4; HIDE=4
 quota=${5-unlimited}
 
-format_domain
-format_domain_idn
-
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf
@@ -38,6 +35,8 @@ if [[ "$account" =~ [[:upper:]] ]]; then
     account=$(echo "$account" |tr '[:upper:]' '[:lower:]')
 fi
 
+format_domain
+format_domain_idn
 #----------------------------------------------------------#
 #                    Verifications                         #
 #----------------------------------------------------------#

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -109,6 +109,10 @@ chmod 660 $USER_DATA/mail/$domain.conf
 syshealth_repair_mail_account_config
 
 user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT')
+if [ ! -f "$HOMEDIR/$user/conf/mail/$domain/limits" ]; then 
+    touch $HOMEDIR/$user/conf/mail/$domain/limits
+fi 
+touch $HOMEDIR/$user/conf/mail/$domain/limits;
 if [ -n "$user_rate_limit" ]; then
     sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
     echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -13,9 +13,13 @@
 # Argument definition
 user=$1
 domain=$2
+domain_idn=$2
 account=$3
 password=$4; HIDE=4
 quota=${5-unlimited}
+
+format_domain
+format_domain_idn
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -108,11 +112,11 @@ syshealth_repair_mail_account_config
 user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT')
 if [ -n "$user_rate_limit" ]; then
     sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-    echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+    echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits
 else
     system=$(cat /etc/exim4/limit.conf)
     sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-    echo "$account@$domain_idn:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
+    echo "$account@$domain_idn:$system" >> $HOMEDIR/$user/conf/mail/$domain/limits
 fi
 
 # Increase mail accounts counter

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -108,11 +108,9 @@ chmod 660 $USER_DATA/mail/$domain.conf
 
 syshealth_repair_mail_account_config
 
-user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT')
-if [ ! -f "$HOMEDIR/$user/conf/mail/$domain/limits" ]; then 
-    touch $HOMEDIR/$user/conf/mail/$domain/limits
-fi 
 touch $HOMEDIR/$user/conf/mail/$domain/limits;
+
+user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT')
 if [ -n "$user_rate_limit" ]; then
     sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
     echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -105,9 +105,14 @@ chmod 660 $USER_DATA/mail/$domain.conf
 
 syshealth_repair_mail_account_config
 
-user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT');
+user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT')
 if [ -n "$user_rate_limit" ]; then
-    echo "$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits/$account
+    sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+    echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+else
+    system=$(cat /etc/exim4/limit.conf)
+    sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+    echo "$account@$domain_idn:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
 fi
 
 # Increase mail accounts counter

--- a/bin/v-change-mail-account-rate-limit
+++ b/bin/v-change-mail-account-rate-limit
@@ -62,15 +62,15 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
         user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT');
         if [ -n "$user_rate_limit" ]; then
             sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-            echo "$account@$domain_id:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+            echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
         else
             system=$(cat /etc/exim4/limit.conf)
             sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-            echo "$account@$domain_id:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
+            echo "$account@$domain_idn:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
         fi
     else
         sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-        echo "$account@$domain_id:$rate" > $HOMEDIR/$user/conf/mail/$domain/limits
+        echo "$account@$domain_idn:$rate" > $HOMEDIR/$user/conf/mail/$domain/limits
     fi
 fi
 

--- a/bin/v-change-mail-account-rate-limit
+++ b/bin/v-change-mail-account-rate-limit
@@ -62,15 +62,15 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
         user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT');
         if [ -n "$user_rate_limit" ]; then
             sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-            echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+            echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits
         else
             system=$(cat /etc/exim4/limit.conf)
             sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-            echo "$account@$domain_idn:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
+            echo "$account@$domain_idn:$system" >> $HOMEDIR/$user/conf/mail/$domain/limits
         fi
     else
         sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-        echo "$account@$domain_idn:$rate" > $HOMEDIR/$user/conf/mail/$domain/limits
+        echo "$account@$domain_idn:$rate" >> $HOMEDIR/$user/conf/mail/$domain/limits
     fi
 fi
 

--- a/bin/v-change-mail-account-rate-limit
+++ b/bin/v-change-mail-account-rate-limit
@@ -58,18 +58,19 @@ check_hestia_demo_mode
 
 md5=$(get_object_value "mail/$domain" 'ACCOUNT' "$account" '$MD5')
 if [[ "$MAIL_SYSTEM" =~ exim ]]; then
-    if [ ! -d "$HOMEDIR/$user/conf/mail/$domain/limits/" ]; then
-        mkdir $HOMEDIR/$user/conf/mail/$domain/limits/
-    fi
     if [ "$rate" = "system" ]; then 
         user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT');
         if [ -n "$user_rate_limit" ]; then
-            echo "$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits/$account
+            sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+            echo "$account@$domain_id:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
         else
-            rm $HOMEDIR/$user/conf/mail/$domain/limits/$account
+            system=$(cat /etc/exim4/limit.conf)
+            sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+            echo "$account@$domain_id:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
         fi
     else
-        echo "$rate" > $HOMEDIR/$user/conf/mail/$domain/limits/$account
+        sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+        echo "$account@$domain_id:$rate" > $HOMEDIR/$user/conf/mail/$domain/limits
     fi
 fi
 

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -665,16 +665,16 @@ rebuild_mail_domain_conf() {
             if [ -n "$RATE_LIMIT" ]; then
                 #user value
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_id:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
             elif [ -n "$user_rate_limit" ]; then
                 #revert to account value
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_id:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
             else
                 #revert to system value
                 system=$(cat /etc/exim4/limits.conf)
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_id:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
             fi
         fi
     done

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -665,16 +665,16 @@ rebuild_mail_domain_conf() {
             if [ -n "$RATE_LIMIT" ]; then
                 #user value
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits
             elif [ -n "$user_rate_limit" ]; then
                 #revert to account value
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_idn:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits
             else
                 #revert to system value
                 system=$(cat /etc/exim4/limits.conf)
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_idn:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$system" >> $HOMEDIR/$user/conf/mail/$domain/limits
             fi
         fi
     done

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -665,14 +665,14 @@ rebuild_mail_domain_conf() {
             if [ -n "$RATE_LIMIT" ]; then
                 #user value
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
-                echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_idn:$RATE_LIMIT" >> $HOMEDIR/$user/conf/mail/$domain/limits
             elif [ -n "$user_rate_limit" ]; then
                 #revert to account value
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
                 echo "$account@$domain_idn:$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits
             else
                 #revert to system value
-                system=$(cat /etc/exim4/limits.conf)
+                system=$(cat /etc/exim4/limit.conf)
                 sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
                 echo "$account@$domain_idn:$system" >> $HOMEDIR/$user/conf/mail/$domain/limits
             fi

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -571,12 +571,12 @@ rebuild_mail_domain_conf() {
         rm -f $HOMEDIR/$user/conf/mail/$domain/passwd
         rm -f $HOMEDIR/$user/conf/mail/$domain/fwd_only
         rm -f $HOMEDIR/$user/conf/mail/$domain/ip
-        rm -fr $HOMEDIR/$user/conf/mail/$domain/limits/
+        rm -fr $HOMEDIR/$user/conf/mail/$domain/limits
         touch $HOMEDIR/$user/conf/mail/$domain/accounts
         touch $HOMEDIR/$user/conf/mail/$domain/aliases
         touch $HOMEDIR/$user/conf/mail/$domain/passwd
         touch $HOMEDIR/$user/conf/mail/$domain/fwd_only
-        mkdir $HOMEDIR/$user/conf/mail/$domain/limits/
+        touch $HOMEDIR/$user/conf/mail/$domain/limits
         
         # Setting outgoing ip address
         if [ -n "$local_ip" ]; then
@@ -664,10 +664,17 @@ rebuild_mail_domain_conf() {
             user_rate_limit=$(get_object_value 'mail' 'DOMAIN' "$domain" '$RATE_LIMIT');
             if [ -n "$RATE_LIMIT" ]; then
                 #user value
-                echo "$RATE_LIMIT" >> $HOMEDIR/$user/conf/mail/$domain/limits/$account
+                sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_id:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
             elif [ -n "$user_rate_limit" ]; then
-                #revert to user value
-                echo "$user_rate_limit" >> $HOMEDIR/$user/conf/mail/$domain/limits/$account
+                #revert to account value
+                sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_id:$user_rate_limit" > $HOMEDIR/$user/conf/mail/$domain/limits
+            else
+                #revert to system value
+                system=$(cat /etc/exim4/limits.conf)
+                sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
+                echo "$account@$domain_id:$system" > $HOMEDIR/$user/conf/mail/$domain/limits
             fi
         fi
     done

--- a/install/deb/exim/exim4.conf.4.94.template
+++ b/install/deb/exim/exim4.conf.4.94.template
@@ -133,7 +133,7 @@ acl_check_rcpt:
 
 # Limit per email account for SMTP auhenticated users
   deny    message       = Email account $authenticated_id is sending too many emails - rate overlimit = $sender_rate / $sender_rate_period
-          set acl_c_msg_limit = ${if exists{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits/${extract{1}{:}{${lookup{$sender_address_local_part}lsearch{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/accounts}}}}} {${readfile{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits/${extract{1}{:}{${lookup{$sender_address_local_part}lsearch{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/accounts}}}}}}} {${readfile{/etc/exim4/limit.conf}}} }
+          set acl_c_msg_limit = ${if exists{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits} {${extract{1}{:}{${lookup{$sender_address_local_part@$sender_address_domain}lsearch{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits}}}}} {${readfile{/etc/exim4/limit.conf}}} }
           ratelimit     = $acl_c_msg_limit / 1h / strict/ $authenticated_id
   
   warn    ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -134,6 +134,7 @@ acl_check_rcpt:
 # Limit per email account for SMTP auhenticated users
   deny    message       = Email account $authenticated_id is sending too many emails - rate overlimit = $sender_rate / $sender_rate_period
           set acl_c_msg_limit = ${if exists{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits} {${extract{1}{:}{${lookup{$sender_address_local_part@$sender_address_domain}lsearch{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits}}}}} {${readfile{/etc/exim4/limit.conf}}} }
+          ratelimit     = $acl_c_msg_limit / 1h / strict/ $authenticated_id
 
   warn    ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id
           log_message           = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -133,8 +133,7 @@ acl_check_rcpt:
 
 # Limit per email account for SMTP auhenticated users
   deny    message       = Email account $authenticated_id is sending too many emails - rate overlimit = $sender_rate / $sender_rate_period
-          set acl_c_msg_limit = ${if exists{/etc/exim4/domains/$sender_address_domain/limits/$sender_address_local_part} {${readfile{/etc/exim4/domains/$sender_address_domain/limits/$sender_address_local_part}}} {${readfile{/etc/exim4/limit.conf}}} }
-          ratelimit     = $acl_c_msg_limit / 1h / strict/ $authenticated_id
+          set acl_c_msg_limit = ${if exists{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits} {${extract{1}{:}{${lookup{$sender_address_local_part@$sender_address_domain}lsearch{/etc/exim4/domains/${lookup{$sender_address_domain}dsearch{/etc/exim4/domains/}}/limits}}}}} {${readfile{/etc/exim4/limit.conf}}} }
 
   warn    ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id
           log_message           = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period

--- a/install/upgrade/versions/1.6.0.sh
+++ b/install/upgrade/versions/1.6.0.sh
@@ -24,7 +24,7 @@ upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 if [ "$MAIL_SYSTEM" = "exim4" ]; then 
     echo "[ * ] Update exim4 config to support rate limits"
     # Upgrade config exim for custom limits
-    sed -i '115,250 s/ratelimit             = 200 \/ 1h \/ $authenticated_id/          set acl_c_msg_limit = \${if exists{\/etc\/exim4\/domains\/\${lookup{\$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits} {\${extract{1}{:}{\${lookup{\$sender_address_local_part@\$sender_address_domain}lsearch{\/etc\/exim4\/domains\/\${lookup{\$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits}}}}} {\${readfile{\/etc\/exim4\/limit.conf}}} }/g' /etc/exim4/exim4.conf.template
+    sed -i '115,250 s/ratelimit             = 200 \/ 1h \/ $authenticated_id/          set acl_c_msg_limit = \${if exists{\/etc\/exim4\/domains\/\${lookup{\$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits} {\${extract{1}{:}{\${lookup{\$sender_address_local_part@\$sender_address_domain}lsearch{\/etc\/exim4\/domains\/\${lookup{\$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits}}}}} {\${readfile{\/etc\/exim4\/limit.conf}}} }\n ratelimit     = \$acl_c_msg_limit \/ 1h \/ strict\/ \$authenticated_idy/g' /etc/exim4/exim4.conf.template
     sed -i '115,250 s/warn    ratelimit     = 100 \/ 1h \/ strict \/ $authenticated_id/warn    ratelimit     = ${eval:$acl_c_msg_limit \/ 2} \/ 1h \/ strict \/ $authenticated_id/g' /etc/exim4/exim4.conf.template
     # Add missing limit.conf file
     cp $HESTIA_INSTALL_DIR/exim/limit.conf /etc/exim4/limit.conf

--- a/install/upgrade/versions/1.6.0.sh
+++ b/install/upgrade/versions/1.6.0.sh
@@ -24,17 +24,8 @@ upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 if [ "$MAIL_SYSTEM" = "exim4" ]; then 
     echo "[ * ] Update exim4 config to support rate limits"
     # Upgrade config exim for custom limits
-    
-    exim_version=$(exim4 --version |  head -1 | awk  '{print $3}' | cut -f -2 -d .);
-    if [ "$exim_version" = "4.94" ] || [ "$exim_version" = "4.95" ]; then
-        #For Debian 11 and Ubuntu 22.04 
-        sed -i '115,250 s/ratelimit             = 200 \/ 1h \/ $authenticated_id/          set acl_c_msg_limit = ${if exists{\/etc\/exim4\/domains\/${lookup{$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits\/${extract{1}{:}{${lookup{$sender_address_local_part}lsearch{\/etc\/exim4\/domains\/${lookup{$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/accounts}}}}} {${readfile{\/etc\/exim4\/domains\/${lookup{$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits\/${extract{1}{:}{${lookup{$sender_address_local_part}lsearch{\/etc\/exim4\/domains\/${lookup{$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/accounts}}}}}}} {${readfile{\/etc\/exim4\/limit.conf}}} } \n  ratelimit     = $acl_c_msg_limit \/ 1h \/ strict\/ $authenticated_id/g' /etc/exim4/exim4.conf.template
-        sed -i '115,250 s/warn    ratelimit     = 100 \/ 1h \/ strict \/ $authenticated_id/warn    ratelimit     = ${eval:$acl_c_msg_limit \/ 2} \/ 1h \/ strict \/ $authenticated_id/g' /etc/exim4/exim4.conf.template
-    else
-        # And the other 
-        sed -i '115,250 s/ratelimit             = 200 \/ 1h \/ $authenticated_id/ set acl_c_msg_limit = ${if exists{\/etc\/exim4\/domains\/$sender_address_domain\/limits\/$sender_address} {${readfile{\/etc\/exim4\/domains\/$sender_address_domain\/limits\/$sender_address_local_part}}} {${readfile{\/etc\/exim4\/limit.conf}}} } \n ratelimit     = $acl_c_msg_limit \/ 1h \/ strict\/ $authenticated_id/g' /etc/exim4/exim4.conf.template
-        sed -i '115,250 s/warn    ratelimit     = 100 \/ 1h \/ strict \/ $authenticated_id/warn    ratelimit     = ${eval:$acl_c_msg_limit \/ 2} \/ 1h \/ strict \/ $authenticated_id/g' /etc/exim4/exim4.conf.template
-    fi
+    sed -i '115,250 s/ratelimit             = 200 \/ 1h \/ $authenticated_id/          set acl_c_msg_limit = \${if exists{\/etc\/exim4\/domains\/\${lookup{\$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits} {\${extract{1}{:}{\${lookup{\$sender_address_local_part@\$sender_address_domain}lsearch{\/etc\/exim4\/domains\/\${lookup{\$sender_address_domain}dsearch{\/etc\/exim4\/domains\/}}\/limits}}}}} {\${readfile{\/etc\/exim4\/limit.conf}}} }/g' /etc/exim4/exim4.conf.template
+    sed -i '115,250 s/warn    ratelimit     = 100 \/ 1h \/ strict \/ $authenticated_id/warn    ratelimit     = ${eval:$acl_c_msg_limit \/ 2} \/ 1h \/ strict \/ $authenticated_id/g' /etc/exim4/exim4.conf.template
     # Add missing limit.conf file
     cp $HESTIA_INSTALL_DIR/exim/limit.conf /etc/exim4/limit.conf
 fi


### PR DESCRIPTION
Look up if a email exists broke when incoming mail was received send address was not found causing to fail the receiving of mail!
