### PR TITLE
Set FORWARD chain default policy to DROP

### DIFF
--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -133,8 +133,11 @@ for line in $(sort -r -n -k 2 -t \' $rules); do
     fi
 done
 
-# Switching chain policy to DROP
+# Switching INPUT chain policy to DROP
 echo "$iptables -P INPUT DROP" >> $tmp
+
+# Switching FORWARD chain policy to DROP
+echo "$iptables -P FORWARD DROP" >> $tmp
 
 # Adding hestia chain
 echo "$iptables -N hestia" >> $tmp


### PR DESCRIPTION
In iptables, the FORWARD chain is used for packets passing THROUGH it, meaning,  packets not addressed to or originating from the local machine. With the FORWARD default policy set to ACCEPT, all traffic between networks that are connected to the local machine is allowed, essentially turning it into a router.

If the machine only has one interface, this won't be much of a problem. However, say you hooked it up to a VPN for remote management access. This could allow a host that's located on the VPN side to use the local machine as a gateway to access networks that the local machine is connected to. For this to work the local machine would have to have IP forwarding enabled (sysctl → net.ipv4.ip_forward = 1) which on most platforms isn't the case by default. Even though, it's a sensible thing to set the default policy of the FORWARD chain to DROP.