### PR TITLE
Validate email/hostname non interactive install

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -609,14 +609,14 @@ fi
 # Asking for contact email
 if [ -z "$email" ]; then
     while validate_email; do
-    echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
-    read -p 'Please enter admin email address: ' email
+        echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
+        read -p 'Please enter admin email address: ' email
     done
 else
-  if validate_email; then
-  echo "Please use a valid emailadress (ex. info@domain.tld)."
-  exit 1
-  fi
+    if validate_email; then
+        echo "Please use a valid emailadress (ex. info@domain.tld)."
+        exit 1
+    fi
 fi
 
 # Asking to set FQDN hostname

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -603,41 +603,42 @@ if [ "$interactive" = 'yes' ]; then
         echo 'Goodbye'
         exit 1
     fi
+fi
 
-    # Asking for contact email
-    if [ -z "$email" ]; then
-        while validate_email; do
-        echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
-        read -p 'Please enter admin email address: ' email
-        done
-    else
-      if validate_email; then
-      echo "Please use a valid emailadress (ex. info@domain.tld)."
-      exit 1
-      fi
+# Validate Email / Hostname even when interactive = no 
+# Asking for contact email
+if [ -z "$email" ]; then
+    while validate_email; do
+    echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
+    read -p 'Please enter admin email address: ' email
+    done
+else
+  if validate_email; then
+  echo "Please use a valid emailadress (ex. info@domain.tld)."
+  exit 1
+  fi
+fi
+
+# Asking to set FQDN hostname
+if [ -z "$servername" ]; then
+    # Ask and validate FQDN hostname.
+    read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
+
+    # Set hostname if it wasn't set
+    if [ -z "$servername" ]; then
+        servername=$(hostname -f)
     fi
 
-    # Asking to set FQDN hostname
-    if [ -z "$servername" ]; then
-        # Ask and validate FQDN hostname.
+    # Validate Hostname, go to loop if the validation fails.
+    while validate_hostname; do
+        echo -e "\nPlease use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
         read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
-
-        # Set hostname if it wasn't set
-        if [ -z "$servername" ]; then
-            servername=$(hostname -f)
-        fi
-
-        # Validate Hostname, go to loop if the validation fails.
-        while validate_hostname; do
-            echo -e "\nPlease use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
-            read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
-        done
-    else
-        # Validate FQDN hostname if it is preset
-        if validate_hostname; then
-            echo "Please use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
-            exit 1
-        fi
+    done
+else
+    # Validate FQDN hostname if it is preset
+    if validate_hostname; then
+        echo "Please use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
+        exit 1
     fi
 fi
 
@@ -1887,6 +1888,20 @@ if [ "$sieve" = 'yes' ]; then
 fi
 
 #----------------------------------------------------------#
+#                  Configure File Manager                  #
+#----------------------------------------------------------#
+
+echo "[ * ] Configuring File Manager..."
+$HESTIA/bin/v-add-sys-filemanager quiet
+
+#----------------------------------------------------------#
+#                  Configure PHPMailer                     #
+#----------------------------------------------------------#
+
+echo "[ * ] Configuring PHPMailer..."
+$HESTIA/bin/v-add-sys-phpmailer quiet
+
+#----------------------------------------------------------#
 #                       Configure API                      #
 #----------------------------------------------------------#
 
@@ -2022,12 +2037,6 @@ chmod 755 /backup/
 # create cronjob to generate ssl 
 echo "@reboot root sleep 10 && rm /etc/cron.d/hestia-ssl && PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:' && /usr/local/hestia/bin/v-add-letsencrypt-host" > /etc/cron.d/hestia-ssl
 
-#----------------------------------------------------------#
-#                  Configure File Manager                  #
-#----------------------------------------------------------#
-
-echo "[ * ] Configuring File Manager..."
-$HESTIA/bin/v-add-sys-filemanager quiet
 
 #----------------------------------------------------------#
 #              Set hestia.conf default values              #
@@ -2058,12 +2067,6 @@ write_config_value "SERVER_SMTP_PASSWD" ""
 write_config_value "SERVER_SMTP_ADDR" ""
 write_config_value "POLICY_CSRF_STRICTNESS" "1"
 
-#----------------------------------------------------------#
-#                  Configure PHPMailer                     #
-#----------------------------------------------------------#
-
-echo "[ * ] Configuring PHPMailer..."
-$HESTIA/bin/v-add-sys-phpmailer quiet
 
 #----------------------------------------------------------#
 #                   Hestia Access Info                     #

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -575,43 +575,44 @@ if [ "$interactive" = 'yes' ]; then
         echo 'Goodbye'
         exit 1
     fi
+fi
 
-  # Asking for contact email
-  if [ -z "$email" ]; then
-      while validate_email; do
-      echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
-      read -p 'Please enter admin email address: ' email
+# Validate Email / Hostname even when interactive = no 
+# Asking for contact email
+if [ -z "$email" ]; then
+    while validate_email; do
+    echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
+    read -p 'Please enter admin email address: ' email
+    done
+else
+  if validate_email; then
+  echo "Please use a valid emailadress (ex. info@domain.tld)."
+  exit 1
+  fi
+fi
+
+  # Asking to set FQDN hostname
+  if [ -z "$servername" ]; then
+      # Ask and validate FQDN hostname.
+      read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
+
+      # Set hostname if it wasn't set
+      if [ -z "$servername" ]; then
+          servername=$(hostname -f)
+      fi
+
+      # Validate Hostname, go to loop if the validation fails.
+      while validate_hostname; do
+          echo -e "\nPlease use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
+          read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
       done
   else
-    if validate_email; then
-    echo "Please use a valid emailadress (ex. info@domain.tld)."
-    exit 1
-    fi
+      # Validate FQDN hostname if it is preset
+      if validate_hostname; then
+          echo "Please use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
+          exit 1
+      fi
   fi
-  
-    # Asking to set FQDN hostname
-    if [ -z "$servername" ]; then
-        # Ask and validate FQDN hostname.
-        read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
-
-        # Set hostname if it wasn't set
-        if [ -z "$servername" ]; then
-            servername=$(hostname -f)
-        fi
-
-        # Validate Hostname, go to loop if the validation fails.
-        while validate_hostname; do
-            echo -e "\nPlease use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
-            read -p "Please enter FQDN hostname [$(hostname -f)]: " servername
-        done
-    else
-        # Validate FQDN hostname if it is preset
-        if validate_hostname; then
-            echo "Please use a valid hostname according to RFC1178 (ex. hostname.domain.tld)."
-            exit 1
-        fi
-    fi
-fi
 
 # Generating admin password if it wasn't set
 if [ -z "$vpass" ]; then
@@ -1910,6 +1911,20 @@ else
     $HESTIA/bin/v-change-sys-api disable
 fi
 
+#----------------------------------------------------------#
+#                  Configure File Manager                  #
+#----------------------------------------------------------#
+
+echo "[ * ] Configuring File Manager..."
+$HESTIA/bin/v-add-sys-filemanager quiet
+
+#----------------------------------------------------------#
+#                  Configure PHPMailer                     #
+#----------------------------------------------------------#
+
+echo "[ * ] Configuring PHPMailer..."
+$HESTIA/bin/v-add-sys-phpmailer quiet
+
 
 #----------------------------------------------------------#
 #                   Configure IP                           #
@@ -2049,13 +2064,6 @@ chmod 755 /backup/
 echo "@reboot root sleep 10 && rm /etc/cron.d/hestia-ssl && PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:' && /usr/local/hestia/bin/v-add-letsencrypt-host" > /etc/cron.d/hestia-ssl
 
 #----------------------------------------------------------#
-#                  Configure File Manager                  #
-#----------------------------------------------------------#
-
-echo "[ * ] Configuring File Manager..."
-$HESTIA/bin/v-add-sys-filemanager quiet
-
-#----------------------------------------------------------#
 #              Set hestia.conf default values              #
 #----------------------------------------------------------#
 
@@ -2083,13 +2091,6 @@ write_config_value "SERVER_SMTP_USER" ""
 write_config_value "SERVER_SMTP_PASSWD" ""
 write_config_value "SERVER_SMTP_ADDR" ""
 write_config_value "POLICY_CSRF_STRICTNESS" "1"
-
-#----------------------------------------------------------#
-#                  Configure PHPMailer                     #
-#----------------------------------------------------------#
-
-echo "[ * ] Configuring PHPMailer..."
-$HESTIA/bin/v-add-sys-phpmailer quiet
 
 #----------------------------------------------------------#
 #                   Hestia Access Info                     #

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -581,14 +581,14 @@ fi
 # Asking for contact email
 if [ -z "$email" ]; then
     while validate_email; do
-    echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
-    read -p 'Please enter admin email address: ' email
+        echo -e "\nPlease use a valid emailadress (ex. info@domain.tld)."
+        read -p 'Please enter admin email address: ' email
     done
 else
-  if validate_email; then
-  echo "Please use a valid emailadress (ex. info@domain.tld)."
-  exit 1
-  fi
+    if validate_email; then
+      echo "Please use a valid emailadress (ex. info@domain.tld)."
+      exit 1
+    fi
 fi
 
   # Asking to set FQDN hostname


### PR DESCRIPTION
+ Move FM / PHPMailer to an earlier step to prevent mail system failure when Nginx / Apache2 doesn't restart due to invalid hostname / usage of ip instead hostname and so on. 
