### PR TITLE
Add detection of MariaDB 10.7

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -244,7 +244,7 @@ if [ -n "$DB_SYSTEM" ] && [ "$DB_SYSTEM" != 'remote' ]; then
                 fi
                 if [ -f /usr/bin/mysql ]; then
                     mariadb_v=`mysql -V | awk 'NR==1{print $5}' | head -c 4`
-                    if [ $mariadb_v = "10.5" ] || [ $mariadb_v = "10.6" ]; then
+                    if [ $mariadb_v = "10.5" ] || [ $mariadb_v = "10.6" ] || [ $mariadb_v = "10.7" ]; then
                         service='mariadb'
                         proc_name='mariadbd'
                     fi


### PR DESCRIPTION
I have updated all my servers to 10.7. MariaDB 10.7 works fine so far without errors; the DBs are created via the webpanel.

The only problem is that on the services overview, MariaDB 10.7 is not recognized.

This commit fixes the problem.