### PR TITLE
Allows wp package install with correct path

### DIFF
--- a/bin/v-add-user-wp-cli
+++ b/bin/v-add-user-wp-cli
@@ -40,7 +40,7 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-WPCLI_DIR="/home/$user/.wp"
+WPCLI_DIR="/home/$user/.wp-cli"
 WPCLI_BIN="$WPCLI_DIR/wp"
 
 if [ -f "$WPCLI_DIR" ]; then


### PR DESCRIPTION
with /.wp folder the wp package install or  wp package list command get Permission error because wp-cli searches for wp-cli folder.