### PR TITLE
Check if netplan file is created

### DIFF
--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -75,13 +75,8 @@ if [ -z "$sys_ip_check" ]; then
         broadcast $broadcast label $iface
     
     # Check if netplan is in use and generate configuration file
-    if dpkg-query -W -f'${Status}' "netplan*" 2>/dev/null | grep -q "ok installed"; then 
-        result=$(cat /etc/netplan/*.yaml 2>/dev/null | grep $(hostname -I | cut -d' ' -f1));
-        if [ -n "$result" ]; then 
-            netplan=1
-        else
-            netplan=0
-        fi
+    if [ -n $(netplan generate --mapping $iface | grep networkd) ]; then
+        netplan=1
     else
         netplan=0
     fi

--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -76,7 +76,7 @@ if [ -z "$sys_ip_check" ]; then
     
     # Check if netplan is in use and generate configuration file
     if [ ! -z $(which netplan) ]; then 
-        if [ ! -z $(netplan generate --mapping "$iface" | grep networkd) ]; then   
+        if  [ ! -z "$(netplan generate --mapping "$iface" | grep networkd)" ]; then   
             netplan=1
         else
             netplan=0

--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -75,7 +75,7 @@ if [ -z "$sys_ip_check" ]; then
         broadcast $broadcast label $iface
     
     # Check if netplan is in use and generate configuration file
-    if [ -n $(netplan generate --mapping $iface | grep networkd) ]; then
+    if [ ! -z $(netplan generate --mapping "$iface" | grep networkd) ]; then
         netplan=1
     else
         netplan=0

--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -75,8 +75,12 @@ if [ -z "$sys_ip_check" ]; then
         broadcast $broadcast label $iface
     
     # Check if netplan is in use and generate configuration file
-    if [ ! -z $(netplan generate --mapping "$iface" | grep networkd) ]; then
-        netplan=1
+    if [ ! -z $(which netplan) ]; then 
+        if [ ! -z $(netplan generate --mapping "$iface" | grep networkd) ]; then   
+            netplan=1
+        else
+            netplan=0
+        fi
     else
         netplan=0
     fi

--- a/install/upgrade/versions/1.6.0.sh
+++ b/install/upgrade/versions/1.6.0.sh
@@ -94,3 +94,12 @@ if [ -f "/etc/cron.d/hestia-sftp" ]; then
     rm /etc/cron.d/hestia-sftp
     echo "@reboot root sleep 60 && /usr/local/hestia/bin/v-add-sys-sftp-jail > /dev/null" > /etc/cron.d/hestia-sftp
 fi
+
+ips=$(ls /usr/local/hestia/data/ips/ | wc -l)
+release=$(lsb_release -s -i);
+if [ $release = 'Ubuntu' ]; then 
+    if [ $ips -gt 1 ]; then
+        add_upgrade_message "Warning: Please check your network configuration!\n\n A bug has been discovered that might affect your setup and can lead to issues after a system reboot. Please review your network configuration. See https://github.com/hestiacp/hestiacp/pull/2612#issuecomment-1135571835 for more info regarding this issue!"
+        $HESTIA/bin/v-add-user-notification admin "Warning: Please check your network configuration!\n\n A bug has been discovered that might affect your setup and can lead to issues after a system reboot. Please review your network configuration. <a href='https://github.com/hestiacp/hestiacp/pull/2612#issuecomment-1135571835'>More info</a>"
+    fi
+fi

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -36,6 +36,11 @@ for file in $files; do
     fi
 done
 
+if [ $err == 1 ];
+then 
+exit "$err";
+fi
+
 for file in $files; do 
     echo "Linting: $file"
     shellcheck -x "$file" -e "SC2086,SC2002,SC2153,SC2181,SC2153,SC2129,SC2016,SC2196,SC1090,SC2031,SC2010,SC2143,SC2046" 

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -31,9 +31,14 @@ for file in $files; do
        printf "%s: \033[0;31m Fail \033[0m\n" "$file"
        err=1
     else 
+        # split loop in 2 parts allowing debuggin in earier stage
        printf "%s: \033[0;32m Success \033[0m\n" "$file"
-        shellcheck -x "$file" -e "SC2086,SC2002,SC2153,SC2181,SC2153,SC2129,SC2016,SC2196,SC1090,SC2031,SC2010,SC2143,SC2046" 
     fi
+done
+
+for file in $files; do 
+    echo "Linting: $file"
+    shellcheck -x "$file" -e "SC2086,SC2002,SC2153,SC2181,SC2153,SC2129,SC2016,SC2196,SC1090,SC2031,SC2010,SC2143,SC2046" 
 done
 
 exit "$err";

--- a/test/test.bats
+++ b/test/test.bats
@@ -581,7 +581,17 @@ function check_ip_not_banned(){
         [ -f "$a2_rpaf" ] && assert_file_contains "$a2_rpaf" "RPAFproxy_ips.*$ip\b"
         [ -f "$a2_remoteip" ] && assert_file_contains "$a2_remoteip" "RemoteIPInternalProxy $ip\$"
     fi
+    
+}
 
+@test "Ip: [Ubuntu] Netplan file updated" {
+   # Skip if Debian
+   if [ $(lsb_release -s -i) != "Ubuntu" ]; then
+   skip
+   fi
+   
+   assert_file_exist /etc/netplan/60-hestia.yaml
+   assert_file_contains /etc/netplan/60-hestia.yaml "$ip"
 }
 
 @test "Ip: Add ip (duplicate)" {

--- a/test/test.bats
+++ b/test/test.bats
@@ -590,8 +590,22 @@ function check_ip_not_banned(){
    skip
    fi
    
+   # Test will fail if systemd (For example Proxmox) is used for setting ip addresses. How ever there is no "decent" way to check if Netplan is used except via the method used in v-add-sys-ip and there for breaking the reason to test this. How ever if the test used in v-add-sys-ip fails it still should check if it exists!
+  
    assert_file_exist /etc/netplan/60-hestia.yaml
+   
+   # also check if file contains the newly added ip
    assert_file_contains /etc/netplan/60-hestia.yaml "$ip"
+}
+
+@test "Ip: [Ubuntu] Netplan file updated" {
+   # Skip with netplan
+   if [ -f /etc/netplan/60-hestia.yaml ]; then
+   skip
+   fi
+   
+   assert_file_exist /etc/networking/interfaces
+   assert_file_contains /etc/networking/interfaces "$ip"
 }
 
 @test "Ip: Add ip (duplicate)" {

--- a/test/test.bats
+++ b/test/test.bats
@@ -598,7 +598,7 @@ function check_ip_not_banned(){
    assert_file_contains /etc/netplan/60-hestia.yaml "$ip"
 }
 
-@test "Ip: [Ubuntu] Netplan file updated" {
+@test "Ip: [Debian] Netplan file updated" {
    # Skip with netplan
    if [ -f /etc/netplan/60-hestia.yaml ]; then
    skip

--- a/test/test.bats
+++ b/test/test.bats
@@ -604,8 +604,8 @@ function check_ip_not_banned(){
    skip
    fi
    
-   assert_file_exist /etc/networking/interfaces
-   assert_file_contains /etc/networking/interfaces "$ip"
+   assert_file_exist  /etc/network/interfaces
+   assert_file_contains  /etc/network/interfaces "$ip"
 }
 
 @test "Ip: Add ip (duplicate)" {


### PR DESCRIPTION
Bug in v-add-sys-ip caused Ip address written to /etc/network/interfaces instead of 60-hestia.yaml when netplan was enabled 

dpkg-query -W -f'${Status}' "netplan*" did not return installed or not causing the system to fail 

Proposed changes:

1. Check if netplan exists via which netplan  if nothing returns  
2. Run netplan generate --manage ip adress 

To check if netplan is active