### PR TITLE
FTP Download path corrected

### DIFF
--- a/func/backup.sh
+++ b/func/backup.sh
@@ -172,6 +172,7 @@ ftp_download() {
     if [ -z "$PORT" ]; then
         PORT='21'
     fi
+    cd $BACKUP
     if [ -z $BPATH ]; then
         ftpc "get $1"
     else


### PR DESCRIPTION
ftp_download() path corrected to be the same as sftp_download() function