### PR TITLE
Improve logging for services

### DIFF
--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -26,8 +26,10 @@ send_email_report() {
     nginx -t >> $tmpfile 2>&1
     service "$PROXY_SYSTEM" restart >> $tmpfile 2>&1
     cat "$tmpfile" |$SENDMAIL -s "$subj" "$email"
-    echo "[ $date | $PROXY_SYSTEM | PROXY ]"  >> /var/log/hestia/debug.log 2>&1
-    cat "$tmpfile" >> /var/log/hestia/debug.log 2>&1
+    if [ "$DEBUG_MODE" = "true" ]; then 
+        echo "[ $date | $PROXY_SYSTEM | PROXY ]"  >> /var/log/hestia/debug.log 2>&1
+        cat "$tmpfile" >> /var/log/hestia/debug.log 2>&1
+    fi
     rm -f $tmpfile
 }
 

--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -17,8 +17,9 @@ source /etc/hestiacp/hestia.conf
 source $HESTIA/func/main.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
-date=$(date +"%Y-%m-%d %H:%M:%S");
+
 send_email_report() {
+    date=$(date +"%Y-%m-%d %H:%M:%S");
     email=$(grep CONTACT $HESTIA/data/users/admin/user.conf)
     email=$(echo "$email" | cut -f 2 -d "'")
     tmpfile=$(mktemp)

--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -17,7 +17,7 @@ source /etc/hestiacp/hestia.conf
 source $HESTIA/func/main.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
-
+date=$(date +"%Y-%m-%d %H:%M:%S");
 send_email_report() {
     email=$(grep CONTACT $HESTIA/data/users/admin/user.conf)
     email=$(echo "$email" | cut -f 2 -d "'")
@@ -26,6 +26,8 @@ send_email_report() {
     nginx -t >> $tmpfile 2>&1
     service "$PROXY_SYSTEM" restart >> $tmpfile 2>&1
     cat "$tmpfile" |$SENDMAIL -s "$subj" "$email"
+    echo "[ $date | $PROXY_SYSTEM | PROXY ]"  >> /var/log/hestia/debug.log 2>&1
+    cat "$tmpfile" >> /var/log/hestia/debug.log 2>&1
     rm -f $tmpfile
 }
 
@@ -76,7 +78,12 @@ if [ -f "$HESTIA/web/inc/nginx_proxy" ]; then
     # Default behaviour
     
     # Preform an check if Nginx is valid as reload doesn't throw an error / exit
-    service $PROXY_SYSTEM configtest > /dev/null 2>&1
+    if [ "$DEBUG_MODE" = "true" ]; then 
+        echo "[ $date | $PROXY_SYSTEM ]"  >> /var/log/hestia/debug.log 2>&1
+        service $PROXY_SYSTEM configtest > /var/log/hestia/debug.log 2>&1
+    else
+        service $PROXY_SYSTEM configtest > /dev/null 2>&1
+    fi
     if [ $? -ne 0 ]; then
         send_email_report
         check_result "$E_RESTART" "$PROXY_SYSTEM restart failed"

--- a/bin/v-restart-proxy
+++ b/bin/v-restart-proxy
@@ -18,8 +18,9 @@ source $HESTIA/func/main.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 
+date=$(date +"%Y-%m-%d %H:%M:%S");
+
 send_email_report() {
-    date=$(date +"%Y-%m-%d %H:%M:%S");
     email=$(grep CONTACT $HESTIA/data/users/admin/user.conf)
     email=$(echo "$email" | cut -f 2 -d "'")
     tmpfile=$(mktemp)

--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -31,6 +31,12 @@ is_format_valid 'service' 'restart'
 #                       Action                             #
 #----------------------------------------------------------#
 
+log="/dev/null"
+if [ "$DEBUG_MODE" = "true" ]; then 
+    
+    log="/var/log/hestia/debug.log"
+fi
+
 # Multi-instance service restart request handling
 if [ "$service" = "php-fpm" ];then
     service_list=''
@@ -51,7 +57,7 @@ for service in $service_list; do
         $BIN/v-stop-firewall
         $BIN/v-update-firewall
     elif [ "$restart" = "ssl" ] && [ "$service" = "nginx" ]; then
-        service $service upgrade > /dev/null 2>&1
+        service $service upgrade >> $log 2>&1
     elif [ -z "$restart" -o "$restart" = "no" ] && [ \
             "$service" = "nginx" -o     \
             "$service" = "apache2" -o   \
@@ -73,8 +79,8 @@ for service in $service_list; do
             "$service" = "fail2ban" ]; then
         systemctl reload-or-restart "$service" > /dev/null 2>&1
     else
-        systemctl reset-failed "$service "> /dev/null 2>&1
-        systemctl restart "$service" > /dev/null 2>&1
+        systemctl reset-failed "$service" >> $log 2>&1
+        systemctl restart "$service" >> $log 2>&1
     fi
 
     # Check the result of the service restart and report whether it failed.

--- a/bin/v-restart-web
+++ b/bin/v-restart-web
@@ -18,6 +18,8 @@ source $HESTIA/func/main.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 
+date=$(date +"%Y-%m-%d %H:%M:%S");
+
 send_email_report() {
     email=$(grep CONTACT $HESTIA/data/users/admin/user.conf)
     email=$(echo "$email" | cut -f 2 -d "'")
@@ -26,10 +28,12 @@ send_email_report() {
     if [ "$WEB_SYSTEM" = "apache2" ]; then 
         apache2ctl configtest >> "$tmpfile" 2>&1
     else 
-        nginx -t >> $tmpfile 2>&1
+        service $WEB_SYSTEM configtest >> "$tmpfile" 2>&1
     fi
     service "$WEB_SYSTEM" restart >> "$tmpfile" 2>&1
     cat "$tmpfile" |$SENDMAIL -s "$subj"  "$email"
+    echo "[ $date | $WEB_SYSTEM | WEB ]"  >> /var/log/hestia/debug.log 2>&1
+    cat $tmpfile >> /var/log/hestia/debug.log 2>&1
     rm -f $tmpfile
 }
 
@@ -64,13 +68,23 @@ if [ $WEB_SYSTEM = 'nginx' ]; then
     if [ "$1" = "ssl" ]; then
         restart="ssl"
     fi
-    service $WEB_SYSTEM configtest > /dev/null 2>&1
+    if [ "$DEBUG_MODE" = "true" ]; then 
+        echo "[  $date | $WEB_SYSTEM | WEB ]"  >> /var/log/hestia/debug.log 2>&1
+        service $WEB_SYSTEM configtest >> /var/log/hestia/debug.log 2>&1
+    else
+        service $WEB_SYSTEM configtest > /dev/null 2>&1
+    fi
     if [ $? -ne 0 ]; then
         send_email_report
         check_result "$E_RESTART" "$WEB_SYSTEM restart failed"
     fi
 elif [ $WEB_SYSTEM = 'apache2' ]; then
-    apache2ctl configtest > /dev/null 2>&1
+    if [ "$DEBUG_MODE" = "true" ]; then 
+        echo "[  $date | $WEB_SYSTEM | WEB ]"  >> /var/log/hestia/debug.log 2>&1
+        apache2ctl configtest >> /var/log/hestia/debug.log 2>&1
+    else
+        apache2ctl configtest > /dev/null 2>&1
+    fi
     if [ $? -ne 0 ]; then
         send_email_report
         check_result "$E_RESTART" "$WEB_SYSTEM restart failed"

--- a/bin/v-restart-web
+++ b/bin/v-restart-web
@@ -32,8 +32,10 @@ send_email_report() {
     fi
     service "$WEB_SYSTEM" restart >> "$tmpfile" 2>&1
     cat "$tmpfile" |$SENDMAIL -s "$subj"  "$email"
-    echo "[ $date | $WEB_SYSTEM | WEB ]"  >> /var/log/hestia/debug.log 2>&1
-    cat $tmpfile >> /var/log/hestia/debug.log 2>&1
+    if [ "$DEBUG_MODE" = "true" ]; then 
+        echo "[ $date | $WEB_SYSTEM | WEB ]"  >> /var/log/hestia/debug.log 2>&1
+        cat $tmpfile >> /var/log/hestia/debug.log 2>&1
+    fi
     rm -f $tmpfile
 }
 


### PR DESCRIPTION
In current system we are in a block box if there is an issue with the configs. 

When DEBUG_MODE is enabled it will save the out put of 
- Config tests (Proxy and web) 
- Output of v-restart-services

Hopefully it will provide with some more information 
