### PR TITLE
Add system.filters to exim config for 4.94 and current installs

### DIFF
--- a/install/deb/exim/exim4.conf.4.94.template
+++ b/install/deb/exim/exim4.conf.4.94.template
@@ -82,6 +82,10 @@ SMTP_RELAY_PORT = ${lookup{port}lsearch{SMTP_RELAY_FILE}}
 SMTP_RELAY_USER = ${lookup{user}lsearch{SMTP_RELAY_FILE}}
 SMTP_RELAY_PASS = ${lookup{pass}lsearch{SMTP_RELAY_FILE}}
 
+# Custom Filter
+system_filter = /etc/exim4/system.filter
+system_filter_user = Debian-exim
+
 ######################################################################
 #                       ACL CONFIGURATION                            #
 #         Specifies access control lists for incoming SMTP mail      #

--- a/install/upgrade/versions/1.6.2.sh
+++ b/install/upgrade/versions/1.6.2.sh
@@ -21,3 +21,9 @@ upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'no'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 
+system_filter=$(cat /etc/exim4/exim4.conf.template | grep 'system_filter');
+if [ -z "$system_filter" ]; then
+    sed -i '/SMTP_RELAY_PASS = \${lookup{pass}lsearch{SMTP_RELAY_FILE}}/a #shouldberemoved\n# Custom Filter\nsystem_filter = \/etc\/exim4\/system.filter\nsystem_filter_user = Debian-exim' /etc/exim4/exim4.conf.template
+    # Keep the spacing between the reley_pass and Custom Filter we need to insert a dummy text and remove it later on
+    sed -i 's/#shouldberemoved//g' /etc/exim4/exim4.conf.template
+fi


### PR DESCRIPTION
Via Discord
Shouldn't the system.filter file change the subject of spam emails? Or is this file never used anywhere?
