### PR TITLE
support unicode characters in shell arguments

### DIFF
--- a/web/add/access-key/index.php
+++ b/web/add/access-key/index.php
@@ -54,8 +54,8 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_apis = escapeshellarg(implode(',', $apis_selected));
-    $v_comment = escapeshellarg(trim($_POST['v_comment'] ?? ''));
+    $v_apis = quoteshellarg(implode(',', $apis_selected));
+    $v_comment = quoteshellarg(trim($_POST['v_comment'] ?? ''));
 
     // Add access key
     if (empty($_SESSION['error_msg'])) {

--- a/web/add/cron/index.php
+++ b/web/add/cron/index.php
@@ -43,12 +43,12 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_min = escapeshellarg($_POST['v_min']);
-    $v_hour = escapeshellarg($_POST['v_hour']);
-    $v_day = escapeshellarg($_POST['v_day']);
-    $v_month = escapeshellarg($_POST['v_month']);
-    $v_wday = escapeshellarg($_POST['v_wday']);
-    $v_cmd = escapeshellarg($_POST['v_cmd']);
+    $v_min = quoteshellarg($_POST['v_min']);
+    $v_hour = quoteshellarg($_POST['v_hour']);
+    $v_day = quoteshellarg($_POST['v_day']);
+    $v_month = quoteshellarg($_POST['v_month']);
+    $v_wday = quoteshellarg($_POST['v_wday']);
+    $v_cmd = quoteshellarg($_POST['v_cmd']);
 
     // Add cron job
     if (empty($_SESSION['error_msg'])) {

--- a/web/add/db/index.php
+++ b/web/add/db/index.php
@@ -57,8 +57,8 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_database = escapeshellarg($_POST['v_database']);
-    $v_dbuser = escapeshellarg($_POST['v_dbuser']);
+    $v_database = quoteshellarg($_POST['v_database']);
+    $v_dbuser = quoteshellarg($_POST['v_dbuser']);
     $v_type = $_POST['v_type'];
     $v_charset = $_POST['v_charset'];
     $v_host = $_POST['v_host'];
@@ -66,9 +66,9 @@ if (!empty($_POST['ok'])) {
 
     // Add database
     if (empty($_SESSION['error_msg'])) {
-        $v_type = escapeshellarg($_POST['v_type']);
-        $v_charset = escapeshellarg($_POST['v_charset']);
-        $v_host = escapeshellarg($_POST['v_host']);
+        $v_type = quoteshellarg($_POST['v_type']);
+        $v_charset = quoteshellarg($_POST['v_charset']);
+        $v_host = quoteshellarg($_POST['v_host']);
         $v_password = tempnam("/tmp", "vst");
         $fp = fopen($v_password, "w");
         fwrite($fp, $_POST['v_password']."\n");
@@ -77,7 +77,7 @@ if (!empty($_POST['ok'])) {
         check_return_code($return_var, $output);
         unset($output);
         unlink($v_password);
-        $v_password = escapeshellarg($_POST['v_password']);
+        $v_password = quoteshellarg($_POST['v_password']);
         $v_type = $_POST['v_type'];
         $v_host = $_POST['v_host'];
         $v_charset = $_POST['v_charset'];

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -37,7 +37,7 @@ if (!empty($_POST['ok'])) {
 
     // Protect input
     $v_domain = preg_replace("/^www./i", "", $_POST['v_domain']);
-    $v_domain = escapeshellarg($v_domain);
+    $v_domain = quoteshellarg($v_domain);
     $v_domain = strtolower($v_domain);
     $v_ip = $_POST['v_ip'];
     // Change NameServers
@@ -65,18 +65,18 @@ if (!empty($_POST['ok'])) {
     if (empty($_POST['v_ns8'])) {
         $_POST['v_ns8'] = '';
     }
-    $v_ns1 = escapeshellarg($_POST['v_ns1']);
-    $v_ns2 = escapeshellarg($_POST['v_ns2']);
-    $v_ns3 = escapeshellarg($_POST['v_ns3']);
-    $v_ns4 = escapeshellarg($_POST['v_ns4']);
-    $v_ns5 = escapeshellarg($_POST['v_ns5']);
-    $v_ns6 = escapeshellarg($_POST['v_ns6']);
-    $v_ns7 = escapeshellarg($_POST['v_ns7']);
-    $v_ns8 = escapeshellarg($_POST['v_ns8']);
+    $v_ns1 = quoteshellarg($_POST['v_ns1']);
+    $v_ns2 = quoteshellarg($_POST['v_ns2']);
+    $v_ns3 = quoteshellarg($_POST['v_ns3']);
+    $v_ns4 = quoteshellarg($_POST['v_ns4']);
+    $v_ns5 = quoteshellarg($_POST['v_ns5']);
+    $v_ns6 = quoteshellarg($_POST['v_ns6']);
+    $v_ns7 = quoteshellarg($_POST['v_ns7']);
+    $v_ns8 = quoteshellarg($_POST['v_ns8']);
 
     // Add dns domain
     if (empty($_SESSION['error_msg'])) {
-        exec(HESTIA_CMD."v-add-dns-domain ".$user." ".$v_domain." ".escapeshellarg($v_ip)." ".$v_ns1." ".$v_ns2." ".$v_ns3." ".$v_ns4." ".$v_ns5."  ".$v_ns6."  ".$v_ns7." ".$v_ns8." no", $output, $return_var);
+        exec(HESTIA_CMD."v-add-dns-domain ".$user." ".$v_domain." ".quoteshellarg($v_ip)." ".$v_ns1." ".$v_ns2." ".$v_ns3." ".$v_ns4." ".$v_ns5."  ".$v_ns6."  ".$v_ns7." ".$v_ns8." no", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
@@ -86,7 +86,7 @@ if (!empty($_POST['ok'])) {
     $v_template = $user_config[$user_plain]['DNS_TEMPLATE'];
 
     if (($v_template != $_POST['v_template']) && (empty($_SESSION['error_msg']))) {
-        $v_template = escapeshellarg($_POST['v_template']);
+        $v_template = quoteshellarg($_POST['v_template']);
         exec(HESTIA_CMD."v-change-dns-domain-tpl ".$user." ".$v_domain." ".$v_template." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -95,7 +95,7 @@ if (!empty($_POST['ok'])) {
     // Set expiriation date
     if (empty($_SESSION['error_msg'])) {
         if ((!empty($_POST['v_exp'])) && ($_POST['v_exp'] != date('Y-m-d', strtotime('+1 year')))) {
-            $v_exp = escapeshellarg($_POST['v_exp']);
+            $v_exp = quoteshellarg($_POST['v_exp']);
             exec(HESTIA_CMD."v-change-dns-domain-exp ".$user." ".$v_domain." ".$v_exp." no", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
@@ -105,7 +105,7 @@ if (!empty($_POST['ok'])) {
     // Set ttl
     if (empty($_SESSION['error_msg'])) {
         if ((!empty($_POST['v_ttl'])) && ($_POST['v_ttl'] != '14400') && (empty($_SESSION['error_msg']))) {
-            $v_ttl = escapeshellarg($_POST['v_ttl']);
+            $v_ttl = quoteshellarg($_POST['v_ttl']);
             exec(HESTIA_CMD."v-change-dns-domain-ttl ".$user." ".$v_domain." ".$v_ttl." no", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
@@ -161,12 +161,12 @@ if (!empty($_POST['ok_rec'])) {
     }
 
     // Protect input
-    $v_domain = escapeshellarg($_POST['v_domain']);
-    $v_rec = escapeshellarg($_POST['v_rec']);
-    $v_type = escapeshellarg($_POST['v_type']);
-    $v_val = escapeshellarg($_POST['v_val']);
-    $v_priority = escapeshellarg($_POST['v_priority']);
-    $v_ttl = escapeshellarg($_POST['v_ttl']);
+    $v_domain = quoteshellarg($_POST['v_domain']);
+    $v_rec = quoteshellarg($_POST['v_rec']);
+    $v_type = quoteshellarg($_POST['v_type']);
+    $v_val = quoteshellarg($_POST['v_val']);
+    $v_priority = quoteshellarg($_POST['v_priority']);
+    $v_ttl = quoteshellarg($_POST['v_ttl']);
     // Add dns record
     if (empty($_SESSION['error_msg'])) {
         exec(HESTIA_CMD."v-add-dns-record ".$user." ".$v_domain." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority." '' yes ".$v_ttl, $output, $return_var);

--- a/web/add/firewall/banlist/index.php
+++ b/web/add/firewall/banlist/index.php
@@ -37,8 +37,8 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_chain = escapeshellarg($_POST['v_chain']);
-    $v_ip = escapeshellarg($_POST['v_ip']);
+    $v_chain = quoteshellarg($_POST['v_chain']);
+    $v_ip = quoteshellarg($_POST['v_ip']);
 
     // Add firewall rule
     if (empty($_SESSION['error_msg'])) {

--- a/web/add/firewall/index.php
+++ b/web/add/firewall/index.php
@@ -60,14 +60,14 @@ if (!empty($_POST['ok'])) {    // Check token
     }
 
     // Protect input
-    $v_action = escapeshellarg($_POST['v_action']);
-    $v_protocol = escapeshellarg($_POST['v_protocol']);
+    $v_action = quoteshellarg($_POST['v_action']);
+    $v_protocol = quoteshellarg($_POST['v_protocol']);
     $v_port = str_replace(" ", ",", $_POST['v_port']);
     $v_port = preg_replace('/\,+/', ',', $v_port);
     $v_port = trim($v_port, ",");
-    $v_port = escapeshellarg($v_port);
-    $v_ip = escapeshellarg($_POST['v_ip']);
-    $v_comment = escapeshellarg($_POST['v_comment']);
+    $v_port = quoteshellarg($v_port);
+    $v_ip = quoteshellarg($_POST['v_ip']);
+    $v_comment = quoteshellarg($_POST['v_comment']);
 
     // Add firewall rule
     if (empty($_SESSION['error_msg'])) {

--- a/web/add/firewall/ipset/index.php
+++ b/web/add/firewall/ipset/index.php
@@ -50,7 +50,7 @@ if (!empty($_POST['ok'])) {
 
     // Add firewall ipset list
     if (empty($_SESSION['error_msg'])) {
-        exec(HESTIA_CMD."v-add-firewall-ipset ".escapeshellarg($v_ipname)." ".escapeshellarg($v_datasource)." ".escapeshellarg($v_ipver)." ".escapeshellarg($v_autoupdate), $output, $return_var);
+        exec(HESTIA_CMD."v-add-firewall-ipset ".quoteshellarg($v_ipname)." ".quoteshellarg($v_datasource)." ".quoteshellarg($v_ipver)." ".quoteshellarg($v_autoupdate), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }

--- a/web/add/ip/index.php
+++ b/web/add/ip/index.php
@@ -43,12 +43,12 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_ip = escapeshellarg($_POST['v_ip']);
-    $v_netmask = escapeshellarg($_POST['v_netmask']);
-    $v_name = escapeshellarg($_POST['v_name']);
-    $v_nat = escapeshellarg($_POST['v_nat']);
-    $v_interface = escapeshellarg($_POST['v_interface']);
-    $v_owner = escapeshellarg($_POST['v_owner']);
+    $v_ip = quoteshellarg($_POST['v_ip']);
+    $v_netmask = quoteshellarg($_POST['v_netmask']);
+    $v_name = quoteshellarg($_POST['v_name']);
+    $v_nat = quoteshellarg($_POST['v_nat']);
+    $v_interface = quoteshellarg($_POST['v_interface']);
+    $v_owner = quoteshellarg($_POST['v_owner']);
     $v_shared = $_POST['v_shared'];
 
     // Check shared checkmark
@@ -61,7 +61,7 @@ if (!empty($_POST['ok'])) {
 
     // Add IP
     if (empty($_SESSION['error_msg'])) {
-        exec(HESTIA_CMD."v-add-sys-ip ".$v_ip." ".$v_netmask." ".$v_interface."  ".$v_owner." ".escapeshellarg($ip_status)." ".$v_name." ".$v_nat, $output, $return_var);
+        exec(HESTIA_CMD."v-add-sys-ip ".$v_ip." ".$v_netmask." ".$v_interface."  ".$v_owner." ".quoteshellarg($ip_status)." ".$v_name." ".$v_nat, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_owner = $_POST['v_owner'];

--- a/web/add/key/index.php
+++ b/web/add/key/index.php
@@ -17,7 +17,7 @@ if (!empty($_POST['ok'])) {
     }
 
     if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-        $user = escapeshellarg($_GET['user']);
+        $user = quoteshellarg($_GET['user']);
     }
 
     if (!$_SESSION['error_msg']) {
@@ -48,7 +48,7 @@ if (!empty($_POST['ok'])) {
             if (in_array($v_key_parts[1], $keylist)) {
                 $_SESSION['error_msg']  =  _('SSH KEY already exists');
             }
-            $v_key = escapeshellarg(trim($_POST['v_key']));
+            $v_key = quoteshellarg(trim($_POST['v_key']));
         }
     }
 

--- a/web/add/mail/index.php
+++ b/web/add/mail/index.php
@@ -15,7 +15,7 @@ if (!empty($_GET['domain'])) {
 }
 if (!empty($v_domain)) {
     // Set webmail alias
-    exec(HESTIA_CMD."v-list-mail-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+    exec(HESTIA_CMD."v-list-mail-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
     if ($return_var > 0) {
         check_return_code_redirect($return_var, $output, '/list/mail/');
     }
@@ -68,7 +68,7 @@ if (!empty($_POST['ok'])) {
 
     // Set domain name to lowercase and remove www prefix
     $v_domain = preg_replace("/^www./i", "", $_POST['v_domain']);
-    $v_domain = escapeshellarg($v_domain);
+    $v_domain = quoteshellarg($v_domain);
     $v_domain = strtolower($v_domain);
 
     // Add mail domain
@@ -87,7 +87,7 @@ if (!empty($_POST['ok'])) {
     if (!empty($_SESSION['IMAP_SYSTEM']) && !empty($_SESSION['WEBMAIL_SYSTEM'])) {
         if (empty($_SESSION['error_msg'])) {
             if (!empty($_POST['v_webmail'])) {
-                $v_webmail = escapeshellarg($_POST['v_webmail']);
+                $v_webmail = quoteshellarg($_POST['v_webmail']);
                 exec(HESTIA_CMD."v-add-mail-domain-webmail ".$user." ".$v_domain." ".$v_webmail." yes", $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
@@ -112,11 +112,11 @@ if (!empty($_POST['ok'])) {
                 ($_POST['v_smtp_relay_user'] != $v_smtp_relay_user) ||
                 ($_POST['v_smtp_relay_port'] != $v_smtp_relay_port)) {
                 $v_smtp_relay = true;
-                $v_smtp_relay_host = escapeshellarg($_POST['v_smtp_relay_host']);
-                $v_smtp_relay_user = escapeshellarg($_POST['v_smtp_relay_user']);
-                $v_smtp_relay_pass = escapeshellarg($_POST['v_smtp_relay_pass']);
+                $v_smtp_relay_host = quoteshellarg($_POST['v_smtp_relay_host']);
+                $v_smtp_relay_user = quoteshellarg($_POST['v_smtp_relay_user']);
+                $v_smtp_relay_pass = quoteshellarg($_POST['v_smtp_relay_pass']);
                 if (!empty($_POST['v_smtp_relay_port'])) {
-                    $v_smtp_relay_port = escapeshellarg($_POST['v_smtp_relay_port']);
+                    $v_smtp_relay_port = quoteshellarg($_POST['v_smtp_relay_port']);
                 } else {
                     $v_smtp_relay_port = '587';
                 }
@@ -189,10 +189,10 @@ if (!empty($_POST['ok_acc'])) {
     }
 
     // Protect input
-    $v_domain = escapeshellarg($_POST['v_domain']);
+    $v_domain = quoteshellarg($_POST['v_domain']);
     $v_domain = strtolower($v_domain);
-    $v_account = escapeshellarg($_POST['v_account']);
-    $v_quota = escapeshellarg($_POST['v_quota']);
+    $v_account = quoteshellarg($_POST['v_account']);
+    $v_quota = quoteshellarg($_POST['v_quota']);
     $v_send_email = $_POST['v_send_email'];
     $v_credentials = $_POST['v_credentials'];
     $v_aliases = $_POST['v_aliases'];
@@ -214,7 +214,7 @@ if (!empty($_POST['ok_acc'])) {
         check_return_code($return_var, $output);
         unset($output);
         unlink($v_password);
-        $v_password = escapeshellarg($_POST['v_password']);
+        $v_password = quoteshellarg($_POST['v_password']);
     }
 
     // Add Aliases
@@ -225,7 +225,7 @@ if (!empty($_POST['ok_acc'])) {
         $valiases = trim($valiases);
         $aliases = explode(" ", $valiases);
         foreach ($aliases as $alias) {
-            $alias = escapeshellarg($alias);
+            $alias = quoteshellarg($alias);
             if (empty($_SESSION['error_msg'])) {
                 exec(HESTIA_CMD."v-add-mail-account-alias ".$user." ".$v_domain." ".$v_account." ".$alias, $output, $return_var);
                 check_return_code($return_var, $output);
@@ -249,7 +249,7 @@ if (!empty($_POST['ok_acc'])) {
         $vfwd = trim($vfwd);
         $fwd = explode(" ", $vfwd);
         foreach ($fwd as $forward) {
-            $forward = escapeshellarg($forward);
+            $forward = quoteshellarg($forward);
             if (empty($_SESSION['error_msg'])) {
                 exec(HESTIA_CMD."v-add-mail-account-forward ".$user." ".$v_domain." ".$v_account." ".$forward, $output, $return_var);
                 check_return_code($return_var, $output);
@@ -267,7 +267,7 @@ if (!empty($_POST['ok_acc'])) {
 
     // Add fwd_only flag
     if ((!empty($_POST['v_rate'])) && (empty($_SESSION['error_msg']))  && $_SESSION['userContext'] == 'admin') {
-        $v_rate = escapeshellarg($_POST['v_rate']);
+        $v_rate = quoteshellarg($_POST['v_rate']);
         exec(HESTIA_CMD."v-change-mail-account-rate-limit ".$user." ".$v_domain." ".$v_account." ".$v_rate, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);

--- a/web/add/package/index.php
+++ b/web/add/package/index.php
@@ -96,23 +96,23 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_package = escapeshellarg($_POST['v_package']);
-    $v_web_template = escapeshellarg($_POST['v_web_template']);
-    $v_backend_template = escapeshellarg($_POST['v_backend_template']);
-    $v_proxy_template = escapeshellarg($_POST['v_proxy_template']);
-    $v_dns_template = escapeshellarg($_POST['v_dns_template']);
-    $v_shell = escapeshellarg($_POST['v_shell']);
-    $v_web_domains = escapeshellarg($_POST['v_web_domains']);
-    $v_web_aliases = escapeshellarg($_POST['v_web_aliases']);
-    $v_dns_domains = escapeshellarg($_POST['v_dns_domains']);
-    $v_dns_records = escapeshellarg($_POST['v_dns_records']);
-    $v_mail_domains = escapeshellarg($_POST['v_mail_domains']);
-    $v_mail_accounts = escapeshellarg($_POST['v_mail_accounts']);
-    $v_databases = escapeshellarg($_POST['v_databases']);
-    $v_cron_jobs = escapeshellarg($_POST['v_cron_jobs']);
-    $v_backups = escapeshellarg($_POST['v_backups']);
-    $v_disk_quota = escapeshellarg($_POST['v_disk_quota']);
-    $v_bandwidth = escapeshellarg($_POST['v_bandwidth']);
+    $v_package = quoteshellarg($_POST['v_package']);
+    $v_web_template = quoteshellarg($_POST['v_web_template']);
+    $v_backend_template = quoteshellarg($_POST['v_backend_template']);
+    $v_proxy_template = quoteshellarg($_POST['v_proxy_template']);
+    $v_dns_template = quoteshellarg($_POST['v_dns_template']);
+    $v_shell = quoteshellarg($_POST['v_shell']);
+    $v_web_domains = quoteshellarg($_POST['v_web_domains']);
+    $v_web_aliases = quoteshellarg($_POST['v_web_aliases']);
+    $v_dns_domains = quoteshellarg($_POST['v_dns_domains']);
+    $v_dns_records = quoteshellarg($_POST['v_dns_records']);
+    $v_mail_domains = quoteshellarg($_POST['v_mail_domains']);
+    $v_mail_accounts = quoteshellarg($_POST['v_mail_accounts']);
+    $v_databases = quoteshellarg($_POST['v_databases']);
+    $v_cron_jobs = quoteshellarg($_POST['v_cron_jobs']);
+    $v_backups = quoteshellarg($_POST['v_backups']);
+    $v_disk_quota = quoteshellarg($_POST['v_disk_quota']);
+    $v_bandwidth = quoteshellarg($_POST['v_bandwidth']);
     $v_ns1 = trim($_POST['v_ns1'], '.');
     $v_ns2 = trim($_POST['v_ns2'], '.');
     $v_ns3 = trim($_POST['v_ns3'], '.');
@@ -140,9 +140,9 @@ if (!empty($_POST['ok'])) {
     if (!empty($v_ns8)) {
         $v_ns .= ",".$v_ns8;
     }
-    $v_ns = escapeshellarg($v_ns);
-    $v_time = escapeshellarg(date('H:i:s'));
-    $v_date = escapeshellarg(date('Y-m-d'));
+    $v_ns = quoteshellarg($v_ns);
+    $v_time = quoteshellarg(date('H:i:s'));
+    $v_date = quoteshellarg(date('Y-m-d'));
 
     // Create package file
     if (empty($_SESSION['error_msg'])) {

--- a/web/add/user/index.php
+++ b/web/add/user/index.php
@@ -58,11 +58,11 @@ if (!empty($_POST['ok'])) {
     }
 
     // Protect input
-    $v_username = escapeshellarg($_POST['v_username']);
-    $v_email = escapeshellarg($_POST['v_email']);
-    $v_package = escapeshellarg($_POST['v_package']);
-    $v_language = escapeshellarg($_POST['v_language']);
-    $v_name = escapeshellarg($_POST['v_name']);
+    $v_username = quoteshellarg($_POST['v_username']);
+    $v_email = quoteshellarg($_POST['v_email']);
+    $v_package = quoteshellarg($_POST['v_package']);
+    $v_language = quoteshellarg($_POST['v_language']);
+    $v_name = quoteshellarg($_POST['v_name']);
     $v_notify = $_POST['v_notify'];
 
 
@@ -76,7 +76,7 @@ if (!empty($_POST['ok'])) {
         check_return_code($return_var, $output);
         unset($output);
         unlink($v_password);
-        $v_password = escapeshellarg($_POST['v_password']);
+        $v_password = quoteshellarg($_POST['v_password']);
     }
 
     // Set language
@@ -88,7 +88,7 @@ if (!empty($_POST['ok'])) {
 
     // Set Role
     if (empty($_SESSION['error_msg'])) {
-        $v_role = escapeshellarg($_POST['v_role']);
+        $v_role = quoteshellarg($_POST['v_role']);
         exec(HESTIA_CMD."v-change-user-role ".$v_username." ".$v_role, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -98,7 +98,7 @@ if (!empty($_POST['ok'])) {
     if (empty($_SESSION['error_msg'])) {
         if (!empty($_POST['v_login_disabled'])) {
             $_POST['v_login_disabled'] = 'yes';
-            exec(HESTIA_CMD."v-change-user-config-value ".$v_username." LOGIN_DISABLED ".escapeshellarg($_POST['v_login_disabled']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-user-config-value ".$v_username." LOGIN_DISABLED ".quoteshellarg($_POST['v_login_disabled']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }

--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -51,7 +51,7 @@ if (!empty($_POST['ok'])) {
     $v_domain = strtolower($v_domain);
 
     // Define domain ip address
-    $v_ip = escapeshellarg($_POST['v_ip']);
+    $v_ip = quoteshellarg($_POST['v_ip']);
 
     // Using public IP instead of internal IP when creating DNS
     // Gets public IP from 'v-list-user-ips' command (that reads /hestia/data/ips/ip), precisely from 'NAT' field
@@ -62,7 +62,7 @@ if (!empty($_POST['ok'])) {
     unset($output);
     if (isset($ips[$v_clean_ip]) && isset($ips[$v_clean_ip]['NAT']) && trim($ips[$v_clean_ip]['NAT'])!='') {
         $v_public_ip = trim($ips[$v_clean_ip]['NAT']);
-        $v_public_ip = escapeshellarg($v_public_ip);
+        $v_public_ip = quoteshellarg($v_public_ip);
     }
 
     // Define domain aliases
@@ -80,7 +80,7 @@ if (!empty($_POST['ok'])) {
     $aliases_arr = array_unique($aliases_arr);
     $aliases_arr = array_filter($aliases_arr);
     $aliases = implode(",", $aliases_arr);
-    $aliases = escapeshellarg($aliases);
+    $aliases = quoteshellarg($aliases);
 
 
     // Define proxy extensions
@@ -97,7 +97,7 @@ if (!empty($_POST['ok'])) {
     $proxy_ext_arr = array_unique($proxy_ext_arr);
     $proxy_ext_arr = array_filter($proxy_ext_arr);
     $proxy_ext = implode(",", $proxy_ext_arr);
-    $proxy_ext = escapeshellarg($proxy_ext);
+    $proxy_ext = quoteshellarg($proxy_ext);
 
     // Define other options
     if (empty($_POST['v_ssl'])) {
@@ -114,7 +114,7 @@ if (!empty($_POST['ok'])) {
     if (empty($_POST['v_stats'])) {
         $_POST['v_stats'] = '';
     }
-    $v_stats = escapeshellarg($_POST['v_stats']);
+    $v_stats = quoteshellarg($_POST['v_stats']);
     $v_stats_user = $_POST['v_stats_user'];
     $v_stats_password = $_POST['v_stats_user'];
     $v_custom_doc_domain = $_POST['v-custom-doc-domain'];
@@ -200,7 +200,7 @@ if (!empty($_POST['ok'])) {
 
     // Add web domain
     if (empty($_SESSION['error_msg'])) {
-        exec(HESTIA_CMD."v-add-web-domain ".$user." ".escapeshellarg($v_domain)." ".$v_ip." 'yes' ".$aliases." ".$proxy_ext, $output, $return_var);
+        exec(HESTIA_CMD."v-add-web-domain ".$user." ".quoteshellarg($v_domain)." ".$v_ip." 'yes' ".$aliases." ".$proxy_ext, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $domain_added = empty($_SESSION['error_msg']);
@@ -208,7 +208,7 @@ if (!empty($_POST['ok'])) {
 
     // Add DNS domain
     if (($_POST['v_dns'] == 'on') && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-dns-domain ".$user." ".escapeshellarg($v_domain)." ".$v_public_ip." '' '' '' '' '' '' '' '' 'no'", $output, $return_var);
+        exec(HESTIA_CMD."v-add-dns-domain ".$user." ".quoteshellarg($v_domain)." ".$v_public_ip." '' '' '' '' '' '' '' '' 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
@@ -217,7 +217,7 @@ if (!empty($_POST['ok'])) {
     if (($_POST['v_dns'] == 'on') && (empty($_SESSION['error_msg']))) {
         foreach ($aliases_arr as $alias) {
             if ($alias != "www.".$v_domain) {
-                $alias = escapeshellarg($alias);
+                $alias = quoteshellarg($alias);
                 exec(HESTIA_CMD."v-add-dns-on-web-alias ".$user." ".$alias." ".$v_ip." 'no'", $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
@@ -227,14 +227,14 @@ if (!empty($_POST['ok'])) {
 
     // Add mail domain
     if (($_POST['v_mail'] == 'on') && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-mail-domain ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-add-mail-domain ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
 
     // Change template
     if (($v_template != $_POST['v_template']) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-change-web-domain-tpl ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($_POST['v_template'])." 'no'", $output, $return_var);
+        exec(HESTIA_CMD."v-change-web-domain-tpl ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($_POST['v_template'])." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $restart_web = 'yes';
@@ -242,7 +242,7 @@ if (!empty($_POST['ok'])) {
     // Change backend template
     if ((!empty($_SESSION['WEB_BACKEND'])) && ($v_backend_template != $_POST['v_backend_template']) && (empty($_SESSION['error_msg']))) {
         $v_backend_template = $_POST['v_backend_template'];
-        exec(HESTIA_CMD."v-change-web-domain-backend-tpl ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_backend_template), $output, $return_var);
+        exec(HESTIA_CMD."v-change-web-domain-backend-tpl ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_backend_template), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
@@ -258,7 +258,7 @@ if (!empty($_POST['ok'])) {
             if (!empty($_POST['v_proxy_template'])) {
                 $v_proxy_template = $_POST['v_proxy_template'];
             }
-            exec(HESTIA_CMD."v-change-web-domain-proxy-tpl ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_proxy_template)." ".escapeshellarg($ext)." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-proxy-tpl ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_proxy_template)." ".quoteshellarg($ext)." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             $v_proxy_ext = str_replace(',', ', ', $ext);
             unset($output);
@@ -269,12 +269,12 @@ if (!empty($_POST['ok'])) {
 
     // Add Lets Encrypt support
     if ((!empty($_POST['v_letsencrypt'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-schedule-letsencrypt-domain ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-schedule-letsencrypt-domain ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
 
         if (!empty($_POST['v_ssl_forcessl']) && $_POST['v_ssl_forcessl'] = 'yes') {
-            exec(HESTIA_CMD."v-add-web-domain-ssl-preset ".$user." ".escapeshellarg($v_domain)." 'yes'", $output, $return_var);
+            exec(HESTIA_CMD."v-add-web-domain-ssl-preset ".$user." ".quoteshellarg($v_domain)." 'yes'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -309,13 +309,13 @@ if (!empty($_POST['ok'])) {
                 fclose($fp);
             }
 
-            $v_ssl_home = escapeshellarg($_POST['v_ssl_home']);
-            exec(HESTIA_CMD."v-add-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." ".$tmpdir." ".$v_ssl_home." 'no'", $output, $return_var);
+            $v_ssl_home = quoteshellarg($_POST['v_ssl_home']);
+            exec(HESTIA_CMD."v-add-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." ".$tmpdir." ".$v_ssl_home." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
 
             if (!empty($_POST['v_ssl_forcessl']) && $_POST['v_ssl_forcessl'] = 'yes') {
-                exec(HESTIA_CMD."v-add-web-domain-ssl-force ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+                exec(HESTIA_CMD."v-add-web-domain-ssl-force ".$user." ".quoteshellarg($v_domain), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -336,37 +336,37 @@ if (!empty($_POST['ok'])) {
 
     // Add web stats
     if ((!empty($_POST['v_stats'])) && ($_POST['v_stats'] != 'none') && (empty($_SESSION['error_msg']))) {
-        $v_stats = escapeshellarg($_POST['v_stats']);
-        exec(HESTIA_CMD."v-add-web-domain-stats ".$user." ".escapeshellarg($v_domain)." ".$v_stats, $output, $return_var);
+        $v_stats = quoteshellarg($_POST['v_stats']);
+        exec(HESTIA_CMD."v-add-web-domain-stats ".$user." ".quoteshellarg($v_domain)." ".$v_stats, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
 
     // Add web stats password
     if ((!empty($_POST['v_stats_user'])) && (empty($_SESSION['error_msg']))) {
-        $v_stats_user = escapeshellarg($_POST['v_stats_user']);
+        $v_stats_user = quoteshellarg($_POST['v_stats_user']);
         $v_stats_password = tempnam("/tmp", "vst");
         $fp = fopen($v_stats_password, "w");
         fwrite($fp, $_POST['v_stats_password']."\n");
         fclose($fp);
-        exec(HESTIA_CMD."v-add-web-domain-stats-user ".$user." ".escapeshellarg($v_domain)." ".$v_stats_user." ".$v_stats_password, $output, $return_var);
+        exec(HESTIA_CMD."v-add-web-domain-stats-user ".$user." ".quoteshellarg($v_domain)." ".$v_stats_user." ".$v_stats_password, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         unlink($v_stats_password);
-        $v_stats_password = escapeshellarg($_POST['v_stats_password']);
+        $v_stats_password = quoteshellarg($_POST['v_stats_password']);
     }
 
     if (!empty($_POST['v-custom-doc-domain']) && !empty($_POST['v_custom_doc_root_check']) && $v_custom_doc_root_prepath.$v_custom_doc_domain.'/public_html'.$v_custom_doc_folder != $v_custom_doc_root) {
         if ($_POST['v-custom-doc-domain'] == $v_domain && empty($_POST['v-custom-doc-folder'])) {
         } else {
-            $v_custom_doc_domain = escapeshellarg($_POST['v-custom-doc-domain']);
+            $v_custom_doc_domain = quoteshellarg($_POST['v-custom-doc-domain']);
             if (substr($_POST['v-custom-doc-folder'], -1) == '/') {
-                $v_custom_doc_folder = escapeshellarg(substr($_POST['v-custom-doc-folder'], 0, -1));
+                $v_custom_doc_folder = quoteshellarg(substr($_POST['v-custom-doc-folder'], 0, -1));
             } else {
-                $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);
+                $v_custom_doc_folder = quoteshellarg($_POST['v-custom-doc-folder']);
             }
-            $v_custom_doc_folder = escapeshellarg($_POST['v-custom-doc-folder']);
-            $v_domain = escapeshellarg(trim($_POST['v_domain']));
+            $v_custom_doc_folder = quoteshellarg($_POST['v-custom-doc-folder']);
+            $v_domain = quoteshellarg(trim($_POST['v_domain']));
 
             exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".$v_domain." ".$v_custom_doc_domain." ".$v_custom_doc_folder." yes", $output, $return_var);
             check_return_code($return_var, $output);
@@ -442,14 +442,14 @@ if (!empty($_POST['ok'])) {
                 $v_ftp_user_data['v_ftp_user'] = preg_replace("/^".$user_plain."_/i", "", $v_ftp_user_data['v_ftp_user']);
                 $v_ftp_username      = $v_ftp_user_data['v_ftp_user'];
                 $v_ftp_username_full = $user . '_' . $v_ftp_user_data['v_ftp_user'];
-                $v_ftp_user = escapeshellarg($v_ftp_user_data['v_ftp_user']);
+                $v_ftp_user = quoteshellarg($v_ftp_user_data['v_ftp_user']);
                 if ($domain_added) {
-                    $v_ftp_path = escapeshellarg(trim($v_ftp_user_data['v_ftp_path']));
+                    $v_ftp_path = quoteshellarg(trim($v_ftp_user_data['v_ftp_path']));
                     $v_ftp_password = tempnam("/tmp", "vst");
                     $fp = fopen($v_ftp_password, "w");
                     fwrite($fp, $v_ftp_user_data['v_ftp_password']."\n");
                     fclose($fp);
-                    exec(HESTIA_CMD."v-add-web-domain-ftp ".$user." ".escapeshellarg($v_domain)." ".$v_ftp_user." ".$v_ftp_password . " " . $v_ftp_path, $output, $return_var);
+                    exec(HESTIA_CMD."v-add-web-domain-ftp ".$user." ".quoteshellarg($v_domain)." ".$v_ftp_user." ".$v_ftp_password . " " . $v_ftp_path, $output, $return_var);
                     check_return_code($return_var, $output);
                     unset($output);
                     unlink($v_ftp_password);

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -15,12 +15,12 @@ if (empty($_GET['domain'])) {
 
 // Edit as someone else?
 if (($_SESSION['user'] == 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check if domain belongs to the user
 $v_domain = $_GET['domain'];
-exec(HESTIA_CMD."v-list-web-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+exec(HESTIA_CMD."v-list-web-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
 if ($return_var > 0) {
     check_return_code_redirect($return_var, $output, '/list/web/');
 }

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -68,7 +68,7 @@ function api_legacy(array $request_data) {
             echo 'Error: missing authentication';
             exit;
         }
-        $v_ip = escapeshellarg(get_real_user_ip());
+        $v_ip = quoteshellarg(get_real_user_ip());
         $output = '';
         exec(HESTIA_CMD."v-get-user-salt admin ".$v_ip." json", $output, $return_var);
         $pam = json_decode(implode('', $output), true);
@@ -107,8 +107,8 @@ function api_legacy(array $request_data) {
         
     } else {
         $key = '/usr/local/hestia/data/keys/'.basename($request_data['hash']);
-        $v_ip = escapeshellarg(get_real_user_ip());
-        exec(HESTIA_CMD."v-check-api-key ".escapeshellarg($key)." ".$v_ip, $output, $return_var);
+        $v_ip = quoteshellarg(get_real_user_ip());
+        exec(HESTIA_CMD."v-check-api-key ".quoteshellarg($key)." ".$v_ip, $output, $return_var);
         unset($output);
         // Check API answer
         if ($return_var > 0) {
@@ -145,7 +145,7 @@ function api_legacy(array $request_data) {
         
         // Prepare arguments
         foreach ($hst_cmd_args as $cmd_arg) {
-            $cmdquery .= " ".escapeshellarg($cmd_arg);
+            $cmdquery .= " ".quoteshellarg($cmd_arg);
         }
         
         // Run cmd query
@@ -218,7 +218,7 @@ function api_connection(array $request_data) {
     }
 
     // Authenticates the key and checks permission to run the script
-    exec(HESTIA_CMD."v-check-access-key ".escapeshellarg($hst_access_key_id)." ".escapeshellarg($hst_secret_access_key)." ".escapeshellarg($hst_cmd)." ".escapeshellarg($v_real_user_ip)." json", $output, $return_var);
+    exec(HESTIA_CMD."v-check-access-key ".quoteshellarg($hst_access_key_id)." ".quoteshellarg($hst_secret_access_key)." ".quoteshellarg($hst_cmd)." ".quoteshellarg($v_real_user_ip)." json", $output, $return_var);
     if ($return_var > 0) {
         //api_error($return_var, "Key $hst_access_key_id - authentication failed");
         api_error($return_var, $output);
@@ -244,7 +244,7 @@ function api_connection(array $request_data) {
 
     // Prepare arguments
     foreach ($hst_cmd_args as $cmd_arg) {
-        $cmdquery .= " ".escapeshellarg($cmd_arg);
+        $cmdquery .= " ".quoteshellarg($cmd_arg);
     }
     
     # v-make-temp files is manodory other wise some functions will break

--- a/web/bulk/access-key/index.php
+++ b/web/bulk/access-key/index.php
@@ -8,7 +8,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_POST);
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user = escapeshellarg($_GET['user']);
+    $user = quoteshellarg($_GET['user']);
     $user_plain = $_GET['user'];
 }
 
@@ -29,7 +29,7 @@ switch ($action) {
 }
 
 foreach ($key as $value) {
-    $v_key = escapeshellarg(trim($value));
+    $v_key = quoteshellarg(trim($value));
 
     // Key data
     exec(HESTIA_CMD."v-list-access-key ".$v_key." json", $output, $return_var);

--- a/web/bulk/backup/exclusions/index.php
+++ b/web/bulk/backup/exclusions/index.php
@@ -17,7 +17,7 @@ switch ($action) {
 }
 
 foreach ($backup as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$user." ".$value, $output, $return_var);
 }
 

--- a/web/bulk/backup/index.php
+++ b/web/bulk/backup/index.php
@@ -17,7 +17,7 @@ switch ($action) {
 }
 
 foreach ($backup as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$user." ".$value, $output, $return_var);
 }
 

--- a/web/bulk/cron/index.php
+++ b/web/bulk/cron/index.php
@@ -56,7 +56,7 @@ if ($_SESSION['userContext'] === 'admin') {
 }
 
 foreach ($job as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$user." ".$value." no", $output, $return_var);
     $restart = 'yes';
 }

--- a/web/bulk/db/index.php
+++ b/web/bulk/db/index.php
@@ -35,7 +35,7 @@ if ($_SESSION['userContext'] === 'admin') {
 }
 
 foreach ($database as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$user." ".$value, $output, $return_var);
 }
 

--- a/web/bulk/dns/index.php
+++ b/web/bulk/dns/index.php
@@ -55,15 +55,15 @@ if ($_SESSION['userContext'] === 'admin') {
 if (empty($record)) {
     foreach ($domain as $value) {
         // DNS
-        $value = escapeshellarg($value);
+        $value = quoteshellarg($value);
         exec(HESTIA_CMD.$cmd." ".$user." ".$value." no", $output, $return_var);
         $restart = 'yes';
     }
 } else {
     foreach ($record as $value) {
         // DNS Record
-        $value = escapeshellarg($value);
-        $dom = escapeshellarg($domain);
+        $value = quoteshellarg($value);
+        $dom = quoteshellarg($domain);
         exec(HESTIA_CMD.$cmd." ".$user." ".$dom." ".$value." no", $output, $return_var);
         $restart = 'yes';
     }

--- a/web/bulk/firewall/banlist/index.php
+++ b/web/bulk/firewall/banlist/index.php
@@ -25,8 +25,8 @@ switch ($action) {
 
 foreach ($ipchain as $value) {
     list($ip, $chain) = explode(":", $value);
-    $v_ip    = escapeshellarg($ip);
-    $v_chain = escapeshellarg($chain);
+    $v_ip    = quoteshellarg($ip);
+    $v_chain = quoteshellarg($chain);
     exec(HESTIA_CMD.$cmd." ".$v_ip." ".$v_chain, $output, $return_var);
 }
 

--- a/web/bulk/firewall/index.php
+++ b/web/bulk/firewall/index.php
@@ -29,7 +29,7 @@ switch ($action) {
 }
 
 foreach ($rule as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$value, $output, $return_var);
     $restart = 'yes';
 }

--- a/web/bulk/firewall/ipset/index.php
+++ b/web/bulk/firewall/ipset/index.php
@@ -24,7 +24,7 @@ switch ($action) {
 
 
 foreach ($setname as $value) {
-    $v_name = escapeshellarg($value);
+    $v_name = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$v_name, $output, $return_var);
 }
 

--- a/web/bulk/hestia/index.php
+++ b/web/bulk/hestia/index.php
@@ -18,7 +18,7 @@ if ($_SESSION['userContext'] === 'admin') {
         default: header("Location: /list/updates/"); exit;
     }
     foreach ($pkg as $value) {
-        $value = escapeshellarg($value);
+        $value = quoteshellarg($value);
         exec(HESTIA_CMD.$cmd." ".$value, $output, $return_var);
     }
 }

--- a/web/bulk/ip/index.php
+++ b/web/bulk/ip/index.php
@@ -26,7 +26,7 @@ if ($_SESSION['userContext'] === 'admin') {
 }
 
 foreach ($ip as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$value, $output, $return_var);
 }
 

--- a/web/bulk/mail/index.php
+++ b/web/bulk/mail/index.php
@@ -63,15 +63,15 @@ if ($_SESSION['userContext'] === 'admin') {
 if (empty($account)) {
     foreach ($domain as $value) {
         // Mail
-        $value = escapeshellarg($value);
+        $value = quoteshellarg($value);
         exec(HESTIA_CMD.$cmd." ".$user." ".$value, $output, $return_var);
         $restart = 'yes';
     }
 } else {
     foreach ($account as $value) {
         // Mail Account
-        $value = escapeshellarg($value);
-        $dom = escapeshellarg($domain);
+        $value = quoteshellarg($value);
+        $dom = quoteshellarg($domain);
         exec(HESTIA_CMD.$cmd." ".$user." ".$dom." ".$value, $output, $return_var);
         $restart = 'yes';
     }

--- a/web/bulk/package/index.php
+++ b/web/bulk/package/index.php
@@ -22,7 +22,7 @@ if ($_SESSION['userContext'] === 'admin') {
 }
 
 foreach ($package as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$value, $output, $return_var);
     $restart = 'yes';
 }

--- a/web/bulk/restore/index.php
+++ b/web/bulk/restore/index.php
@@ -8,7 +8,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_POST);
 
 $action = $_POST['action'];
-$backup = escapeshellarg($_POST['backup']);
+$backup = quoteshellarg($_POST['backup']);
 
 $web = 'no';
 $dns = 'no';
@@ -18,22 +18,22 @@ $cron = 'no';
 $udir = 'no';
 
 if (!empty($_POST['web'])) {
-    $web = escapeshellarg(implode(",", $_POST['web']));
+    $web = quoteshellarg(implode(",", $_POST['web']));
 }
 if (!empty($_POST['dns'])) {
-    $dns = escapeshellarg(implode(",", $_POST['dns']));
+    $dns = quoteshellarg(implode(",", $_POST['dns']));
 }
 if (!empty($_POST['mail'])) {
-    $mail = escapeshellarg(implode(",", $_POST['mail']));
+    $mail = quoteshellarg(implode(",", $_POST['mail']));
 }
 if (!empty($_POST['db'])) {
-    $db = escapeshellarg(implode(",", $_POST['db']));
+    $db = quoteshellarg(implode(",", $_POST['db']));
 }
 if (!empty($_POST['cron'])) {
     $cron = 'yes';
 }
 if (!empty($_POST['udir'])) {
-    $udir = escapeshellarg(implode(",", $_POST['udir']));
+    $udir = quoteshellarg(implode(",", $_POST['udir']));
 }
 
 if ($action == 'restore') {

--- a/web/bulk/service/index.php
+++ b/web/bulk/service/index.php
@@ -30,7 +30,7 @@ if ($_SESSION['userContext'] === 'admin') {
     }
 
     foreach ($service as $value) {
-        $value = escapeshellarg($value);
+        $value = quoteshellarg($value);
         exec(HESTIA_CMD.$cmd." ".$value, $output, $return_var);
     }
 }

--- a/web/bulk/user/index.php
+++ b/web/bulk/user/index.php
@@ -45,7 +45,7 @@ if ($_SESSION['userContext'] === 'admin') {
 }
 
 foreach ($user as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$value." ".$restart, $output, $return_var);
     $changes = 'yes';
 }

--- a/web/bulk/web/index.php
+++ b/web/bulk/web/index.php
@@ -42,7 +42,7 @@ if ($_SESSION['userContext'] === 'admin') {
 }
 
 foreach ($domain as $value) {
-    $value = escapeshellarg($value);
+    $value = quoteshellarg($value);
     exec(HESTIA_CMD.$cmd." ".$user." ".$value." no", $output, $return_var);
     $restart='yes';
 }

--- a/web/copy/package/index.php
+++ b/web/copy/package/index.php
@@ -20,7 +20,7 @@ if (empty($_GET['package'])) {
 
 if ($_SESSION['userContext'] === 'admin') {
     if (!empty($_GET['package'])) {
-        $v_package = escapeshellarg($_GET['package']);
+        $v_package = quoteshellarg($_GET['package']);
         exec(HESTIA_CMD."v-copy-user-package ".$v_package." ".$v_package."-copy", $output, $return_var);
     }
 

--- a/web/delete/access-key/index.php
+++ b/web/delete/access-key/index.php
@@ -8,7 +8,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user = escapeshellarg($_GET['user']);
+    $user = quoteshellarg($_GET['user']);
     $user_plain = $_GET['user'];
 }
 
@@ -20,7 +20,7 @@ if (($user_plain == 'admin' && $api_status < 1) || ($user_plain != 'admin' && $a
 }
 
 if (!empty($_GET['key'])) {
-    $v_key = escapeshellarg(trim($_GET['key']));
+    $v_key = quoteshellarg(trim($_GET['key']));
 
     // Key data
     exec(HESTIA_CMD."v-list-access-key ".$v_key." json", $output, $return_var);

--- a/web/delete/backup/exclusion/index.php
+++ b/web/delete/backup/exclusion/index.php
@@ -4,14 +4,14 @@ ob_start();
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check token
 verify_csrf($_GET);
 
 if (!empty($_GET['system'])) {
-    $v_system = escapeshellarg($_GET['system']);
+    $v_system = quoteshellarg($_GET['system']);
     exec(HESTIA_CMD."v-delete-user-backup-exclusions ".$user." ".$v_system, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/delete/backup/index.php
+++ b/web/delete/backup/index.php
@@ -4,14 +4,14 @@ ob_start();
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check token
 verify_csrf($_GET);
 
 if (!empty($_GET['backup'])) {
-    $v_backup = escapeshellarg($_GET['backup']);
+    $v_backup = quoteshellarg($_GET['backup']);
     exec(HESTIA_CMD."v-delete-user-backup ".$user." ".$v_backup, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/delete/cron/index.php
+++ b/web/delete/cron/index.php
@@ -4,15 +4,15 @@ ob_start();
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check token
 verify_csrf($_GET);
 
 if (!empty($_GET['job'])) {
-    $v_username = escapeshellarg($user);
-    $v_job = escapeshellarg($_GET['job']);
+    $v_username = quoteshellarg($user);
+    $v_job = quoteshellarg($_GET['job']);
     exec(HESTIA_CMD."v-delete-cron-job ".$user." ".$v_job, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/delete/db/index.php
+++ b/web/delete/db/index.php
@@ -4,14 +4,14 @@ ob_start();
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check token
 verify_csrf($_GET);
 
 if (!empty($_GET['database'])) {
-    $v_database = escapeshellarg($_GET['database']);
+    $v_database = quoteshellarg($_GET['database']);
     exec(HESTIA_CMD."v-delete-database ".$user." ".$v_database, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/delete/dns/index.php
+++ b/web/delete/dns/index.php
@@ -5,7 +5,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 // Delete as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check token
@@ -13,7 +13,7 @@ verify_csrf($_GET);
 
 // DNS domain
 if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-delete-dns-domain ".$user." ".$v_domain, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);
@@ -29,8 +29,8 @@ if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
 
 // DNS record
 if ((!empty($_GET['domain'])) && (!empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_record_id = escapeshellarg($_GET['record_id']);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_record_id = quoteshellarg($_GET['record_id']);
     exec(HESTIA_CMD."v-delete-dns-record ".$user." ".$v_domain." ".$v_record_id, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/delete/firewall/banlist/index.php
+++ b/web/delete/firewall/banlist/index.php
@@ -14,8 +14,8 @@ if ($_SESSION['userContext'] != 'admin') {
 verify_csrf($_GET);
 
 if ((!empty($_GET['ip'])) && (!empty($_GET['chain']))) {
-    $v_ip = escapeshellarg($_GET['ip']);
-    $v_chain = escapeshellarg($_GET['chain']);
+    $v_ip = quoteshellarg($_GET['ip']);
+    $v_chain = quoteshellarg($_GET['chain']);
     exec(HESTIA_CMD."v-delete-firewall-ban ".$v_ip." ".$v_chain, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/delete/firewall/index.php
+++ b/web/delete/firewall/index.php
@@ -14,7 +14,7 @@ if ($_SESSION['userContext'] != 'admin') {
 verify_csrf($_GET);
 
 if (!empty($_GET['rule'])) {
-    $v_rule = escapeshellarg($_GET['rule']);
+    $v_rule = quoteshellarg($_GET['rule']);
     exec(HESTIA_CMD."v-delete-firewall-rule ".$v_rule, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/delete/firewall/ipset/index.php
+++ b/web/delete/firewall/ipset/index.php
@@ -15,7 +15,7 @@ verify_csrf($_GET);
 
 if (!empty($_GET['listname'])) {
     $v_listname = $_GET['listname'];
-    exec(HESTIA_CMD."v-delete-firewall-ipset ".escapeshellarg($v_listname), $output, $return_var);
+    exec(HESTIA_CMD."v-delete-firewall-ipset ".quoteshellarg($v_listname), $output, $return_var);
 }
 check_return_code($return_var, $output);
 unset($output);

--- a/web/delete/ip/index.php
+++ b/web/delete/ip/index.php
@@ -8,7 +8,7 @@ verify_csrf($_GET);
 
 if ($_SESSION['userContext'] === 'admin') {
     if (!empty($_GET['ip'])) {
-        $v_ip = escapeshellarg($_GET['ip']);
+        $v_ip = quoteshellarg($_GET['ip']);
         exec(HESTIA_CMD."v-delete-sys-ip ".$v_ip, $output, $return_var);
     }
     check_return_code($return_var, $output);

--- a/web/delete/key/index.php
+++ b/web/delete/key/index.php
@@ -7,11 +7,11 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 if (!empty($_GET['key'])) {
-    $v_key = escapeshellarg(trim($_GET['key']));
+    $v_key = quoteshellarg(trim($_GET['key']));
     exec(HESTIA_CMD."v-delete-user-ssh-key ".$user." ".$v_key);
     check_return_code($return_var, $output);
 }

--- a/web/delete/log/auth/index.php
+++ b/web/delete/log/auth/index.php
@@ -7,7 +7,7 @@ verify_csrf($_GET);
 
 // Check if administrator is viewing system log (currently 'admin' user)
 if (($_SESSION['userContext'] === "admin") && (isset($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
     $token=$_SESSION['token'];
 }
 
@@ -23,11 +23,11 @@ if (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
         $ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
     }
 }
-$v_ip = escapeshellarg($ip);
+$v_ip = quoteshellarg($ip);
 $user_agent = $_SERVER['HTTP_USER_AGENT'];
-$v_user_agent = escapeshellarg($user_agent);
+$v_user_agent = quoteshellarg($user_agent);
 
-$v_session_id = escapeshellarg($_SESSION['token']);
+$v_session_id = quoteshellarg($_SESSION['token']);
 
 // Add current user session back to log unless impersonating another user
 if (!isset($_SESSION['look'])) {

--- a/web/delete/log/index.php
+++ b/web/delete/log/index.php
@@ -7,7 +7,7 @@ verify_csrf($_GET);
 
 // Check if administrator is viewing system log (currently 'admin' user)
 if (($_SESSION['userContext'] === "admin") && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
     $token=$_SESSION['token'];
 }
 

--- a/web/delete/mail/index.php
+++ b/web/delete/mail/index.php
@@ -5,7 +5,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 // Delete as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($user);
+    $user=quoteshellarg($user);
 }
 
 // Check token
@@ -13,8 +13,8 @@ verify_csrf($_GET);
 
 // Mail domain
 if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
-    $v_username = escapeshellarg($user);
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_username = quoteshellarg($user);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-delete-mail-domain ".$user." ".$v_domain, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);
@@ -32,8 +32,8 @@ if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
 
 // Mail account
 if ((!empty($_GET['domain'])) && (!empty($_GET['account']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_account = escapeshellarg($_GET['account']);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_account = quoteshellarg($_GET['account']);
     exec(HESTIA_CMD."v-delete-mail-account ".$user." ".$v_domain." ".$v_account, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/delete/notification/index.php
+++ b/web/delete/notification/index.php
@@ -6,12 +6,12 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if ($_GET['delete'] == 1) {
-    $v_id = escapeshellarg((int)$_GET['notification_id']);
+    $v_id = quoteshellarg((int)$_GET['notification_id']);
     exec(HESTIA_CMD."v-delete-user-notification ".$user." ".$v_id, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);
 } else {
-    $v_id = escapeshellarg((int)$_GET['notification_id']);
+    $v_id = quoteshellarg((int)$_GET['notification_id']);
     exec(HESTIA_CMD."v-acknowledge-user-notification ".$user." ".$v_id, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/delete/package/index.php
+++ b/web/delete/package/index.php
@@ -14,7 +14,7 @@ if ($_GET['package'] === 'default') {
 
 if ($_SESSION['userContext'] === 'admin') {
     if (!empty($_GET['package'])) {
-        $v_package = escapeshellarg($_GET['package']);
+        $v_package = quoteshellarg($_GET['package']);
         exec(HESTIA_CMD."v-delete-user-package ".$v_package, $output, $return_var);
     }
     check_return_code($return_var, $output);

--- a/web/delete/user/index.php
+++ b/web/delete/user/index.php
@@ -8,7 +8,7 @@ verify_csrf($_GET);
 
 if ($_SESSION['userContext'] === 'admin') {
     if (!empty($_GET['user'])) {
-        $v_username = escapeshellarg($_GET['user']);
+        $v_username = quoteshellarg($_GET['user']);
         exec(HESTIA_CMD."v-delete-user ".$v_username, $output, $return_var);
     }
     check_return_code($return_var, $output);

--- a/web/delete/web/cache/index.php
+++ b/web/delete/web/cache/index.php
@@ -8,11 +8,11 @@ verify_csrf($_GET);
 
 // Delete as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 if (!empty($_GET['domain'])) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-purge-nginx-cache ".$user." ".$v_domain, $output, $return_var);
     check_return_code($return_var, $output);
 }

--- a/web/delete/web/index.php
+++ b/web/delete/web/index.php
@@ -8,11 +8,11 @@ verify_csrf($_GET);
 
 // Delete as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user = escapeshellarg($user);
+    $user = quoteshellarg($user);
 }
 
 if (!empty($_GET['domain'])) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD . 'v-delete-web-domain ' . $user . ' ' . $v_domain . " 'yes'", $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/download/backup/index.php
+++ b/web/download/backup/index.php
@@ -9,7 +9,7 @@ verify_csrf($_GET);
 $backup = $_GET['backup'];
 
 if (!file_exists('/backup/'.$backup)) {
-    $backup = escapeshellarg($_GET['backup']);
+    $backup = quoteshellarg($_GET['backup']);
     exec(HESTIA_CMD."v-schedule-user-backup-download ".$user." ".$backup, $output, $return_var);
     if ($return_var == 0) {
         $_SESSION['error_msg'] = _('BACKUP_DOWNLOAD_SCHEDULED');

--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -6,7 +6,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 $v_domain = $_GET['domain'];
-$v_domain = escapeshellarg($_GET['domain']);
+$v_domain = quoteshellarg($_GET['domain']);
 if ($_GET['type'] == 'access') {
     $type = 'access';
 }
@@ -20,7 +20,7 @@ header("Content-Disposition: attachment; filename=".$_GET['domain'].".".$type."-
 header("Content-Type: application/octet-stream; ");
 header("Content-Transfer-Encoding: binary");
 
-$v_domain = escapeshellarg($_GET['domain']);
+$v_domain = quoteshellarg($_GET['domain']);
 if ($_GET['type'] == 'access') {
     $type = 'access';
 }

--- a/web/edit/backup/exclusions/index.php
+++ b/web/edit/backup/exclusions/index.php
@@ -7,7 +7,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // List backup exclustions
@@ -70,32 +70,32 @@ if (!empty($_POST['save'])) {
     $v_web = $_POST['v_web'];
     $v_web_tmp = str_replace("\r\n", ",", $_POST['v_web']);
     $v_web_tmp = rtrim($v_web_tmp, ",");
-    $v_web_tmp = "WEB=" . escapeshellarg($v_web_tmp);
+    $v_web_tmp = "WEB=" . quoteshellarg($v_web_tmp);
 
     $v_dns = $_POST['v_dns'];
     $v_dns_tmp = str_replace("\r\n", ",", $_POST['v_dns']);
     $v_dns_tmp = rtrim($v_dns_tmp, ",");
-    $v_dns_tmp = "DNS=" . escapeshellarg($v_dns_tmp);
+    $v_dns_tmp = "DNS=" . quoteshellarg($v_dns_tmp);
 
     $v_mail = $_POST['v_mail'];
     $v_mail_tmp = str_replace("\r\n", ",", $_POST['v_mail']);
     $v_mail_tmp = rtrim($v_mail_tmp, ",");
-    $v_mail_tmp = "MAIL=" . escapeshellarg($v_mail_tmp);
+    $v_mail_tmp = "MAIL=" . quoteshellarg($v_mail_tmp);
 
     $v_db = $_POST['v_db'];
     $v_db_tmp = str_replace("\r\n", ",", $_POST['v_db']);
     $v_db_tmp = rtrim($v_db_tmp, ",");
-    $v_db_tmp = "DB=" . escapeshellarg($v_db_tmp);
+    $v_db_tmp = "DB=" . quoteshellarg($v_db_tmp);
 
     $v_cron = $_POST['v_cron'];
     $v_cron_tmp = str_replace("\r\n", ",", $_POST['v_cron']);
     $v_cron_tmp = rtrim($v_cron_tmp, ",");
-    $v_cron_tmp = "CRON=" . escapeshellarg($v_cron_tmp);
+    $v_cron_tmp = "CRON=" . quoteshellarg($v_cron_tmp);
 
     $v_userdir = $_POST['v_userdir'];
     $v_userdir_tmp = str_replace("\r\n", ",", $_POST['v_userdir']);
     $v_userdir_tmp = rtrim($v_userdir_tmp, ",");
-    $v_userdir_tmp = "USER=" . escapeshellarg($v_userdir_tmp);
+    $v_userdir_tmp = "USER=" . quoteshellarg($v_userdir_tmp);
 
     // Create temporary exeption list on a filesystem
     exec('mktemp', $mktemp_output, $return_var);

--- a/web/edit/cron/index.php
+++ b/web/edit/cron/index.php
@@ -7,7 +7,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 // Check job id
@@ -17,7 +17,7 @@ if (empty($_GET['job'])) {
 }
 
 // List cron job
-$v_job = escapeshellarg($_GET['job']);
+$v_job = quoteshellarg($_GET['job']);
 exec(HESTIA_CMD."v-list-cron-job ".$user." ".$v_job." 'json'", $output, $return_var);
 check_return_code_redirect($return_var, $output, '/list/cron/');
 
@@ -49,13 +49,13 @@ if (!empty($_POST['save'])) {
     verify_csrf($_POST);
 
     $v_username = $user;
-    $v_job = escapeshellarg($_GET['job']);
-    $v_min = escapeshellarg($_POST['v_min']);
-    $v_hour = escapeshellarg($_POST['v_hour']);
-    $v_day = escapeshellarg($_POST['v_day']);
-    $v_month = escapeshellarg($_POST['v_month']);
-    $v_wday = escapeshellarg($_POST['v_wday']);
-    $v_cmd = escapeshellarg($_POST['v_cmd']);
+    $v_job = quoteshellarg($_GET['job']);
+    $v_min = quoteshellarg($_POST['v_min']);
+    $v_hour = quoteshellarg($_POST['v_hour']);
+    $v_day = quoteshellarg($_POST['v_day']);
+    $v_month = quoteshellarg($_POST['v_month']);
+    $v_wday = quoteshellarg($_POST['v_wday']);
+    $v_cmd = quoteshellarg($_POST['v_cmd']);
 
     // Save changes
     exec(HESTIA_CMD."v-change-cron-job ".$user." ".$v_job." ".$v_min." ".$v_hour." ".$v_day." ".$v_month." ".$v_wday." ".$v_cmd, $output, $return_var);

--- a/web/edit/db/index.php
+++ b/web/edit/db/index.php
@@ -14,13 +14,13 @@ if (empty($_GET['database'])) {
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
     $user_plain=htmlentities($_GET['user']);
 }
 
 // List datbase
 $v_database = $_GET['database'];
-exec(HESTIA_CMD."v-list-database ".$user." ".escapeshellarg($v_database)." 'json'", $output, $return_var);
+exec(HESTIA_CMD."v-list-database ".$user." ".quoteshellarg($v_database)." 'json'", $output, $return_var);
 check_return_code_redirect($return_var, $output, '/list/db/');
 $data = json_decode(implode('', $output), true);
 unset($output);
@@ -50,8 +50,8 @@ if (!empty($_POST['save'])) {
 
     // Change database user
     if (($v_dbuser != $_POST['v_dbuser']) && (empty($_SESSION['error_msg']))) {
-        $v_dbuser = escapeshellarg($v_dbuser);
-        exec(HESTIA_CMD."v-change-database-user ".$user." ".escapeshellarg($v_database)." ".$v_dbuser, $output, $return_var);
+        $v_dbuser = quoteshellarg($v_dbuser);
+        exec(HESTIA_CMD."v-change-database-user ".$user." ".quoteshellarg($v_database)." ".$v_dbuser, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_dbuser = $_POST['v_dbuser'];
@@ -66,11 +66,11 @@ if (!empty($_POST['save'])) {
             $fp = fopen($v_password, "w");
             fwrite($fp, $_POST['v_password']."\n");
             fclose($fp);
-            exec(HESTIA_CMD."v-change-database-password ".$user." ".escapeshellarg($v_database)." ".$v_password, $output, $return_var);
+            exec(HESTIA_CMD."v-change-database-password ".$user." ".quoteshellarg($v_database)." ".$v_password, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             unlink($v_password);
-            $v_password = escapeshellarg($_POST['v_password']);
+            $v_password = quoteshellarg($_POST['v_password']);
         }
     }
 

--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -14,7 +14,7 @@ if (empty($_GET['domain'])) {
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
     $user_plain=htmlentities($_GET['user']);
 }
 
@@ -25,7 +25,7 @@ unset($output);
 
 // List dns domain
 if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-list-dns-domain ".$user." ".$v_domain." json", $output, $return_var);
     check_return_code_redirect($return_var, $output,'/list/dns/');
     $data = json_decode(implode('', $output), true);
@@ -56,8 +56,8 @@ if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
 
 // List dns record
 if ((!empty($_GET['domain'])) && (!empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_record_id = escapeshellarg($_GET['record_id']);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_record_id = quoteshellarg($_GET['record_id']);
     exec(HESTIA_CMD."v-list-dns-records ".$user." ".$v_domain." 'json'", $output, $return_var);
     check_return_code_redirect($return_var, $output,'/list/dns/');
     $data = json_decode(implode('', $output), true);
@@ -83,14 +83,14 @@ if ((!empty($_GET['domain'])) && (!empty($_GET['record_id']))) {
 
 // Check POST request for dns domain
 if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_POST['v_domain']);
+    $v_domain = quoteshellarg($_POST['v_domain']);
 
     // Check token
     verify_csrf($_POST);
 
     // Change domain IP
     if (($v_ip != $_POST['v_ip']) && (empty($_SESSION['error_msg']))) {
-        $v_ip = escapeshellarg($_POST['v_ip']);
+        $v_ip = quoteshellarg($_POST['v_ip']);
         exec(HESTIA_CMD."v-change-dns-domain-ip ".$user." ".$v_domain." ".$v_ip." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         $restart_dns = 'yes';
@@ -99,7 +99,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['recor
 
     // Change domain template
     if (($v_template != $_POST['v_template']) && (empty($_SESSION['error_msg']))) {
-        $v_template = escapeshellarg($_POST['v_template']);
+        $v_template = quoteshellarg($_POST['v_template']);
         exec(HESTIA_CMD."v-change-dns-domain-tpl ".$user." ".$v_domain." ".$v_template." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -108,7 +108,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['recor
 
     // Change SOA record
     if (($v_soa != $_POST['v_soa']) && (empty($_SESSION['error_msg']))) {
-        $v_soa = escapeshellarg($_POST['v_soa']);
+        $v_soa = quoteshellarg($_POST['v_soa']);
         exec(HESTIA_CMD."v-change-dns-domain-soa ".$user." ".$v_domain." ".$v_soa." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -117,7 +117,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['recor
 
     // Change expiriation date
     if (($v_exp != $_POST['v_exp']) && (empty($_SESSION['error_msg']))) {
-        $v_exp = escapeshellarg($_POST['v_exp']);
+        $v_exp = quoteshellarg($_POST['v_exp']);
         exec(HESTIA_CMD."v-change-dns-domain-exp ".$user." ".$v_domain." ".$v_exp." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -125,7 +125,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['recor
 
     // Change domain ttl
     if (($v_ttl != $_POST['v_ttl']) && (empty($_SESSION['error_msg']))) {
-        $v_ttl = escapeshellarg($_POST['v_ttl']);
+        $v_ttl = quoteshellarg($_POST['v_ttl']);
         exec(HESTIA_CMD."v-change-dns-domain-ttl ".$user." ".$v_domain." ".$v_ttl." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -158,16 +158,16 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['reco
     verify_csrf($_POST);
 
     // Protect input
-    $v_domain = escapeshellarg($_POST['v_domain']);
-    $v_record_id = escapeshellarg($_POST['v_record_id']);
+    $v_domain = quoteshellarg($_POST['v_domain']);
+    $v_record_id = quoteshellarg($_POST['v_record_id']);
 
     // Change dns record
     if (($v_rec != $_POST['v_rec']) || ($v_type != $_POST['v_type']) || ($v_val != $_POST['v_val']) || ($v_priority != $_POST['v_priority']) || ($v_ttl != $_POST['v_ttl']) && (empty($_SESSION['error_msg']))) {
-        $v_rec = escapeshellarg($_POST['v_rec']);
-        $v_type = escapeshellarg($_POST['v_type']);
-        $v_val = escapeshellarg($_POST['v_val']);
-        $v_priority = escapeshellarg($_POST['v_priority']);
-        $v_ttl = escapeshellarg($_POST['v_ttl']);
+        $v_rec = quoteshellarg($_POST['v_rec']);
+        $v_type = quoteshellarg($_POST['v_type']);
+        $v_val = quoteshellarg($_POST['v_val']);
+        $v_priority = quoteshellarg($_POST['v_priority']);
+        $v_ttl = quoteshellarg($_POST['v_ttl']);
         exec(HESTIA_CMD."v-change-dns-record ".$user." ".$v_domain." ".$v_record_id." ".$v_rec." ".$v_type." ".$v_val." ".$v_priority." yes ".$v_ttl, $output, $return_var);
         check_return_code($return_var, $output);
         $v_rec = $_POST['v_rec'];
@@ -180,7 +180,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['reco
 
     // Change dns record id
     if (($_GET['record_id'] != $_POST['v_record_id']) && (empty($_SESSION['error_msg']))) {
-        $v_old_record_id = escapeshellarg($_GET['record_id']);
+        $v_old_record_id = quoteshellarg($_GET['record_id']);
         exec(HESTIA_CMD."v-change-dns-record-id ".$user." ".$v_domain." ".$v_old_record_id." ".$v_record_id, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);

--- a/web/edit/firewall/index.php
+++ b/web/edit/firewall/index.php
@@ -19,7 +19,7 @@ if (empty($_GET['rule'])) {
 }
 
 // List rule
-$v_rule = escapeshellarg($_GET['rule']);
+$v_rule = quoteshellarg($_GET['rule']);
 exec(HESTIA_CMD."v-list-firewall-rule ".$v_rule." 'json'", $output, $return_var);
 check_return_code_redirect($return_var, $output,'/list/firewall');
 $data = json_decode(implode('', $output), true);
@@ -89,15 +89,15 @@ if (!empty($_POST['save'])) {
         $_SESSION['error_msg'] = sprintf(_('Field "%s" can not be blank.'), $error_msg);
     }
     if (empty($_SESSION['error_msg'])) {
-        $v_rule = escapeshellarg($_GET['rule']);
-        $v_action = escapeshellarg($_POST['v_action']);
-        $v_protocol = escapeshellarg($_POST['v_protocol']);
+        $v_rule = quoteshellarg($_GET['rule']);
+        $v_action = quoteshellarg($_POST['v_action']);
+        $v_protocol = quoteshellarg($_POST['v_protocol']);
         $v_port = str_replace(" ", ",", $_POST['v_port']);
         $v_port = preg_replace('/\,+/', ',', $v_port);
         $v_port = trim($v_port, ",");
-        $v_port = escapeshellarg($v_port);
-        $v_ip = escapeshellarg($_POST['v_ip']);
-        $v_comment = escapeshellarg($_POST['v_comment']);
+        $v_port = quoteshellarg($v_port);
+        $v_ip = quoteshellarg($_POST['v_ip']);
+        $v_comment = quoteshellarg($_POST['v_comment']);
 
         // Change Status
         exec(HESTIA_CMD."v-change-firewall-rule ".$v_rule." ".$v_action." ".$v_ip." ".$v_port." ".$v_protocol." ".$v_comment, $output, $return_var);

--- a/web/edit/ip/index.php
+++ b/web/edit/ip/index.php
@@ -19,7 +19,7 @@ if (empty($_GET['ip'])) {
 }
 
 // List ip
-$v_ip = escapeshellarg($_GET['ip']);
+$v_ip = quoteshellarg($_GET['ip']);
 exec(HESTIA_CMD."v-list-sys-ip ".$v_ip." 'json'", $output, $return_var);
 check_return_code_redirect($return_var, $output, '/list/ip');
 $data = json_decode(implode('', $output), true);
@@ -52,7 +52,7 @@ if (!empty($_POST['save'])) {
     // Check token
     verify_csrf($_POST);
 
-    $v_ip = escapeshellarg($_POST['v_ip']);
+    $v_ip = quoteshellarg($_POST['v_ip']);
 
     // Change Status
     if (($v_ipstatus == 'shared') && (empty($_POST['v_shared'])) && (empty($_SESSION['error_msg']))) {
@@ -70,7 +70,7 @@ if (!empty($_POST['save'])) {
 
     // Change owner
     if (($v_owner != $_POST['v_owner']) && (empty($_SESSION['error_msg']))) {
-        $v_owner = escapeshellarg($_POST['v_owner']);
+        $v_owner = quoteshellarg($_POST['v_owner']);
         exec(HESTIA_CMD."v-change-sys-ip-owner ".$v_ip." ".$v_owner, $output, $return_var);
         check_return_code($return_var, $output);
         $v_owner = $_POST['v_owner'];
@@ -79,7 +79,7 @@ if (!empty($_POST['save'])) {
 
     // Change associated domain
     if (($v_name != $_POST['v_name']) && (empty($_SESSION['error_msg']))) {
-        $v_name = escapeshellarg($_POST['v_name']);
+        $v_name = quoteshellarg($_POST['v_name']);
         exec(HESTIA_CMD."v-change-sys-ip-name ".$v_ip." ".$v_name, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
@@ -87,7 +87,7 @@ if (!empty($_POST['save'])) {
 
     // Change NAT address
     if (($v_nat != $_POST['v_nat']) && (empty($_SESSION['error_msg']))) {
-        $v_nat = escapeshellarg($_POST['v_nat']);
+        $v_nat = quoteshellarg($_POST['v_nat']);
         exec(HESTIA_CMD."v-change-sys-ip-nat ".$v_ip." ".$v_nat, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);

--- a/web/edit/mail/index.php
+++ b/web/edit/mail/index.php
@@ -14,7 +14,7 @@ if (empty($_GET['domain'])) {
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
     $user_plain=htmlentities($_GET['user']);
 }
 
@@ -28,7 +28,7 @@ if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
     $webmail_clients = json_decode(implode('', $output), true);
     unset($output);
 
-    exec(HESTIA_CMD."v-list-mail-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+    exec(HESTIA_CMD."v-list-mail-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     check_return_code_redirect($return_var, $output, '/list/mail/');
     unset($output);
@@ -58,7 +58,7 @@ if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
 
     $v_ssl = $data[$v_domain]['SSL'];
     if (!empty($v_ssl)) {
-        exec(HESTIA_CMD."v-list-mail-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+        exec(HESTIA_CMD."v-list-mail-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
         $ssl_str = json_decode(implode('', $output), true);
         unset($output);
         $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -83,7 +83,7 @@ if ((!empty($_GET['domain'])) && (!empty($_GET['account']))) {
     $v_domain = $_GET['domain'];
 
     $v_account = $_GET['account'];
-    exec(HESTIA_CMD."v-list-mail-account ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." 'json'", $output, $return_var);
+    exec(HESTIA_CMD."v-list-mail-account ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." 'json'", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     check_return_code_redirect($return_var, $output, '/list/mail/');
     unset($output);
@@ -120,7 +120,7 @@ if ((!empty($_GET['domain'])) && (!empty($_GET['account']))) {
 
     // Parse autoreply
     if ($v_autoreply == 'yes') {
-        exec(HESTIA_CMD."v-list-mail-account-autoreply ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." json", $output, $return_var);
+        exec(HESTIA_CMD."v-list-mail-account-autoreply ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." json", $output, $return_var);
         $autoreply_str = json_decode(implode('', $output), true);
         unset($output);
         $v_autoreply_message = $autoreply_str[$v_account]['MSG'];
@@ -137,14 +137,14 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
     verify_csrf($_POST);
 
 
-    exec(HESTIA_CMD."v-list-mail-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+    exec(HESTIA_CMD."v-list-mail-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     check_return_code_redirect($return_var, $output, '/list/mail/');
     unset($output);
 
     // Delete antispam
     if (($v_antispam == 'yes') && (empty($_POST['v_antispam'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-domain-antispam ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-domain-antispam ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_antispam = 'no';
         unset($output);
@@ -152,7 +152,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Add antispam
     if (($v_antispam == 'no') && (!empty($_POST['v_antispam'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-mail-domain-antispam ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-add-mail-domain-antispam ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_antispam = 'yes';
         unset($output);
@@ -160,7 +160,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Delete antivirus
     if (($v_antivirus == 'yes') && (empty($_POST['v_antivirus'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-domain-antivirus ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-domain-antivirus ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_antivirus = 'no';
         unset($output);
@@ -168,7 +168,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Add antivirus
     if (($v_antivirus == 'no') && (!empty($_POST['v_antivirus'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-mail-domain-antivirus ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-add-mail-domain-antivirus ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_antivirus = 'yes';
         unset($output);
@@ -176,7 +176,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Delete DKIM
     if (($v_dkim == 'yes') && (empty($_POST['v_dkim'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-domain-dkim ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-domain-dkim ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_dkim = 'no';
         unset($output);
@@ -184,7 +184,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Add DKIM
     if (($v_dkim == 'no') && (!empty($_POST['v_dkim'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-mail-domain-dkim ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-add-mail-domain-dkim ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_dkim = 'yes';
         unset($output);
@@ -192,7 +192,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Delete catchall
     if ((!empty($v_catchall)) && (empty($_POST['v_catchall'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-domain-catchall ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-domain-catchall ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         $v_catchall = '';
         unset($output);
@@ -203,9 +203,9 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
         if (empty($_POST['v_rate'])) {
             $v_rate = 'system';
         } else {
-            $v_rate = escapeshellarg($_POST['v_rate']);
+            $v_rate = quoteshellarg($_POST['v_rate']);
         }
-        exec(HESTIA_CMD."v-change-mail-domain-rate-limit ".$v_username." ".escapeshellarg($v_domain)." ".$v_rate, $output, $return_var);
+        exec(HESTIA_CMD."v-change-mail-domain-rate-limit ".$v_username." ".quoteshellarg($v_domain)." ".$v_rate, $output, $return_var);
         check_return_code($return_var, $output);
         if ($v_rate == 'system') {
             $v_rate = '';
@@ -229,8 +229,8 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
     // Change catchall address
     if ((!empty($v_catchall)) && (!empty($_POST['v_catchall'])) && (empty($_SESSION['error_msg']))) {
         if ($v_catchall != $_POST['v_catchall']) {
-            $v_catchall = escapeshellarg($_POST['v_catchall']);
-            exec(HESTIA_CMD."v-change-mail-domain-catchall ".$v_username." ".escapeshellarg($v_domain)." ".$v_catchall, $output, $return_var);
+            $v_catchall = quoteshellarg($_POST['v_catchall']);
+            exec(HESTIA_CMD."v-change-mail-domain-catchall ".$v_username." ".quoteshellarg($v_domain)." ".$v_catchall, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -238,8 +238,8 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Add catchall
     if ((empty($v_catchall)) && (!empty($_POST['v_catchall'])) && (empty($_SESSION['error_msg']))) {
-        $v_catchall = escapeshellarg($_POST['v_catchall']);
-        exec(HESTIA_CMD."v-add-mail-domain-catchall ".$v_username." ".escapeshellarg($v_domain)." ".$v_catchall, $output, $return_var);
+        $v_catchall = quoteshellarg($_POST['v_catchall']);
+        exec(HESTIA_CMD."v-add-mail-domain-catchall ".$v_username." ".quoteshellarg($v_domain)." ".$v_catchall, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
@@ -247,7 +247,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
     if (!empty($_SESSION['IMAP_SYSTEM']) && !empty($_SESSION['WEBMAIL_SYSTEM'])) {
         if (empty($_SESSION['error_msg'])) {
             if (!empty($_POST['v_webmail'])) {
-                $v_webmail = escapeshellarg($_POST['v_webmail']);
+                $v_webmail = quoteshellarg($_POST['v_webmail']);
                 exec(HESTIA_CMD."v-add-mail-domain-webmail ".$user." ".$v_domain." ".$v_webmail." yes", $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
@@ -296,13 +296,13 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
                 fclose($fp);
             }
 
-            exec(HESTIA_CMD."v-change-mail-domain-sslcert ".$user." ".escapeshellarg($v_domain)." ".$tmpdir." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-change-mail-domain-sslcert ".$user." ".quoteshellarg($v_domain)." ".$tmpdir." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $restart_web = 'yes';
             $restart_proxy = 'yes';
 
-            exec(HESTIA_CMD."v-list-mail-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+            exec(HESTIA_CMD."v-list-mail-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
             $ssl_str = json_decode(implode('', $output), true);
             unset($output);
             $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -332,7 +332,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Delete Lets Encrypt support
     if (($v_letsencrypt == 'yes') && (empty($_POST['v_letsencrypt']) || empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-letsencrypt-domain ".$user." ".escapeshellarg($v_domain)." ' ' 'yes'", $output, $return_var);
+        exec(HESTIA_CMD."v-delete-letsencrypt-domain ".$user." ".quoteshellarg($v_domain)." ' ' 'yes'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_crt = '';
@@ -346,7 +346,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Delete SSL certificate
     if (($v_ssl == 'yes') && (empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-domain-ssl ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-domain-ssl ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_crt = '';
@@ -358,7 +358,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
 
     // Add Lets Encrypt support
     if ((!empty($_POST['v_ssl'])) && ($v_letsencrypt == 'no') && (!empty($_POST['v_letsencrypt'])) && empty($_SESSION['error_msg'])) {
-        exec(HESTIA_CMD."v-add-letsencrypt-domain ".$user." ".escapeshellarg($v_domain)." ' ' 'yes'", $output, $return_var);
+        exec(HESTIA_CMD."v-add-letsencrypt-domain ".$user." ".quoteshellarg($v_domain)." ' ' 'yes'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_letsencrypt = 'yes';
@@ -407,14 +407,14 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
                 fwrite($fp, str_replace("\r\n", "\n", $_POST['v_ssl_ca']));
                 fclose($fp);
             }
-            exec(HESTIA_CMD."v-add-mail-domain-ssl ".$user." ".escapeshellarg($v_domain)." ".$tmpdir." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-add-mail-domain-ssl ".$user." ".quoteshellarg($v_domain)." ".$tmpdir." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_ssl = 'yes';
             $restart_web = 'yes';
             $restart_proxy = 'yes';
 
-            exec(HESTIA_CMD."v-list-mail-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+            exec(HESTIA_CMD."v-list-mail-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
             $ssl_str = json_decode(implode('', $output), true);
             unset($output);
             $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -449,15 +449,15 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
                 ($_POST['v_smtp_relay_user'] != $v_smtp_relay_user) ||
                 ($_POST['v_smtp_relay_port'] != $v_smtp_relay_port)) {
                 $v_smtp_relay = true;
-                $v_smtp_relay_host = escapeshellarg($_POST['v_smtp_relay_host']);
-                $v_smtp_relay_user = escapeshellarg($_POST['v_smtp_relay_user']);
-                $v_smtp_relay_pass = escapeshellarg($_POST['v_smtp_relay_pass']);
+                $v_smtp_relay_host = quoteshellarg($_POST['v_smtp_relay_host']);
+                $v_smtp_relay_user = quoteshellarg($_POST['v_smtp_relay_user']);
+                $v_smtp_relay_pass = quoteshellarg($_POST['v_smtp_relay_pass']);
                 if (!empty($_POST['v_smtp_relay_port'])) {
-                    $v_smtp_relay_port = escapeshellarg($_POST['v_smtp_relay_port']);
+                    $v_smtp_relay_port = quoteshellarg($_POST['v_smtp_relay_port']);
                 } else {
                     $v_smtp_relay_port = '587';
                 }
-                exec(HESTIA_CMD."v-add-mail-domain-smtp-relay ".$v_username." ".escapeshellarg($v_domain)." ".$v_smtp_relay_host." '".$v_smtp_relay_user."' '".$v_smtp_relay_pass."' ".$v_smtp_relay_port, $output, $return_var);
+                exec(HESTIA_CMD."v-add-mail-domain-smtp-relay ".$v_username." ".quoteshellarg($v_domain)." ".$v_smtp_relay_host." '".$v_smtp_relay_user."' '".$v_smtp_relay_pass."' ".$v_smtp_relay_port, $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -465,7 +465,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (empty($_GET['accou
         if ((!isset($_POST['v_smtp_relay'])) && ($v_smtp_relay == true)) {
             $v_smtp_relay = false;
             $v_smtp_relay_host = $v_smtp_relay_user = $v_smtp_relay_pass = $v_smtp_relay_port = '';
-            exec(HESTIA_CMD."v-delete-mail-domain-smtp-relay ".$v_username." ".escapeshellarg($v_domain), $output, $return_var);
+            exec(HESTIA_CMD."v-delete-mail-domain-smtp-relay ".$v_username." ".quoteshellarg($v_domain), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -494,7 +494,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
     $v_send_email = $_POST['v_send_email'];
     $v_credentials = $_POST['v_credentials'];
 
-    exec(HESTIA_CMD."v-list-mail-account ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." json", $output, $return_var);
+    exec(HESTIA_CMD."v-list-mail-account ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." json", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     check_return_code_redirect($return_var, $output, '/list/mail/');
     unset($output);
@@ -508,11 +508,11 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
             $fp = fopen($v_password, "w");
             fwrite($fp, $_POST['v_password']."\n");
             fclose($fp);
-            exec(HESTIA_CMD."v-change-mail-account-password ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".$v_password, $output, $return_var);
+            exec(HESTIA_CMD."v-change-mail-account-password ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".$v_password, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             unlink($v_password);
-            $v_password = escapeshellarg($_POST['v_password']);
+            $v_password = quoteshellarg($_POST['v_password']);
         }
     }
 
@@ -521,9 +521,9 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
         if (empty($_POST['v_quota'])) {
             $v_quota = 0;
         } else {
-            $v_quota = escapeshellarg($_POST['v_quota']);
+            $v_quota = quoteshellarg($_POST['v_quota']);
         }
-        exec(HESTIA_CMD."v-change-mail-account-quota ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".$v_quota, $output, $return_var);
+        exec(HESTIA_CMD."v-change-mail-account-quota ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".$v_quota, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
@@ -532,9 +532,9 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
         if (empty($_POST['v_rate'])) {
             $v_rate = 'system';
         } else {
-            $v_rate = escapeshellarg($_POST['v_rate']);
+            $v_rate = quoteshellarg($_POST['v_rate']);
         }
-        exec(HESTIA_CMD."v-change-mail-account-rate-limit ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".$v_rate, $output, $return_var);
+        exec(HESTIA_CMD."v-change-mail-account-rate-limit ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".$v_rate, $output, $return_var);
         check_return_code($return_var, $output);
         if ($v_rate == 'system') {
             $v_rate = '';
@@ -553,7 +553,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
         $result = array_diff($valiases, $aliases);
         foreach ($result as $alias) {
             if ((empty($_SESSION['error_msg'])) && (!empty($alias))) {
-                exec(HESTIA_CMD."v-delete-mail-account-alias ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".escapeshellarg($alias), $output, $return_var);
+                exec(HESTIA_CMD."v-delete-mail-account-alias ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".quoteshellarg($alias), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -561,7 +561,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
         $result = array_diff($aliases, $valiases);
         foreach ($result as $alias) {
             if ((empty($_SESSION['error_msg'])) && (!empty($alias))) {
-                exec(HESTIA_CMD."v-add-mail-account-alias ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".escapeshellarg($alias), $output, $return_var);
+                exec(HESTIA_CMD."v-add-mail-account-alias ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".quoteshellarg($alias), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -571,11 +571,11 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
     if (empty($_SESSION['error_msg']) && !empty($_POST['v_blackhole'])) {
         foreach ($vfwd as $forward) {
             if ((empty($_SESSION['error_msg'])) && (!empty($forward))) {
-                exec(HESTIA_CMD."v-delete-mail-account-forward ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".escapeshellarg($forward), $output, $return_var);
+                exec(HESTIA_CMD."v-delete-mail-account-forward ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".quoteshellarg($forward), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
-            exec(HESTIA_CMD."v-add-mail-account-forward ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." :blackhole:", $output, $return_var);
+            exec(HESTIA_CMD."v-add-mail-account-forward ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." :blackhole:", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_fwd  = '';
@@ -593,7 +593,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
         $result = array_diff($vfwd, $fwd);
         foreach ($result as $forward) {
             if ((empty($_SESSION['error_msg'])) && (!empty($forward))) {
-                exec(HESTIA_CMD."v-delete-mail-account-forward ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".escapeshellarg($forward), $output, $return_var);
+                exec(HESTIA_CMD."v-delete-mail-account-forward ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".quoteshellarg($forward), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -601,7 +601,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
         $result = array_diff($fwd, $vfwd);
         foreach ($result as $forward) {
             if ((empty($_SESSION['error_msg'])) && (!empty($forward))) {
-                exec(HESTIA_CMD."v-add-mail-account-forward ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".escapeshellarg($forward), $output, $return_var);
+                exec(HESTIA_CMD."v-add-mail-account-forward ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".quoteshellarg($forward), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -611,7 +611,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
 
     // Delete FWD_ONLY flag
     if (($v_fwd_only == 'yes') && (empty($_POST['v_fwd_only'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-account-fwd-only ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-account-fwd-only ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_fwd_only = '';
@@ -619,7 +619,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
 
     // Add FWD_ONLY flag
     if (($v_fwd_only != 'yes') && (!empty($_POST['v_fwd_only'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-mail-account-fwd-only ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account), $output, $return_var);
+        exec(HESTIA_CMD."v-add-mail-account-fwd-only ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_fwd_only = 'yes';
@@ -627,7 +627,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
 
     // Delete autoreply
     if (($v_autoreply == 'yes') && (empty($_POST['v_autoreply'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-mail-account-autoreply ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-mail-account-autoreply ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_autoreply = 'no';
@@ -638,8 +638,8 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
     if ((!empty($_POST['v_autoreply'])) && (empty($_SESSION['error_msg']))) {
         if ($v_autoreply_message != str_replace("\r\n", "\n", $_POST['v_autoreply_message'])) {
             $v_autoreply_message = str_replace("\r\n", "\n", $_POST['v_autoreply_message']);
-            $v_autoreply_message = escapeshellarg($v_autoreply_message);
-            exec(HESTIA_CMD."v-add-mail-account-autoreply ".$v_username." ".escapeshellarg($v_domain)." ".escapeshellarg($v_account)." ".$v_autoreply_message, $output, $return_var);
+            $v_autoreply_message = quoteshellarg($v_autoreply_message);
+            exec(HESTIA_CMD."v-add-mail-account-autoreply ".$v_username." ".quoteshellarg($v_domain)." ".quoteshellarg($v_account)." ".$v_autoreply_message, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_autoreply = 'yes';

--- a/web/edit/package/index.php
+++ b/web/edit/package/index.php
@@ -26,7 +26,7 @@ if ($_GET['package'] === 'system') {
 }
 
 // List package
-$v_package = escapeshellarg($_GET['package']);
+$v_package = quoteshellarg($_GET['package']);
 exec(HESTIA_CMD."v-list-user-package ".$v_package." 'json'", $output, $return_var);
 check_return_code_redirect($return_var, $output, '/list/package/');
 $data = json_decode(implode('', $output), true);
@@ -212,28 +212,28 @@ if (!empty($_POST['save'])) {
     }
 
     // Protect input
-    $v_package = escapeshellarg($_POST['v_package']);
-    $v_package_new = escapeshellarg($_POST['v_package_new']);
-    $v_web_template = escapeshellarg($_POST['v_web_template']);
+    $v_package = quoteshellarg($_POST['v_package']);
+    $v_package_new = quoteshellarg($_POST['v_package_new']);
+    $v_web_template = quoteshellarg($_POST['v_web_template']);
     if (!empty($_SESSION['WEB_BACKEND'])) {
-        $v_backend_template = escapeshellarg($_POST['v_backend_template']);
+        $v_backend_template = quoteshellarg($_POST['v_backend_template']);
     }
     if (!empty($_SESSION['PROXY_SYSTEM'])) {
-        $v_proxy_template = escapeshellarg($_POST['v_proxy_template']);
+        $v_proxy_template = quoteshellarg($_POST['v_proxy_template']);
     }
-    $v_dns_template = escapeshellarg($_POST['v_dns_template']);
-    $v_shell = escapeshellarg($_POST['v_shell']);
-    $v_web_domains = escapeshellarg($_POST['v_web_domains']);
-    $v_web_aliases = escapeshellarg($_POST['v_web_aliases']);
-    $v_dns_domains = escapeshellarg($_POST['v_dns_domains']);
-    $v_dns_records = escapeshellarg($_POST['v_dns_records']);
-    $v_mail_domains = escapeshellarg($_POST['v_mail_domains']);
-    $v_mail_accounts = escapeshellarg($_POST['v_mail_accounts']);
-    $v_databases = escapeshellarg($_POST['v_databases']);
-    $v_cron_jobs = escapeshellarg($_POST['v_cron_jobs']);
-    $v_backups = escapeshellarg($_POST['v_backups']);
-    $v_disk_quota = escapeshellarg($_POST['v_disk_quota']);
-    $v_bandwidth = escapeshellarg($_POST['v_bandwidth']);
+    $v_dns_template = quoteshellarg($_POST['v_dns_template']);
+    $v_shell = quoteshellarg($_POST['v_shell']);
+    $v_web_domains = quoteshellarg($_POST['v_web_domains']);
+    $v_web_aliases = quoteshellarg($_POST['v_web_aliases']);
+    $v_dns_domains = quoteshellarg($_POST['v_dns_domains']);
+    $v_dns_records = quoteshellarg($_POST['v_dns_records']);
+    $v_mail_domains = quoteshellarg($_POST['v_mail_domains']);
+    $v_mail_accounts = quoteshellarg($_POST['v_mail_accounts']);
+    $v_databases = quoteshellarg($_POST['v_databases']);
+    $v_cron_jobs = quoteshellarg($_POST['v_cron_jobs']);
+    $v_backups = quoteshellarg($_POST['v_backups']);
+    $v_disk_quota = quoteshellarg($_POST['v_disk_quota']);
+    $v_bandwidth = quoteshellarg($_POST['v_bandwidth']);
     $v_ns1 = trim($_POST['v_ns1'], '.');
     $v_ns2 = trim($_POST['v_ns2'], '.');
     $v_ns3 = trim($_POST['v_ns3'], '.');
@@ -261,9 +261,9 @@ if (!empty($_POST['save'])) {
     if (!empty($v_ns8)) {
         $v_ns .= ",".$v_ns8;
     }
-    $v_ns = escapeshellarg($v_ns);
-    $v_time = escapeshellarg(date('H:i:s'));
-    $v_date = escapeshellarg(date('Y-m-d'));
+    $v_ns = quoteshellarg($v_ns);
+    $v_time = quoteshellarg(date('H:i:s'));
+    $v_date = quoteshellarg(date('Y-m-d'));
 
     // Save package file on a fs
     $pkg = "WEB_TEMPLATE=".$v_web_template."\n";

--- a/web/edit/server/index.php
+++ b/web/edit/server/index.php
@@ -206,7 +206,7 @@ foreach ($backup_types as $backup_type) {
     if ($backup_type == 'local') {
         $v_backup = 'yes';
     } else {
-        exec(HESTIA_CMD."v-list-backup-host ".escapeshellarg($backup_type)." json", $output, $return_var);
+        exec(HESTIA_CMD."v-list-backup-host ".quoteshellarg($backup_type)." json", $output, $return_var);
         $v_remote_backup = json_decode(implode('', $output), true);
         unset($output);
         if (in_array($backup_type, array('ftp','sftp'))) {
@@ -286,7 +286,7 @@ if (!empty($_POST['save'])) {
 
     // Change hostname
     if ((!empty($_POST['v_hostname'])) && ($v_hostname != $_POST['v_hostname'])) {
-        exec(HESTIA_CMD."v-change-sys-hostname ".escapeshellarg($_POST['v_hostname']), $output, $return_var);
+        exec(HESTIA_CMD."v-change-sys-hostname ".quoteshellarg($_POST['v_hostname']), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_hostname = $_POST['v_hostname'];
@@ -303,7 +303,7 @@ if (!empty($_POST['save'])) {
                 array_map(function ($php_version) use ($post_php) {
                     if (array_key_exists($php_version->tpl, $post_php)) {
                         if (!$php_version->installed) {
-                            exec(HESTIA_CMD . "v-add-web-php " . escapeshellarg($php_version->version), $output, $return_var);
+                            exec(HESTIA_CMD . "v-add-web-php " . quoteshellarg($php_version->version), $output, $return_var);
                             check_return_code($return_var, $output);
                             unset($output);
                             if (empty($_SESSION['error_msg'])) {
@@ -312,7 +312,7 @@ if (!empty($_POST['save'])) {
                         }
                     } else {
                         if ($php_version->installed && !$php_version->protected) {
-                            exec(HESTIA_CMD . "v-delete-web-php " . escapeshellarg($php_version->version), $output, $return_var);
+                            exec(HESTIA_CMD . "v-delete-web-php " . quoteshellarg($php_version->version), $output, $return_var);
                             check_return_code($return_var, $output);
                             unset($output);
                             if (empty($_SESSION['error_msg'])) {
@@ -328,7 +328,7 @@ if (!empty($_POST['save'])) {
 
         if (empty($_SESSION['error_msg'])) {
             if ('php-'.$_POST['v_php_default_version'] != DEFAULT_PHP_VERSION) {
-                exec(HESTIA_CMD . "v-change-sys-php " . escapeshellarg($_POST['v_php_default_version']), $output, $return_var);
+                exec(HESTIA_CMD . "v-change-sys-php " . quoteshellarg($_POST['v_php_default_version']), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 //force reload
@@ -382,7 +382,7 @@ if (!empty($_POST['save'])) {
             }
 
             if ($v_timezone != $v_tz) {
-                exec(HESTIA_CMD."v-change-sys-timezone ".escapeshellarg($v_tz), $output, $return_var);
+                exec(HESTIA_CMD."v-change-sys-timezone ".quoteshellarg($v_tz), $output, $return_var);
                 check_return_code($return_var, $output);
                 $v_timezone = $v_tz;
                 unset($output);
@@ -394,12 +394,12 @@ if (!empty($_POST['save'])) {
     if (empty($_SESSION['error_msg'])) {
         if ((!empty($_POST['v_language'])) && ($_SESSION['LANGUAGE'] != $_POST['v_language'])) {
             if (isset($_POST['v_language_update'])) {
-                exec(HESTIA_CMD."v-change-sys-language ".escapeshellarg($_POST['v_language'])." yes", $output, $return_var);
+                exec(HESTIA_CMD."v-change-sys-language ".quoteshellarg($_POST['v_language'])." yes", $output, $return_var);
                 if (empty($_SESSION['error_msg'])) {
                     $_SESSION['LANGUAGE'] = $_POST['v_language'];
                 }
             }
-            exec(HESTIA_CMD."v-change-sys-language ".escapeshellarg($_POST['v_language']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-language ".quoteshellarg($_POST['v_language']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -411,7 +411,7 @@ if (!empty($_POST['save'])) {
     // Update theme
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_theme'] != $_SESSION['THEME']) {
-            exec(HESTIA_CMD."v-change-sys-config-value THEME ".escapeshellarg($_POST['v_theme']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value THEME ".quoteshellarg($_POST['v_theme']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -425,7 +425,7 @@ if (!empty($_POST['save'])) {
             $_POST['v_debug_mode'] = 'false';
         }
         if ($_POST['v_debug_mode'] != $_SESSION['DEBUG_MODE']) {
-            exec(HESTIA_CMD."v-change-sys-config-value DEBUG_MODE ".escapeshellarg($_POST['v_debug_mode']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value DEBUG_MODE ".quoteshellarg($_POST['v_debug_mode']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_debug_mode_adv = 'yes';
@@ -440,7 +440,7 @@ if (!empty($_POST['save'])) {
             } else {
                 $_POST['v_plugin_app_installer'] = 'false';
             }
-            exec(HESTIA_CMD."v-change-sys-config-value PLUGIN_APP_INSTALLER ".escapeshellarg($_POST['v_plugin_app_installer']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value PLUGIN_APP_INSTALLER ".quoteshellarg($_POST['v_plugin_app_installer']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -454,14 +454,14 @@ if (!empty($_POST['save'])) {
             $_POST['v_experimental_features'] = 'false';
         }
         if ($_POST['v_experimental_features'] != $_SESSION['POLICY_SYSTEM_ENABLE_BACON']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_ENABLE_BACON ".escapeshellarg($_POST['v_experimental_features']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_ENABLE_BACON ".quoteshellarg($_POST['v_experimental_features']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_debug_mode_adv = 'yes';
         }
         if (($_POST['v_policy_user_view_suspended'] != $_SESSION['POLICY_SYSTEM_ENABLE_BACON']) && $_POST['v_experimental_features'] == "false") {
             //disable preview mode
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_VIEW_SUSPENDED ".escapeshellarg($_POST['v_policy_user_view_suspended']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_VIEW_SUSPENDED ".quoteshellarg($_POST['v_policy_user_view_suspended']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -559,7 +559,7 @@ if (!empty($_POST['save'])) {
     // Update mysql pasword
     if (empty($_SESSION['error_msg'])) {
         if (!empty($_POST['v_mysql_password'])) {
-            exec(HESTIA_CMD."v-change-database-host-password mysql localhost root ".escapeshellarg($_POST['v_mysql_password']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-database-host-password mysql localhost root ".quoteshellarg($_POST['v_mysql_password']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_db_adv = 'yes';
@@ -569,7 +569,7 @@ if (!empty($_POST['save'])) {
     // Update webmail url
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_webmail_alias'] != $_SESSION['WEBMAIL_ALIAS']) {
-            exec(HESTIA_CMD."v-change-sys-webmail ".escapeshellarg($_POST['v_webmail_alias']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-webmail ".quoteshellarg($_POST['v_webmail_alias']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_mail_adv = 'yes';
@@ -583,11 +583,11 @@ if (!empty($_POST['save'])) {
                      ($_POST['v_smtp_relay_user'] != $v_smtp_relay_user) ||
                      ($_POST['v_smtp_relay_port'] != $v_smtp_relay_port)) {
                 $v_smtp_relay = true;
-                $v_smtp_relay_host = escapeshellarg($_POST['v_smtp_relay_host']);
-                $v_smtp_relay_user = escapeshellarg($_POST['v_smtp_relay_user']);
-                $v_smtp_relay_pass = escapeshellarg($_POST['v_smtp_relay_pass']);
+                $v_smtp_relay_host = quoteshellarg($_POST['v_smtp_relay_host']);
+                $v_smtp_relay_user = quoteshellarg($_POST['v_smtp_relay_user']);
+                $v_smtp_relay_pass = quoteshellarg($_POST['v_smtp_relay_pass']);
                 if (!empty($_POST['v_smtp_relay_port'])) {
-                    $v_smtp_relay_port = escapeshellarg($_POST['v_smtp_relay_port']);
+                    $v_smtp_relay_port = quoteshellarg($_POST['v_smtp_relay_port']);
                 } else {
                     $v_smtp_relay_port = '587';
                 }
@@ -608,7 +608,7 @@ if (!empty($_POST['save'])) {
     // Update phpMyAdmin url
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_mysql_url'] != $_SESSION['DB_PMA_ALIAS']) {
-            exec(HESTIA_CMD."v-change-sys-db-alias pma ".escapeshellarg($_POST['v_mysql_url']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-db-alias pma ".quoteshellarg($_POST['v_mysql_url']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_db_adv = 'yes';
@@ -618,7 +618,7 @@ if (!empty($_POST['save'])) {
     // Update phpPgAdmin url
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_pgsql_url'] != $_SESSION['DB_PGA_ALIAS']) {
-            exec(HESTIA_CMD."v-change-sys-db-alias pga ".escapeshellarg($_POST['v_pgsql_url']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-db-alias pga ".quoteshellarg($_POST['v_pgsql_url']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_db_adv = 'yes';
@@ -638,7 +638,7 @@ if (!empty($_POST['save'])) {
             } else {
                 $_POST['v_upgrade_send_notification_email'] = 'false';
             }
-            exec(HESTIA_CMD."v-change-sys-config-value UPGRADE_SEND_EMAIL ".escapeshellarg($_POST['v_upgrade_send_notification_email']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value UPGRADE_SEND_EMAIL ".quoteshellarg($_POST['v_upgrade_send_notification_email']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_upgrade_notification_adv = 'yes';
@@ -661,7 +661,7 @@ if (!empty($_POST['save'])) {
             } else {
                 $_POST['v_upgrade_send_email_log'] = 'false';
             }
-            exec(HESTIA_CMD."v-change-sys-config-value UPGRADE_SEND_EMAIL_LOG ".escapeshellarg($_POST['v_upgrade_send_email_log']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value UPGRADE_SEND_EMAIL_LOG ".quoteshellarg($_POST['v_upgrade_send_email_log']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_upgrade_send_log_adv = 'yes';
@@ -700,7 +700,7 @@ if (!empty($_POST['save'])) {
             if ($_POST['v_backup_mode'] == 'gzip') {
                 $_POST['v_backup_gzip'] = 9;
             }
-            exec(HESTIA_CMD."v-change-sys-config-value BACKUP_GZIP ".escapeshellarg($_POST['v_backup_gzip']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value BACKUP_GZIP ".quoteshellarg($_POST['v_backup_gzip']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -713,7 +713,7 @@ if (!empty($_POST['save'])) {
     // Change backup mode
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_backup_mode'] != $v_backup_mode) {
-            exec(HESTIA_CMD."v-change-sys-config-value BACKUP_MODE ".escapeshellarg($_POST['v_backup_mode']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value BACKUP_MODE ".quoteshellarg($_POST['v_backup_mode']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -725,7 +725,7 @@ if (!empty($_POST['save'])) {
                 if (empty($_SESSION['error_msg'])) {
                     $v_backup_gzip = $_POST['v_backup_gzip'];
                 }
-                exec(HESTIA_CMD."v-change-sys-config-value BACKUP_GZIP ".escapeshellarg($_POST['v_backup_gzip']), $output, $return_var);
+                exec(HESTIA_CMD."v-change-sys-config-value BACKUP_GZIP ".quoteshellarg($_POST['v_backup_gzip']), $output, $return_var);
             }
         }
     }
@@ -738,7 +738,7 @@ if (!empty($_POST['save'])) {
         if ($_POST['v_backup_dir'] != $v_backup_dir) {
             /*
             See #1655
-            exec (HESTIA_CMD."v-change-sys-config-value BACKUP ".escapeshellarg($_POST['v_backup_dir']), $output, $return_var);
+            exec (HESTIA_CMD."v-change-sys-config-value BACKUP ".quoteshellarg($_POST['v_backup_dir']), $output, $return_var);
             check_return_code($return_var,$output);
             unset($output);
             */
@@ -753,12 +753,12 @@ if (!empty($_POST['save'])) {
     if (empty($_SESSION['error_msg'])) {
         if (($v_backup_host == '' && $v_backup_bucket == '' && ((!empty($_POST['v_backup_host'])) || !empty($_POST['v_backup_bucket'])))) {
             if (in_array($_POST['v_backup_type'], array('ftp','sftp'))) {
-                $v_backup_host = escapeshellarg($_POST['v_backup_host']);
-                $v_backup_port = escapeshellarg($_POST['v_backup_port']);
-                $v_backup_type = escapeshellarg($_POST['v_backup_type']);
-                $v_backup_username = escapeshellarg($_POST['v_backup_username']);
+                $v_backup_host = quoteshellarg($_POST['v_backup_host']);
+                $v_backup_port = quoteshellarg($_POST['v_backup_port']);
+                $v_backup_type = quoteshellarg($_POST['v_backup_type']);
+                $v_backup_username = quoteshellarg($_POST['v_backup_username']);
                 $v_backup_password = escapeshellcmd($_POST['v_backup_password']);
-                $v_backup_bpath = escapeshellarg($_POST['v_backup_bpath']);
+                $v_backup_bpath = quoteshellarg($_POST['v_backup_bpath']);
                 exec(HESTIA_CMD."v-add-backup-host ". $v_backup_type ." ". $v_backup_host ." ". $v_backup_username ." ". $v_backup_password ." ". $v_backup_bpath." ".$v_backup_port, $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
@@ -784,21 +784,21 @@ if (!empty($_POST['save'])) {
                 $v_backup_adv = 'yes';
                 $v_backup_remote_adv = 'yes';
             } elseif (in_array($_POST['v_backup_type'], array('b2'))) {
-                $v_backup_type = escapeshellarg($_POST['v_backup_type']);
-                $v_backup_bucket = escapeshellarg($_POST['v_backup_bucket']);
-                $v_backup_application_id = escapeshellarg($_POST['v_backup_application_id']);
-                $v_backup_application_key = escapeshellarg($_POST['v_backup_application_key']);
+                $v_backup_type = quoteshellarg($_POST['v_backup_type']);
+                $v_backup_bucket = quoteshellarg($_POST['v_backup_bucket']);
+                $v_backup_application_id = quoteshellarg($_POST['v_backup_application_id']);
+                $v_backup_application_key = quoteshellarg($_POST['v_backup_application_key']);
                 exec(HESTIA_CMD."v-add-backup-host ". $v_backup_type ." ". $v_backup_bucket ." ". $v_backup_application_id ." ". $v_backup_application_key, $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 if (empty($_SESSION['error_msg'])) {
-                    $v_backup_bucket = escapeshellarg($_POST['v_backup_bucket']);
+                    $v_backup_bucket = quoteshellarg($_POST['v_backup_bucket']);
                 }
                 if (empty($_SESSION['error_msg'])) {
-                    $v_backup_application_id = escapeshellarg($_POST['v_backup_application_id']);
+                    $v_backup_application_id = quoteshellarg($_POST['v_backup_application_id']);
                 }
                 if (empty($_SESSION['error_msg'])) {
-                    $v_backup_application_key = escapeshellarg($_POST['v_backup_application_key']);
+                    $v_backup_application_key = quoteshellarg($_POST['v_backup_application_key']);
                 }
                 $v_backup_new = 'yes';
                 $v_backup_adv = 'yes';
@@ -810,15 +810,15 @@ if (!empty($_POST['save'])) {
     // Change remote backup host type
     if (empty($_SESSION['error_msg'])) {
         if ((!empty($_POST['v_backup_host'])) && ($_POST['v_backup_type'] != $v_backup_type) && $v_backup_type != '') {
-            exec(HESTIA_CMD."v-delete-backup-host " . escapeshellarg($v_backup_type), $output, $return_var);
+            exec(HESTIA_CMD."v-delete-backup-host " . quoteshellarg($v_backup_type), $output, $return_var);
             unset($output);
             if (in_array($_POST['v_backup_type'], array('ftp','sftp'))) {
-                $v_backup_host = escapeshellarg($_POST['v_backup_host']);
-                $v_backup_port = escapeshellarg($_POST['v_backup_port']);
-                $v_backup_type = escapeshellarg($_POST['v_backup_type']);
-                $v_backup_username = escapeshellarg($_POST['v_backup_username']);
+                $v_backup_host = quoteshellarg($_POST['v_backup_host']);
+                $v_backup_port = quoteshellarg($_POST['v_backup_port']);
+                $v_backup_type = quoteshellarg($_POST['v_backup_type']);
+                $v_backup_username = quoteshellarg($_POST['v_backup_username']);
                 $v_backup_password = escapeshellcmd($_POST['v_backup_password']);
-                $v_backup_bpath = escapeshellarg($_POST['v_backup_bpath']);
+                $v_backup_bpath = quoteshellarg($_POST['v_backup_bpath']);
                 exec(HESTIA_CMD."v-add-backup-host ". $v_backup_type ." ". $v_backup_host ." ". $v_backup_username ." ". $v_backup_password ." ". $v_backup_bpath." ".$v_backup_port, $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
@@ -843,21 +843,21 @@ if (!empty($_POST['save'])) {
                 $v_backup_adv = 'yes';
                 $v_backup_remote_adv = 'yes';
             } elseif (in_array($_POST['v_backup_type'], array('b2'))) {
-                $v_backup_bucket = escapeshellarg($_POST['v_backup_bucket']);
-                $v_backup_application_id = escapeshellarg($_POST['v_backup_application_id']);
-                $v_backup_application_key = escapeshellarg($_POST['v_backup_application_key']);
+                $v_backup_bucket = quoteshellarg($_POST['v_backup_bucket']);
+                $v_backup_application_id = quoteshellarg($_POST['v_backup_application_id']);
+                $v_backup_application_key = quoteshellarg($_POST['v_backup_application_key']);
                 exec(HESTIA_CMD."v-add-backup-host ". $v_backup_type ." ". $v_backup_bucket ." ". $v_backup_application_id ." ". $v_backup_application_key, $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
-                $v_backup_type = escapeshellarg($_POST['v_backup_type']);
+                $v_backup_type = quoteshellarg($_POST['v_backup_type']);
                 if (empty($_SESSION['error_msg'])) {
-                    $v_backup_bucket = escapeshellarg($_POST['v_backup_bucket']);
+                    $v_backup_bucket = quoteshellarg($_POST['v_backup_bucket']);
                 }
                 if (empty($_SESSION['error_msg'])) {
-                    $v_backup_application_id = escapeshellarg($_POST['v_backup_application_id']);
+                    $v_backup_application_id = quoteshellarg($_POST['v_backup_application_id']);
                 }
                 if (empty($_SESSION['error_msg'])) {
-                    $v_backup_application_key = escapeshellarg($_POST['v_backup_application_key']);
+                    $v_backup_application_key = quoteshellarg($_POST['v_backup_application_key']);
                 }
                 $v_backup_adv = 'yes';
                 $v_backup_remote_adv = 'yes';
@@ -870,12 +870,12 @@ if (!empty($_POST['save'])) {
         if ((!empty($_POST['v_backup_host'])) && ($_POST['v_backup_type'] == $v_backup_type) && (!isset($v_backup_new))) {
             if (in_array($_POST['v_backup_type'], array('ftp','sftp'))) {
                 if (($_POST['v_backup_host'] != $v_backup_host) || ($_POST['v_backup_username'] != $v_backup_username) || ($_POST['v_backup_password'] != $v_backup_password) || ($_POST['v_backup_bpath'] != $v_backup_bpath || $_POST['v_backup_port'] != $v_backup_port)) {
-                    $v_backup_host = escapeshellarg($_POST['v_backup_host']);
-                    $v_backup_port = escapeshellarg($_POST['v_backup_port']);
-                    $v_backup_type = escapeshellarg($_POST['v_backup_type']);
-                    $v_backup_username = escapeshellarg($_POST['v_backup_username']);
+                    $v_backup_host = quoteshellarg($_POST['v_backup_host']);
+                    $v_backup_port = quoteshellarg($_POST['v_backup_port']);
+                    $v_backup_type = quoteshellarg($_POST['v_backup_type']);
+                    $v_backup_username = quoteshellarg($_POST['v_backup_username']);
                     $v_backup_password = escapeshellcmd($_POST['v_backup_password']);
-                    $v_backup_bpath = escapeshellarg($_POST['v_backup_bpath']);
+                    $v_backup_bpath = quoteshellarg($_POST['v_backup_bpath']);
                     exec(HESTIA_CMD."v-add-backup-host ". $v_backup_type ." ". $v_backup_host ." ". $v_backup_username ." ". $v_backup_password ." ". $v_backup_bpath." ".$v_backup_port, $output, $return_var);
                     check_return_code($return_var, $output);
                     unset($output);
@@ -902,21 +902,21 @@ if (!empty($_POST['save'])) {
                 }
             } elseif (in_array($_POST['v_backup_type'], array('b2'))) {
                 if (($_POST['v_backup_bucket'] != $v_backup_bucket) || ($_POST['v_backup_application_key'] != $v_backup_application_key) || ($_POST['v_backup_application_id'] != $v_backup_application_id)) {
-                    $v_backup_type = escapeshellarg($_POST['v_backup_type']);
-                    $v_backup_bucket = escapeshellarg($_POST['v_backup_bucket']);
-                    $v_backup_application_id = escapeshellarg($_POST['v_backup_application_id']);
-                    $v_backup_application_key = escapeshellarg($_POST['v_backup_application_key']);
+                    $v_backup_type = quoteshellarg($_POST['v_backup_type']);
+                    $v_backup_bucket = quoteshellarg($_POST['v_backup_bucket']);
+                    $v_backup_application_id = quoteshellarg($_POST['v_backup_application_id']);
+                    $v_backup_application_key = quoteshellarg($_POST['v_backup_application_key']);
                     exec(HESTIA_CMD."v-add-backup-host ". $v_backup_type ." ". $v_backup_bucket ." ". $v_backup_application_id ." ". $v_backup_application_key, $output, $return_var);
                     check_return_code($return_var, $output);
                     unset($output);
                     if (empty($_SESSION['error_msg'])) {
-                        $v_backup_bucket = escapeshellarg($_POST['v_backup_bucket']);
+                        $v_backup_bucket = quoteshellarg($_POST['v_backup_bucket']);
                     }
                     if (empty($_SESSION['error_msg'])) {
-                        $v_backup_application_id = escapeshellarg($_POST['v_backup_application_id']);
+                        $v_backup_application_id = quoteshellarg($_POST['v_backup_application_id']);
                     }
                     if (empty($_SESSION['error_msg'])) {
-                        $v_backup_application_key = escapeshellarg($_POST['v_backup_application_key']);
+                        $v_backup_application_key = quoteshellarg($_POST['v_backup_application_key']);
                     }
                     $v_backup_adv = 'yes';
                     $v_backup_remote_adv = 'yes';
@@ -928,7 +928,7 @@ if (!empty($_POST['save'])) {
     // Delete remote backup host
     if (empty($_SESSION['error_msg'])) {
         if (empty($_POST['v_backup_remote_adv']) && $v_backup_remote_adv != '') {
-            exec(HESTIA_CMD."v-delete-backup-host ".escapeshellarg($v_backup_type), $output, $return_var);
+            exec(HESTIA_CMD."v-delete-backup-host ".quoteshellarg($v_backup_type), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -966,7 +966,7 @@ if (!empty($_POST['save'])) {
             if ($_POST['v_inactive_session_timeout'] < 1) {
                 $_SESSION['error_msg'] = _('Inactive session timeout can not lower than 1 minute');
             } else {
-                exec(HESTIA_CMD."v-change-sys-config-value INACTIVE_SESSION_TIMEOUT ".escapeshellarg($_POST['v_inactive_session_timeout']), $output, $return_var);
+                exec(HESTIA_CMD."v-change-sys-config-value INACTIVE_SESSION_TIMEOUT ".quoteshellarg($_POST['v_inactive_session_timeout']), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 if (empty($_SESSION['error_msg'])) {
@@ -980,7 +980,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_CSRF_STRICTNESS
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_csrf_strictness'] != $_SESSION['POLICY_CSRF_STRICTNESS']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_CSRF_STRICTNESS ".escapeshellarg($_POST['v_policy_csrf_strictness']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_CSRF_STRICTNESS ".quoteshellarg($_POST['v_policy_csrf_strictness']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -993,7 +993,7 @@ if (!empty($_POST['save'])) {
     // Change ENFORCE_SUBDOMAIN_OWNERSHIP
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_enforce_subdomain_ownership'] != $_SESSION['ENFORCE_SUBDOMAIN_OWNERSHIP']) {
-            exec(HESTIA_CMD."v-change-sys-config-value ENFORCE_SUBDOMAIN_OWNERSHIP ".escapeshellarg($_POST['v_enforce_subdomain_ownership']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value ENFORCE_SUBDOMAIN_OWNERSHIP ".quoteshellarg($_POST['v_enforce_subdomain_ownership']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1006,7 +1006,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_USER_EDIT_DETAILS
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_user_edit_details'] != $_SESSION['POLICY_USER_EDIT_DETAILS']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_EDIT_DETAILS ".escapeshellarg($_POST['v_policy_user_edit_details']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_EDIT_DETAILS ".quoteshellarg($_POST['v_policy_user_edit_details']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1019,7 +1019,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_USER_EDIT_WEB_TEMPLATES
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_user_edit_web_templates'] != $_SESSION['POLICY_USER_EDIT_WEB_TEMPLATES']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_EDIT_WEB_TEMPLATES ".escapeshellarg($_POST['v_policy_user_edit_web_templates']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_EDIT_WEB_TEMPLATES ".quoteshellarg($_POST['v_policy_user_edit_web_templates']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1032,7 +1032,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_USER_EDIT_DNS_TEMPLATES
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_user_edit_dns_templates'] != $_SESSION['POLICY_USER_EDIT_DNS_TEMPLATES']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_EDIT_DNS_TEMPLATES ".escapeshellarg($_POST['v_policy_user_edit_dns_templates']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_EDIT_DNS_TEMPLATES ".quoteshellarg($_POST['v_policy_user_edit_dns_templates']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1057,7 +1057,7 @@ if (!empty($_POST['save'])) {
         }
         if (empty($_SESSION['error_msg'])) {
             if ($_POST['v_api_system'] != $_SESSION['API_SYSTEM']) {
-                exec(HESTIA_CMD."v-change-sys-config-value API_SYSTEM ".escapeshellarg($_POST['v_api_system']), $output, $return_var);
+                exec(HESTIA_CMD."v-change-sys-config-value API_SYSTEM ".quoteshellarg($_POST['v_api_system']), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 if (empty($_SESSION['error_msg'])) {
@@ -1074,7 +1074,7 @@ if (!empty($_POST['save'])) {
                 if ($_POST['v_api'] == 'yes') {
                     $api_status = 'yes';
                 }
-                exec(HESTIA_CMD."v-change-sys-config-value API ".escapeshellarg($api_status), $output, $return_var);
+                exec(HESTIA_CMD."v-change-sys-config-value API ".quoteshellarg($api_status), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 if (empty($_SESSION['error_msg'])) {
@@ -1098,7 +1098,7 @@ if (!empty($_POST['save'])) {
                     }
                 }
                 if (implode(',', $ips) != $_SESSION['API_ALLOWED_IP']) {
-                    exec(HESTIA_CMD."v-change-sys-config-value API_ALLOWED_IP ".escapeshellarg(implode(',', $ips)), $output, $return_var);
+                    exec(HESTIA_CMD."v-change-sys-config-value API_ALLOWED_IP ".quoteshellarg(implode(',', $ips)), $output, $return_var);
                     check_return_code($return_var, $output);
                     unset($output);
                     if (empty($_SESSION['error_msg'])) {
@@ -1114,7 +1114,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_USER_VIEW_LOGS
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_user_view_logs'] != $_SESSION['POLICY_USER_VIEW_LOGS']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_VIEW_LOGS ".escapeshellarg($_POST['v_policy_user_view_logs']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_VIEW_LOGS ".quoteshellarg($_POST['v_policy_user_view_logs']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1127,7 +1127,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_USER_DELETE_LOGS
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_user_delete_logs'] != $_SESSION['POLICY_USER_DELETE_LOGS']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_DELETE_LOGS ".escapeshellarg($_POST['v_policy_user_delete_logs']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_DELETE_LOGS ".quoteshellarg($_POST['v_policy_user_delete_logs']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1140,7 +1140,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_SYSTEM_PASSWORD_RESET
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_system_password_reset'] != $_SESSION['POLICY_SYSTEM_PASSWORD_RESET']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_PASSWORD_RESET ".escapeshellarg($_POST['v_policy_system_password_reset']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_PASSWORD_RESET ".quoteshellarg($_POST['v_policy_system_password_reset']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1153,7 +1153,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_SYSTEM_PROTECTED_ADMIN
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_system_protected_admin'] != $_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_PROTECTED_ADMIN ".escapeshellarg($_POST['v_policy_system_protected_admin']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_PROTECTED_ADMIN ".quoteshellarg($_POST['v_policy_system_protected_admin']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1166,7 +1166,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_USER_VIEW_SUSPENDED
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_user_view_suspended'] != $_SESSION['POLICY_USER_VIEW_SUSPENDED'] && !empty($_SESSION['POLICY_USER_VIEW_SUSPENDED'])) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_VIEW_SUSPENDED ".escapeshellarg($_POST['v_policy_user_view_suspended']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_VIEW_SUSPENDED ".quoteshellarg($_POST['v_policy_user_view_suspended']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1188,7 +1188,7 @@ if (!empty($_POST['save'])) {
         }
         {
                 if ($_POST['v_policy_user_change_theme'] != $_SESSION['POLICY_USER_CHANGE_THEME']) {
-                    exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_CHANGE_THEME ".escapeshellarg($_POST['v_policy_user_change_theme']), $output, $return_var);
+                    exec(HESTIA_CMD."v-change-sys-config-value POLICY_USER_CHANGE_THEME ".quoteshellarg($_POST['v_policy_user_change_theme']), $output, $return_var);
                     check_return_code($return_var, $output);
                     unset($output);
                     if ($_POST['v_policy_user_change_theme']) {
@@ -1205,7 +1205,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_SYSTEM_HIDE_ADMIN
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_system_hide_admin'] != $_SESSION['POLICY_SYSTEM_HIDE_ADMIN']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_HIDE_ADMIN ".escapeshellarg($_POST['v_policy_system_hide_admin']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_HIDE_ADMIN ".quoteshellarg($_POST['v_policy_system_hide_admin']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1219,7 +1219,7 @@ if (!empty($_POST['save'])) {
     // Change POLICY_SYSTEM_HIDE_SERVICES
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_policy_system_hide_services'] != $_SESSION['POLICY_SYSTEM_HIDE_SERVICES']) {
-            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_HIDE_SERVICES ".escapeshellarg($_POST['v_policy_system_hide_services']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value POLICY_SYSTEM_HIDE_SERVICES ".quoteshellarg($_POST['v_policy_system_hide_services']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {
@@ -1232,7 +1232,7 @@ if (!empty($_POST['save'])) {
     // Change login style
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_login_style'] != $_SESSION['LOGIN_STYLE']) {
-            exec(HESTIA_CMD."v-change-sys-config-value LOGIN_STYLE ".escapeshellarg($_POST['v_login_style']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-sys-config-value LOGIN_STYLE ".quoteshellarg($_POST['v_login_style']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             if (empty($_SESSION['error_msg'])) {

--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -32,7 +32,7 @@ if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look'])) && ($us
 verify_csrf($_GET);
 
 // List user
-exec(HESTIA_CMD."v-list-user ".escapeshellarg($v_username)." json", $output, $return_var);
+exec(HESTIA_CMD."v-list-user ".quoteshellarg($v_username)." json", $output, $return_var);
 check_return_code_redirect($return_var, $output, '/list/user/');
 
 $data = json_decode(implode('', $output), true);
@@ -160,22 +160,22 @@ if (!empty($_POST['save'])) {
             $fp = fopen($v_password, "w");
             fwrite($fp, $_POST['v_password']."\n");
             fclose($fp);
-            exec(HESTIA_CMD."v-change-user-password ".escapeshellarg($v_username)." ".$v_password, $output, $return_var);
+            exec(HESTIA_CMD."v-change-user-password ".quoteshellarg($v_username)." ".$v_password, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             unlink($v_password);
-            $v_password = escapeshellarg($_POST['v_password']);
+            $v_password = quoteshellarg($_POST['v_password']);
         }
     }
 
     // Enable twofa
     if ((!empty($_POST['v_twofa'])) && (empty($v_twofa)) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-user-2fa ".escapeshellarg($v_username), $output, $return_var);
+        exec(HESTIA_CMD."v-add-user-2fa ".quoteshellarg($v_username), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
 
         // List user
-        exec(HESTIA_CMD."v-list-user ".escapeshellarg($v_username)." json", $output, $return_var);
+        exec(HESTIA_CMD."v-list-user ".quoteshellarg($v_username)." json", $output, $return_var);
         check_return_code($return_var, $output);
         $data = json_decode(implode('', $output), true);
         unset($output);
@@ -187,7 +187,7 @@ if (!empty($_POST['save'])) {
 
     // Disable twofa
     if ((empty($_POST['v_twofa'])) && (!empty($v_twofa)) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-user-2fa ".escapeshellarg($v_username), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-user-2fa ".quoteshellarg($v_username), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_twofa = '';
@@ -196,8 +196,8 @@ if (!empty($_POST['save'])) {
 
     // Change default sort order
     if (($v_sort_order != $_POST['v_sort_order']) && (empty($_SESSION['error_msg']))) {
-        $v_sort_order = escapeshellarg($_POST['v_sort_order']);
-        exec(HESTIA_CMD."v-change-user-sort-order ".escapeshellarg($v_username)." ".$v_sort_order, $output, $return_var);
+        $v_sort_order = quoteshellarg($_POST['v_sort_order']);
+        exec(HESTIA_CMD."v-change-user-sort-order ".quoteshellarg($v_username)." ".$v_sort_order, $output, $return_var);
         check_return_code($return_var, $output);
         unset($_SESSION['userSortOrder']);
         $_SESSION['userSortOrder'] = $v_sort_order;
@@ -215,7 +215,7 @@ if (!empty($_POST['save'])) {
             } else {
                 $_POST['v_login_disabled'] = 'no';
             }
-            exec(HESTIA_CMD."v-change-user-config-value ".escapeshellarg($v_username)." LOGIN_DISABLED ".escapeshellarg($_POST['v_login_disabled']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-user-config-value ".quoteshellarg($v_username)." LOGIN_DISABLED ".quoteshellarg($_POST['v_login_disabled']), $output, $return_var);
             check_return_code($return_var, $output);
             $data[$user]['LOGIN_DISABLED'] = $_POST['v_login_disabled'];
             unset($output);
@@ -233,12 +233,12 @@ if (!empty($_POST['save'])) {
             } else {
                 $_POST['v_login_use_iplist'] = 'no';
             }
-            exec(HESTIA_CMD."v-change-user-config-value ".escapeshellarg($v_username)." LOGIN_USE_IPLIST ".escapeshellarg($_POST['v_login_use_iplist']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-user-config-value ".quoteshellarg($v_username)." LOGIN_USE_IPLIST ".quoteshellarg($_POST['v_login_use_iplist']), $output, $return_var);
             if ($_POST['v_login_use_iplist'] === 'no') {
-                exec(HESTIA_CMD."v-change-user-config-value ".escapeshellarg($v_username)." LOGIN_ALLOW_IPS ''", $output, $return_var);
+                exec(HESTIA_CMD."v-change-user-config-value ".quoteshellarg($v_username)." LOGIN_ALLOW_IPS ''", $output, $return_var);
                 $v_login_allowed_ips = '';
             } else {
-                exec(HESTIA_CMD."v-change-user-config-value ".escapeshellarg($v_username)." LOGIN_ALLOW_IPS ".escapeshellarg($_POST['v_login_allowed_ips']), $output, $return_var);
+                exec(HESTIA_CMD."v-change-user-config-value ".quoteshellarg($v_username)." LOGIN_ALLOW_IPS ".quoteshellarg($_POST['v_login_allowed_ips']), $output, $return_var);
                 unset($v_login_allowed_ips);
                 $v_login_allowed_ips = $_POST['v_login_allowed_ips'];
             }
@@ -251,23 +251,23 @@ if (!empty($_POST['save'])) {
     if ($_SESSION['userContext'] === 'admin') {
         // Change package (admin only)
         if (($v_package != $_POST['v_package']) && ($_SESSION['userContext'] === 'admin') && (empty($_SESSION['error_msg']))) {
-            $v_package = escapeshellarg($_POST['v_package']);
-            exec(HESTIA_CMD."v-change-user-package ".escapeshellarg($v_username)." ".$v_package, $output, $return_var);
+            $v_package = quoteshellarg($_POST['v_package']);
+            exec(HESTIA_CMD."v-change-user-package ".quoteshellarg($v_username)." ".$v_package, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
 
         // Change phpcli (admin only)
         if (($v_phpcli != $_POST['v_phpcli']) && ($_SESSION['userContext'] === 'admin') && (empty($_SESSION['error_msg']))) {
-            $v_phpcli = escapeshellarg($_POST['v_phpcli']);
-            exec(HESTIA_CMD."v-change-user-php-cli ".escapeshellarg($v_username)." ".$v_phpcli, $output, $return_var);
+            $v_phpcli = quoteshellarg($_POST['v_phpcli']);
+            exec(HESTIA_CMD."v-change-user-php-cli ".quoteshellarg($v_username)." ".$v_phpcli, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
         if (($v_role != $_POST['v_role']) && ($_SESSION['userContext'] === 'admin') && $v_username != "admin" && (empty($_SESSION['error_msg']))) {
             if (!empty($_POST['v_role'])) {
-                $v_role = escapeshellarg($_POST['v_role']);
-                exec(HESTIA_CMD."v-change-user-role ".escapeshellarg($v_username)." ".$v_role, $output, $return_var);
+                $v_role = quoteshellarg($_POST['v_role']);
+                exec(HESTIA_CMD."v-change-user-role ".quoteshellarg($v_username)." ".$v_role, $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 $v_role = $_POST['v_role'];
@@ -275,16 +275,16 @@ if (!empty($_POST['save'])) {
         }
         // Change shell (admin only)
         if (($v_shell != $_POST['v_shell']) && ($_SESSION['userContext'] === 'admin') && (empty($_SESSION['error_msg']))) {
-            $v_shell = escapeshellarg($_POST['v_shell']);
-            exec(HESTIA_CMD."v-change-user-shell ".escapeshellarg($v_username)." ".$v_shell, $output, $return_var);
+            $v_shell = quoteshellarg($_POST['v_shell']);
+            exec(HESTIA_CMD."v-change-user-shell ".quoteshellarg($v_username)." ".$v_shell, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
     }
     // Change language
     if (($v_language != $_POST['v_language']) && (empty($_SESSION['error_msg']))) {
-        $v_language = escapeshellarg($_POST['v_language']);
-        exec(HESTIA_CMD."v-change-user-language ".escapeshellarg($v_username)." ".$v_language, $output, $return_var);
+        $v_language = quoteshellarg($_POST['v_language']);
+        exec(HESTIA_CMD."v-change-user-language ".quoteshellarg($v_username)." ".$v_language, $output, $return_var);
         check_return_code($return_var, $output);
         if (empty($_SESSION['error_msg'])) {
             if (($_GET['user'] == $_SESSION['user'])) {
@@ -304,8 +304,8 @@ if (!empty($_POST['save'])) {
         if (!filter_var($_POST['v_email'], FILTER_VALIDATE_EMAIL)) {
             $_SESSION['error_msg'] = _('Please enter valid email address.');
         } else {
-            $v_email = escapeshellarg($_POST['v_email']);
-            exec(HESTIA_CMD."v-change-user-contact ".escapeshellarg($v_username)." ".$v_email, $output, $return_var);
+            $v_email = quoteshellarg($_POST['v_email']);
+            exec(HESTIA_CMD."v-change-user-contact ".quoteshellarg($v_username)." ".$v_email, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -316,8 +316,8 @@ if (!empty($_POST['save'])) {
         if (empty($_POST['v_name'])) {
             $_SESSION['error_msg'] = _('Please enter a valid name');
         } else {
-            $v_name = escapeshellarg($_POST['v_name']);
-            exec(HESTIA_CMD."v-change-user-name ".escapeshellarg($v_username). " ".$v_name, $output, $return_var);
+            $v_name = quoteshellarg($_POST['v_name']);
+            exec(HESTIA_CMD."v-change-user-name ".quoteshellarg($v_username). " ".$v_name, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_name = $_POST['v_name'];
@@ -327,7 +327,7 @@ if (!empty($_POST['save'])) {
     // Update theme
     if (empty($_SESSION['error_msg'])) {
         if ($_POST['v_user_theme'] != $_SESSION['userTheme']) {
-            exec(HESTIA_CMD."v-change-user-theme ".escapeshellarg($v_username)." ".escapeshellarg($_POST['v_user_theme']), $output, $return_var);
+            exec(HESTIA_CMD."v-change-user-theme ".quoteshellarg($v_username)." ".quoteshellarg($_POST['v_user_theme']), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_user_theme = $_POST['v_user_theme'];
@@ -366,15 +366,15 @@ if (!empty($_POST['save'])) {
 
     if (($v_ns1 != $_POST['v_ns1']) || ($v_ns2 != $_POST['v_ns2']) || ($v_ns3 != $_POST['v_ns3']) || ($v_ns4 != $_POST['v_ns4']) || ($v_ns5 != $_POST['v_ns5'])
  || ($v_ns6 != $_POST['v_ns6']) || ($v_ns7 != $_POST['v_ns7']) || ($v_ns8 != $_POST['v_ns8']) && (empty($_SESSION['error_msg']))) {
-        $v_ns1 = escapeshellarg($_POST['v_ns1']);
-        $v_ns2 = escapeshellarg($_POST['v_ns2']);
-        $v_ns3 = escapeshellarg($_POST['v_ns3']);
-        $v_ns4 = escapeshellarg($_POST['v_ns4']);
-        $v_ns5 = escapeshellarg($_POST['v_ns5']);
-        $v_ns6 = escapeshellarg($_POST['v_ns6']);
-        $v_ns7 = escapeshellarg($_POST['v_ns7']);
-        $v_ns8 = escapeshellarg($_POST['v_ns8']);
-        $ns_cmd = HESTIA_CMD."v-change-user-ns ".escapeshellarg($v_username)." ".$v_ns1." ".$v_ns2;
+        $v_ns1 = quoteshellarg($_POST['v_ns1']);
+        $v_ns2 = quoteshellarg($_POST['v_ns2']);
+        $v_ns3 = quoteshellarg($_POST['v_ns3']);
+        $v_ns4 = quoteshellarg($_POST['v_ns4']);
+        $v_ns5 = quoteshellarg($_POST['v_ns5']);
+        $v_ns6 = quoteshellarg($_POST['v_ns6']);
+        $v_ns7 = quoteshellarg($_POST['v_ns7']);
+        $v_ns8 = quoteshellarg($_POST['v_ns8']);
+        $ns_cmd = HESTIA_CMD."v-change-user-ns ".quoteshellarg($v_username)." ".$v_ns1." ".$v_ns2;
         if (!empty($_POST['v_ns3'])) {
             $ns_cmd = $ns_cmd." ".$v_ns3;
         }

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -15,7 +15,7 @@ if (empty($_GET['domain'])) {
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
     $user_plain=htmlentities($_GET['user']);
 }
 
@@ -26,7 +26,7 @@ $user_domains = array_keys($user_domains);
 unset($output);
 
 $v_domain = $_GET['domain'];
-exec(HESTIA_CMD."v-list-web-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+exec(HESTIA_CMD."v-list-web-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
 # Check if domain exists if not return /list/web/
 check_return_code_redirect($return_var, $output, '/list/web/');
 $data = json_decode(implode('', $output), true);
@@ -40,7 +40,7 @@ $valiases = explode(",", $data[$v_domain]['ALIAS']);
 
 $v_ssl = $data[$v_domain]['SSL'];
 if (!empty($v_ssl)) {
-    exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+    exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
     $ssl_str = json_decode(implode('', $output), true);
     unset($output);
     $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -185,7 +185,7 @@ if (!empty($_POST['save'])) {
     }
 
     if (($v_ip != $_POST['v_ip']) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-change-web-domain-ip ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($_POST['v_ip'])." 'no'", $output, $return_var);
+        exec(HESTIA_CMD."v-change-web-domain-ip ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($_POST['v_ip'])." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         $restart_web = 'yes';
         $restart_proxy = 'yes';
@@ -194,10 +194,10 @@ if (!empty($_POST['save'])) {
 
     // Change dns domain IP
     if (($v_ip != $_POST['v_ip']) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-list-dns-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+        exec(HESTIA_CMD."v-list-dns-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
         unset($output);
         if ($return_var == 0) {
-            exec(HESTIA_CMD."v-change-dns-domain-ip ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_newip_public)." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-change-dns-domain-ip ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_newip_public)." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $restart_dns = 'yes';
@@ -207,10 +207,10 @@ if (!empty($_POST['save'])) {
     // Change dns ip for each alias
     if (($v_ip != $_POST['v_ip']) && (empty($_SESSION['error_msg']))) {
         foreach ($valiases as $v_alias) {
-            exec(HESTIA_CMD."v-list-dns-domain ".$user." ".escapeshellarg($v_alias)." json", $output, $return_var);
+            exec(HESTIA_CMD."v-list-dns-domain ".$user." ".quoteshellarg($v_alias)." json", $output, $return_var);
             unset($output);
             if ($return_var == 0) {
-                exec(HESTIA_CMD."v-change-dns-domain-ip ".$user." ".escapeshellarg($v_alias)." ".escapeshellarg($v_newip_public), $output, $return_var);
+                exec(HESTIA_CMD."v-change-dns-domain-ip ".$user." ".quoteshellarg($v_alias)." ".quoteshellarg($v_newip_public), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 $restart_dns = 'yes';
@@ -220,10 +220,10 @@ if (!empty($_POST['save'])) {
 
     // Change mail domain IP
     if (($v_ip != $_POST['v_ip']) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-list-mail-domain ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+        exec(HESTIA_CMD."v-list-mail-domain ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
         unset($output);
         if ($return_var == 0) {
-            exec(HESTIA_CMD."v-rebuild-mail-domain ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+            exec(HESTIA_CMD."v-rebuild-mail-domain ".$user." ".quoteshellarg($v_domain), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $restart_email = 'yes';
@@ -234,7 +234,7 @@ if (!empty($_POST['save'])) {
     if (($_SESSION['POLICY_USER_EDIT_WEB_TEMPLATES'] == 'yes') || ($_SESSION['userContext'] === "admin")) {
         // Change template
         if (($v_template != $_POST['v_template']) && (empty($_SESSION['error_msg']))) {
-            exec(HESTIA_CMD."v-change-web-domain-tpl ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($_POST['v_template'])." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-tpl ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($_POST['v_template'])." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $restart_web = 'yes';
@@ -243,7 +243,7 @@ if (!empty($_POST['save'])) {
         // Change backend template
         if ((!empty($_SESSION['WEB_BACKEND'])) && ($v_backend_template != $_POST['v_backend_template'])  && (empty($_SESSION['error_msg']))) {
             $v_backend_template = $_POST['v_backend_template'];
-            exec(HESTIA_CMD."v-change-web-domain-backend-tpl ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_backend_template), $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-backend-tpl ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_backend_template), $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -257,11 +257,11 @@ if (!empty($_POST['save'])) {
                 if (empty($_POST['v_nginx_cache_duration'])) {
                     $_POST['v_nginx_cache_duration'] = "2m";
                 }
-                exec(HESTIA_CMD."v-add-fastcgi-cache ".$user." ".escapeshellarg($v_domain).' '. escapeshellarg($_POST['v_nginx_cache_duration']), $output, $return_var);
+                exec(HESTIA_CMD."v-add-fastcgi-cache ".$user." ".quoteshellarg($v_domain).' '. quoteshellarg($_POST['v_nginx_cache_duration']), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             } else {
-                exec(HESTIA_CMD."v-delete-fastcgi-cache ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+                exec(HESTIA_CMD."v-delete-fastcgi-cache ".$user." ".quoteshellarg($v_domain), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
             }
@@ -270,7 +270,7 @@ if (!empty($_POST['save'])) {
 
         // Delete proxy support
         if ((!empty($_SESSION['PROXY_SYSTEM'])) && (!empty($v_proxy)) && (empty($_POST['v_proxy'])) && (empty($_SESSION['error_msg']))) {
-            exec(HESTIA_CMD."v-delete-web-domain-proxy ".$user." ".escapeshellarg($v_domain)." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-delete-web-domain-proxy ".$user." ".quoteshellarg($v_domain)." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             unset($v_proxy);
@@ -289,7 +289,7 @@ if (!empty($_POST['save'])) {
                 if (!empty($_POST['v_proxy_template'])) {
                     $v_proxy_template = $_POST['v_proxy_template'];
                 }
-                exec(HESTIA_CMD."v-change-web-domain-proxy-tpl ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_proxy_template)." ".escapeshellarg($ext)." 'no'", $output, $return_var);
+                exec(HESTIA_CMD."v-change-web-domain-proxy-tpl ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_proxy_template)." ".quoteshellarg($ext)." 'no'", $output, $return_var);
                 check_return_code($return_var, $output);
                 $v_proxy_ext = str_replace(',', ', ', $ext);
                 unset($output);
@@ -308,7 +308,7 @@ if (!empty($_POST['save'])) {
                 $ext = str_replace(' ', ",", $ext);
                 $v_proxy_ext = str_replace(',', ', ', $ext);
             }
-            exec(HESTIA_CMD."v-add-web-domain-proxy ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_proxy_template)." ".escapeshellarg($ext)." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-add-web-domain-proxy ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_proxy_template)." ".quoteshellarg($ext)." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $restart_proxy = 'yes';
@@ -327,15 +327,15 @@ if (!empty($_POST['save'])) {
             if ((empty($_SESSION['error_msg'])) && (!empty($alias))) {
                 $restart_web = 'yes';
                 $restart_proxy = 'yes';
-                exec(HESTIA_CMD."v-delete-web-domain-alias ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($alias)." 'no'", $output, $return_var);
+                exec(HESTIA_CMD."v-delete-web-domain-alias ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($alias)." 'no'", $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
 
                 if (empty($_SESSION['error_msg'])) {
-                    exec(HESTIA_CMD."v-list-dns-domain ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+                    exec(HESTIA_CMD."v-list-dns-domain ".$user." ".quoteshellarg($v_domain), $output, $return_var);
                     unset($output);
                     if ($return_var == 0) {
-                        exec(HESTIA_CMD."v-delete-dns-on-web-alias ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($alias)." 'no'", $output, $return_var);
+                        exec(HESTIA_CMD."v-delete-dns-on-web-alias ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($alias)." 'no'", $output, $return_var);
                         check_return_code($return_var, $output);
                         unset($output);
                         $restart_dns = 'yes';
@@ -349,14 +349,14 @@ if (!empty($_POST['save'])) {
             if ((empty($_SESSION['error_msg'])) && (!empty($alias))) {
                 $restart_web = 'yes';
                 $restart_proxy = 'yes';
-                exec(HESTIA_CMD."v-add-web-domain-alias ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($alias)." 'no'", $output, $return_var);
+                exec(HESTIA_CMD."v-add-web-domain-alias ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($alias)." 'no'", $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 if (empty($_SESSION['error_msg'])) {
-                    exec(HESTIA_CMD."v-list-dns-domain ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+                    exec(HESTIA_CMD."v-list-dns-domain ".$user." ".quoteshellarg($v_domain), $output, $return_var);
                     unset($output);
                     if ($return_var == 0) {
-                        exec(HESTIA_CMD."v-add-dns-on-web-alias ".$user." ".escapeshellarg($alias)." ".escapeshellarg($v_newip_public ?: $v_ip_public)." no", $output, $return_var);
+                        exec(HESTIA_CMD."v-add-dns-on-web-alias ".$user." ".quoteshellarg($alias)." ".quoteshellarg($v_newip_public ?: $v_ip_public)." no", $output, $return_var);
                         check_return_code($return_var, $output);
                         unset($output);
                         $restart_dns = 'yes';
@@ -373,7 +373,7 @@ if (!empty($_POST['save'])) {
 
             // Add certificate with new aliases
                 $l_aliases = str_replace("\n", ',', $v_aliases);
-                exec(HESTIA_CMD."v-add-letsencrypt-domain ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($l_aliases)." ''", $output, $return_var);
+                exec(HESTIA_CMD."v-add-letsencrypt-domain ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($l_aliases)." ''", $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 $v_letsencrypt = 'yes';
@@ -381,7 +381,7 @@ if (!empty($_POST['save'])) {
                 $restart_web = 'yes';
                 $restart_proxy = 'yes';
 
-                exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+                exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
                 $ssl_str = json_decode(implode('', $output), true);
                 unset($output);
                 $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -399,8 +399,8 @@ if (!empty($_POST['save'])) {
 
         if ((!empty($v_stats)) && ($_POST['v_stats'] == $v_stats) && (empty($_SESSION['error_msg']))) {
             // Update statistics configuration when changing domain aliases
-            $v_stats = escapeshellarg($_POST['v_stats']);
-            exec(HESTIA_CMD."v-change-web-domain-stats ".$user." ".escapeshellarg($v_domain)." ".$v_stats, $output, $return_var);
+            $v_stats = quoteshellarg($_POST['v_stats']);
+            exec(HESTIA_CMD."v-change-web-domain-stats ".$user." ".quoteshellarg($v_domain)." ".$v_stats, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         }
@@ -409,8 +409,8 @@ if (!empty($_POST['save'])) {
     // Change document root for ssl domain
     if (($v_ssl == 'yes') && (!empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
         if ($v_ssl_home != $_POST['v_ssl_home']) {
-            $v_ssl_home = escapeshellarg($_POST['v_ssl_home']);
-            exec(HESTIA_CMD."v-change-web-domain-sslhome ".$user." ".escapeshellarg($v_domain)." ".$v_ssl_home." 'no'", $output, $return_var);
+            $v_ssl_home = quoteshellarg($_POST['v_ssl_home']);
+            exec(HESTIA_CMD."v-change-web-domain-sslhome ".$user." ".quoteshellarg($v_domain)." ".$v_ssl_home." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             $v_ssl_home = $_POST['v_ssl_home'];
             $restart_web = 'yes';
@@ -449,13 +449,13 @@ if (!empty($_POST['save'])) {
                 fclose($fp);
             }
 
-            exec(HESTIA_CMD."v-change-web-domain-sslcert ".$user." ".escapeshellarg($v_domain)." ".$tmpdir." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-sslcert ".$user." ".quoteshellarg($v_domain)." ".$tmpdir." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $restart_web = 'yes';
             $restart_proxy = 'yes';
 
-            exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+            exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
             $ssl_str = json_decode(implode('', $output), true);
             unset($output);
             $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -485,7 +485,7 @@ if (!empty($_POST['save'])) {
 
     // Delete Lets Encrypt support
     if (($v_letsencrypt == 'yes') && (empty($_POST['v_letsencrypt']) || empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-letsencrypt-domain ".$user." ".escapeshellarg($v_domain)." ''", $output, $return_var);
+        exec(HESTIA_CMD."v-delete-letsencrypt-domain ".$user." ".quoteshellarg($v_domain)." ''", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_crt = '';
@@ -500,7 +500,7 @@ if (!empty($_POST['save'])) {
 
     // Delete SSL certificate
     if (($v_ssl == 'yes') && (empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." 'no'", $output, $return_var);
+        exec(HESTIA_CMD."v-delete-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." 'no'", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_crt = '';
@@ -516,7 +516,7 @@ if (!empty($_POST['save'])) {
     // Add Lets Encrypt support
     if ((!empty($_POST['v_ssl'])) && ($v_letsencrypt == 'no') && (!empty($_POST['v_letsencrypt'])) && empty($_SESSION['error_msg'])) {
         $l_aliases = str_replace("\n", ',', $v_aliases);
-        exec(HESTIA_CMD."v-add-letsencrypt-domain ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($l_aliases)." ''", $output, $return_var);
+        exec(HESTIA_CMD."v-add-letsencrypt-domain ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($l_aliases)." ''", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         if ($return_var != 0) {
@@ -545,7 +545,7 @@ if (!empty($_POST['save'])) {
         if (empty($_POST['v_ssl_home'])) {
             $errors[] = 'ssl home';
         }
-        $v_ssl_home = escapeshellarg($_POST['v_ssl_home']);
+        $v_ssl_home = quoteshellarg($_POST['v_ssl_home']);
         if (!empty($errors[0])) {
             foreach ($errors as $i => $error) {
                 if ($i == 0) {
@@ -579,14 +579,14 @@ if (!empty($_POST['save'])) {
                 fwrite($fp, str_replace("\r\n", "\n", $_POST['v_ssl_ca']));
                 fclose($fp);
             }
-            exec(HESTIA_CMD."v-add-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." ".$tmpdir." ".$v_ssl_home." 'no'", $output, $return_var);
+            exec(HESTIA_CMD."v-add-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." ".$tmpdir." ".$v_ssl_home." 'no'", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_ssl = 'yes';
             $restart_web = 'yes';
             $restart_proxy = 'yes';
 
-            exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".escapeshellarg($v_domain)." json", $output, $return_var);
+            exec(HESTIA_CMD."v-list-web-domain-ssl ".$user." ".quoteshellarg($v_domain)." json", $output, $return_var);
             $ssl_str = json_decode(implode('', $output), true);
             unset($output);
             $v_ssl_crt = $ssl_str[$v_domain]['CRT'];
@@ -616,7 +616,7 @@ if (!empty($_POST['save'])) {
 
     // Add Force SSL
     if ((!empty($_POST['v_ssl_forcessl'])) && (!empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-web-domain-ssl-force ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-add-web-domain-ssl-force ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_forcessl = 'yes';
@@ -626,7 +626,7 @@ if (!empty($_POST['save'])) {
 
     // Add SSL HSTS
     if ((!empty($_POST['v_ssl_hsts'])) && (!empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-add-web-domain-ssl-hsts ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-add-web-domain-ssl-hsts ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_hsts = 'yes';
@@ -636,7 +636,7 @@ if (!empty($_POST['save'])) {
 
     // Delete Force SSL
     if (($v_ssl_forcessl == 'yes') && (empty($_POST['v_ssl_forcessl'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-web-domain-ssl-force ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-web-domain-ssl-force ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_forcessl = 'no';
@@ -646,7 +646,7 @@ if (!empty($_POST['save'])) {
 
     // Delete SSL HSTS
     if (($v_ssl_hsts == 'yes') && (empty($_POST['v_ssl_hsts'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-web-domain-ssl-hsts ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-web-domain-ssl-hsts ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_ssl_hsts = 'no';
@@ -656,7 +656,7 @@ if (!empty($_POST['save'])) {
 
     // Delete web stats
     if ((!empty($v_stats)) && ($_POST['v_stats'] == 'none') && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-web-domain-stats ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-web-domain-stats ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_stats = '';
@@ -664,23 +664,23 @@ if (!empty($_POST['save'])) {
 
     // Change web stats engine
     if ((!empty($v_stats)) && ($_POST['v_stats'] != $v_stats) && (empty($_SESSION['error_msg']))) {
-        $v_stats = escapeshellarg($_POST['v_stats']);
-        exec(HESTIA_CMD."v-change-web-domain-stats ".$user." ".escapeshellarg($v_domain)." ".$v_stats, $output, $return_var);
+        $v_stats = quoteshellarg($_POST['v_stats']);
+        exec(HESTIA_CMD."v-change-web-domain-stats ".$user." ".quoteshellarg($v_domain)." ".$v_stats, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
 
     // Add web stats
     if ((empty($v_stats)) && ($_POST['v_stats'] != 'none') && (empty($_SESSION['error_msg']))) {
-        $v_stats = escapeshellarg($_POST['v_stats']);
-        exec(HESTIA_CMD."v-add-web-domain-stats ".$user." ".escapeshellarg($v_domain)." ".$v_stats, $output, $return_var);
+        $v_stats = quoteshellarg($_POST['v_stats']);
+        exec(HESTIA_CMD."v-add-web-domain-stats ".$user." ".quoteshellarg($v_domain)." ".$v_stats, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
     }
 
     // Delete web stats authorization
     if ((!empty($v_stats_user)) && (empty($_POST['v_stats_auth'])) && (empty($_SESSION['error_msg']))) {
-        exec(HESTIA_CMD."v-delete-web-domain-stats-user ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-web-domain-stats-user ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         $v_stats_user = '';
@@ -702,16 +702,16 @@ if (!empty($_POST['save'])) {
             }
             $_SESSION['error_msg'] =  sprintf(_('Field "%s" can not be blank.'), $error_msg);
         } else {
-            $v_stats_user = escapeshellarg($_POST['v_stats_user']);
+            $v_stats_user = quoteshellarg($_POST['v_stats_user']);
             $v_stats_password = tempnam("/tmp", "vst");
             $fp = fopen($v_stats_password, "w");
             fwrite($fp, $_POST['v_stats_password']."\n");
             fclose($fp);
-            exec(HESTIA_CMD."v-add-web-domain-stats-user ".$user." ".escapeshellarg($v_domain)." ".$v_stats_user." ".$v_stats_password, $output, $return_var);
+            exec(HESTIA_CMD."v-add-web-domain-stats-user ".$user." ".quoteshellarg($v_domain)." ".$v_stats_user." ".$v_stats_password, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             unlink($v_stats_password);
-            $v_stats_password = escapeshellarg($_POST['v_stats_password']);
+            $v_stats_password = quoteshellarg($_POST['v_stats_password']);
         }
     }
 
@@ -731,16 +731,16 @@ if (!empty($_POST['save'])) {
             $_SESSION['error_msg'] =  sprintf(_('Field "%s" can not be blank.'), $error_msg);
         }
         if (($v_stats_user != $_POST['v_stats_user']) || (!empty($_POST['v_stats_password'])) && (empty($_SESSION['error_msg']))) {
-            $v_stats_user = escapeshellarg($_POST['v_stats_user']);
+            $v_stats_user = quoteshellarg($_POST['v_stats_user']);
             $v_stats_password = tempnam("/tmp", "vst");
             $fp = fopen($v_stats_password, "w");
             fwrite($fp, $_POST['v_stats_password']."\n");
             fclose($fp);
-            exec(HESTIA_CMD."v-add-web-domain-stats-user ".$user." ".escapeshellarg($v_domain)." ".$v_stats_user." ".$v_stats_password, $output, $return_var);
+            exec(HESTIA_CMD."v-add-web-domain-stats-user ".$user." ".quoteshellarg($v_domain)." ".$v_stats_user." ".$v_stats_password, $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             unlink($v_stats_password);
-            $v_stats_password = escapeshellarg($_POST['v_stats_password']);
+            $v_stats_password = quoteshellarg($_POST['v_stats_password']);
         }
     }
 
@@ -774,14 +774,14 @@ if (!empty($_POST['save'])) {
                 // Add ftp account
                 $v_ftp_username      = $v_ftp_user_data['v_ftp_user'];
                 $v_ftp_username_full = $user . '_' . $v_ftp_user_data['v_ftp_user'];
-                $v_ftp_user = escapeshellarg($v_ftp_username);
-                $v_ftp_path = escapeshellarg(trim($v_ftp_user_data['v_ftp_path']));
+                $v_ftp_user = quoteshellarg($v_ftp_username);
+                $v_ftp_path = quoteshellarg(trim($v_ftp_user_data['v_ftp_path']));
                 if (empty($_SESSION['error_msg'])) {
                     $v_ftp_password = tempnam("/tmp", "vst");
                     $fp = fopen($v_ftp_password, "w");
                     fwrite($fp, $v_ftp_user_data['v_ftp_password']."\n");
                     fclose($fp);
-                    exec(HESTIA_CMD."v-add-web-domain-ftp ".$user." ".escapeshellarg($v_domain)." ".$v_ftp_user." ".$v_ftp_password . " " . $v_ftp_path, $output, $return_var);
+                    exec(HESTIA_CMD."v-add-web-domain-ftp ".$user." ".quoteshellarg($v_domain)." ".$v_ftp_user." ".$v_ftp_password . " " . $v_ftp_path, $output, $return_var);
                     check_return_code($return_var, $output);
                     if ((!empty($v_ftp_user_data['v_ftp_email'])) && (empty($_SESSION['error_msg']))) {
                         $to = $v_ftp_user_data['v_ftp_email'];
@@ -789,13 +789,13 @@ if (!empty($_POST['save'])) {
                         $hostname = exec('hostname');
                         $from = "noreply@".$hostname;
                         $from_name = _('Hestia Control Panel');
-                        $mailtext = sprintf(_('FTP_ACCOUNT_READY'), escapeshellarg($_GET['domain']), $user, $v_ftp_username, $v_ftp_user_data['v_ftp_password']);
+                        $mailtext = sprintf(_('FTP_ACCOUNT_READY'), quoteshellarg($_GET['domain']), $user, $v_ftp_username, $v_ftp_user_data['v_ftp_password']);
                         send_email($to, $subject, $mailtext, $from, $from_name);
                         unset($v_ftp_email);
                     }
                     unset($output);
                     unlink($v_ftp_password);
-                    $v_ftp_password = escapeshellarg($v_ftp_user_data['v_ftp_password']);
+                    $v_ftp_password = quoteshellarg($v_ftp_user_data['v_ftp_password']);
                 }
 
                 if ($return_var == 0) {
@@ -820,7 +820,7 @@ if (!empty($_POST['save'])) {
             // Delete FTP account
             if ($v_ftp_user_data['delete'] == 1) {
                 $v_ftp_username = $user_plain . '_' . $v_ftp_user_data['v_ftp_user'];
-                exec(HESTIA_CMD."v-delete-web-domain-ftp ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($v_ftp_username), $output, $return_var);
+                exec(HESTIA_CMD."v-delete-web-domain-ftp ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($v_ftp_username), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
 
@@ -845,10 +845,10 @@ if (!empty($_POST['save'])) {
                 // Change FTP account path
                 $v_ftp_username_for_emailing = $v_ftp_user_data['v_ftp_user'];
                 $v_ftp_username = $user_plain . '_' . $v_ftp_user_data['v_ftp_user']; //preg_replace("/^".$user."_/", "", $v_ftp_user_data['v_ftp_user']);
-                $v_ftp_username = escapeshellarg($v_ftp_username);
-                $v_ftp_path = escapeshellarg(trim($v_ftp_user_data['v_ftp_path']));
-                if (escapeshellarg(trim($v_ftp_user_data['v_ftp_path_prev'])) != $v_ftp_path) {
-                    exec(HESTIA_CMD."v-change-web-domain-ftp-path ".$user." ".escapeshellarg($v_domain)." ".$v_ftp_username." ".$v_ftp_path, $output, $return_var);
+                $v_ftp_username = quoteshellarg($v_ftp_username);
+                $v_ftp_path = quoteshellarg(trim($v_ftp_user_data['v_ftp_path']));
+                if (quoteshellarg(trim($v_ftp_user_data['v_ftp_path_prev'])) != $v_ftp_path) {
+                    exec(HESTIA_CMD."v-change-web-domain-ftp-path ".$user." ".quoteshellarg($v_domain)." ".$v_ftp_username." ".$v_ftp_path, $output, $return_var);
                     check_return_code($return_var, $output);
                     unset($output);
                 }
@@ -858,7 +858,7 @@ if (!empty($_POST['save'])) {
                     $fp = fopen($v_ftp_password, "w");
                     fwrite($fp, $v_ftp_user_data['v_ftp_password']."\n");
                     fclose($fp);
-                    exec(HESTIA_CMD."v-change-web-domain-ftp-password ".$user." ".escapeshellarg($v_domain)." ".$v_ftp_username." ".$v_ftp_password, $output, $return_var);
+                    exec(HESTIA_CMD."v-change-web-domain-ftp-password ".$user." ".quoteshellarg($v_domain)." ".$v_ftp_username." ".$v_ftp_password, $output, $return_var);
                     unlink($v_ftp_password);
 
                     $to = $v_ftp_user_data['v_ftp_email'];
@@ -866,7 +866,7 @@ if (!empty($_POST['save'])) {
                     $hostname = exec('hostname');
                     $from = "noreply@".$hostname;
                     $from_name = _('Hestia Control Panel');
-                    $mailtext =  sprintf(_('FTP_ACCOUNT_READY'), escapeshellarg($_GET['domain']), $user, $v_ftp_username_for_emailing, $v_ftp_user_data['v_ftp_password']);
+                    $mailtext =  sprintf(_('FTP_ACCOUNT_READY'), quoteshellarg($_GET['domain']), $user, $v_ftp_username_for_emailing, $v_ftp_user_data['v_ftp_password']);
                     send_email($to, $subject, $mailtext, $from, $from_name);
                     unset($v_ftp_email);
                 }
@@ -886,7 +886,7 @@ if (!empty($_POST['save'])) {
     }
     //custom docoot with check box disabled
     if (!empty($v_custom_doc_root) && empty($_POST['v_custom_doc_root_check'])) {
-        exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".escapeshellarg($v_domain)." default", $output, $return_var);
+        exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".quoteshellarg($v_domain)." default", $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         unset($_POST['v-custom-doc-domain'], $_POST['v-custom-doc-folder']);
@@ -896,14 +896,14 @@ if (!empty($_POST['save'])) {
 
     if (!empty($_POST['v-custom-doc-domain']) && !empty($_POST['v_custom_doc_root_check']) && $v_custom_doc_root_prepath.$v_custom_doc_domain.'/public_html'.$v_custom_doc_folder != $v_custom_doc_root) {
         if ($_POST['v-custom-doc-domain'] == $v_domain && empty($_POST['v-custom-doc-folder'])) {
-            exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".escapeshellarg($v_domain)." default", $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".quoteshellarg($v_domain)." default", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
         } else {
-            $v_custom_doc_folder = escapeshellarg(rtrim($_POST['v-custom-doc-folder'], '/'));
-            $v_custom_doc_domain = escapeshellarg($_POST['v-custom-doc-domain']);
+            $v_custom_doc_folder = quoteshellarg(rtrim($_POST['v-custom-doc-folder'], '/'));
+            $v_custom_doc_domain = quoteshellarg($_POST['v-custom-doc-domain']);
 
-            exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".escapeshellarg($v_domain)." ".$v_custom_doc_domain." ".$v_custom_doc_folder ." yes", $output, $return_var);
+            exec(HESTIA_CMD."v-change-web-domain-docroot ".$user." ".quoteshellarg($v_domain)." ".$v_custom_doc_domain." ".$v_custom_doc_folder ." yes", $output, $return_var);
             check_return_code($return_var, $output);
             unset($output);
             $v_custom_doc_root = 1;
@@ -915,7 +915,7 @@ if (!empty($_POST['save'])) {
     }
 
     if (!empty($v_redirect) && empty($_POST['v-redirect-checkbox'])) {
-        exec(HESTIA_CMD."v-delete-web-domain-redirect ".$user." ".escapeshellarg($v_domain), $output, $return_var);
+        exec(HESTIA_CMD."v-delete-web-domain-redirect ".$user." ".quoteshellarg($v_domain), $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
         unset($_POST['v-redirect']);
@@ -930,7 +930,7 @@ if (!empty($_POST['save'])) {
                 if ($_POST['v-redirect']  == 'custom') {
                     $_POST['v-redirect'] = $_POST['v-redirect-custom'];
                 }
-                exec(HESTIA_CMD."v-add-web-domain-redirect ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($_POST['v-redirect'])." ".escapeshellarg($_POST['v-redirect-code']), $output, $return_var);
+                exec(HESTIA_CMD."v-add-web-domain-redirect ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($_POST['v-redirect'])." ".quoteshellarg($_POST['v-redirect-code']), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 $restart_web = 'yes';
@@ -941,7 +941,7 @@ if (!empty($_POST['save'])) {
                 $_POST['v-redirect'] = $_POST['v-redirect-custom'];
             }
             if ($_POST['v-redirect'] != $v_redirect || $_POST['v-redirect-code'] != $v_redirect_code) {
-                exec(HESTIA_CMD."v-add-web-domain-redirect ".$user." ".escapeshellarg($v_domain)." ".escapeshellarg($_POST['v-redirect'])." ".escapeshellarg($_POST['v-redirect-code']), $output, $return_var);
+                exec(HESTIA_CMD."v-add-web-domain-redirect ".$user." ".quoteshellarg($v_domain)." ".quoteshellarg($_POST['v-redirect'])." ".quoteshellarg($_POST['v-redirect-code']), $output, $return_var);
                 check_return_code($return_var, $output);
                 unset($output);
                 $restart_web = 'yes';

--- a/web/generate/ssl/index.php
+++ b/web/generate/ssl/index.php
@@ -70,19 +70,19 @@ if (!empty($errors[0])) {
 }
 
 // Protect input
-$v_domain = escapeshellarg($_POST['v_domain']);
+$v_domain = quoteshellarg($_POST['v_domain']);
 $waliases = preg_replace("/\n/", " ", $_POST['v_aliases']);
 $waliases = preg_replace("/,/", " ", $waliases);
 $waliases = preg_replace('/\s+/', ' ', $waliases);
 $waliases = trim($waliases);
 $aliases = explode(" ", $waliases);
-$v_aliases = escapeshellarg(str_replace(' ', "\n", $waliases));
+$v_aliases = quoteshellarg(str_replace(' ', "\n", $waliases));
 
-$v_email = escapeshellarg($_POST['v_email']);
-$v_country = escapeshellarg($_POST['v_country']);
-$v_state = escapeshellarg($_POST['v_state']);
-$v_locality = escapeshellarg($_POST['v_locality']);
-$v_org = escapeshellarg($_POST['v_org']);
+$v_email = quoteshellarg($_POST['v_email']);
+$v_country = quoteshellarg($_POST['v_country']);
+$v_state = quoteshellarg($_POST['v_state']);
+$v_locality = quoteshellarg($_POST['v_locality']);
+$v_org = quoteshellarg($_POST['v_org']);
 
 exec(HESTIA_CMD."v-generate-ssl-cert ".$v_domain." ".$v_email." ".$v_country." ".$v_state." ".$v_locality." ".$v_org." IT  ".$v_aliases." json", $output, $return_var);
 

--- a/web/inc/helpers.php
+++ b/web/inc/helpers.php
@@ -126,7 +126,7 @@ function hst_add_history_log($message, $category = 'System', $level = 'Info', $u
     $category = ucfirst(strtolower($category));
     $level = ucfirst(strtolower($level));
 
-    $command_args = escapeshellarg($user).' '.escapeshellarg($level).' '.escapeshellarg($category).' '.escapeshellarg($message);
+    $command_args = quoteshellarg($user).' '.quoteshellarg($level).' '.quoteshellarg($category).' '.quoteshellarg($message);
     exec(HESTIA_CMD."v-log-action ".$command_args, $output, $return_var);
     unset($output);
 

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -65,8 +65,8 @@ if (!isset($_SESSION['user_combined_ip'])) {
 
 // Checking user to use session from the same IP he has been logged in
 if ($_SESSION['user_combined_ip'] != $user_combined_ip) {
-    $v_user = escapeshellarg($_SESSION['user']);
-    $v_session_id = escapeshellarg($_SESSION['token']);
+    $v_user = quoteshellarg($_SESSION['user']);
+    $v_session_id = quoteshellarg($_SESSION['token']);
     exec(HESTIA_CMD . 'v-log-user-logout ' . $v_user . ' ' . $v_session_id, $output, $return_var);
     destroy_sessions();
     header('Location: /login/');
@@ -107,8 +107,8 @@ if (!defined('NO_AUTH_REQUIRED')) {
         destroy_sessions();
         header('Location: /login/');
     } elseif ($_SESSION['INACTIVE_SESSION_TIMEOUT'] * 60 + $_SESSION['LAST_ACTIVITY'] < time()) {
-        $v_user = escapeshellarg($_SESSION['user']);
-        $v_session_id = escapeshellarg($_SESSION['token']);
+        $v_user = quoteshellarg($_SESSION['user']);
+        $v_session_id = quoteshellarg($_SESSION['token']);
         exec(HESTIA_CMD . 'v-log-user-logout ' . $v_user . ' ' . $v_session_id, $output, $return_var);
         destroy_sessions();
         header('Location: /login/');
@@ -119,12 +119,12 @@ if (!defined('NO_AUTH_REQUIRED')) {
 }
 
 if (isset($_SESSION['user'])) {
-    $user = escapeshellarg($_SESSION['user']);
+    $user = quoteshellarg($_SESSION['user']);
     $user_plain = htmlentities($_SESSION['user']);
 }
 
 if (isset($_SESSION['look']) && $_SESSION['look']  != '' && ($_SESSION['userContext'] === 'admin')) {
-    $user = escapeshellarg($_SESSION['look']);
+    $user = quoteshellarg($_SESSION['look']);
     $user_plain = htmlentities($_SESSION['look']);
 }
 
@@ -498,7 +498,7 @@ function backendtpl_with_webdomains()
 
     $backend_list=[];
     foreach ($users as $user => $user_details) {
-        exec(HESTIA_CMD . 'v-list-web-domains '. escapeshellarg($user) . ' json', $output, $return_var);
+        exec(HESTIA_CMD . 'v-list-web-domains '. quoteshellarg($user) . ' json', $output, $return_var);
         $domains = json_decode(implode('', $output), true);
         unset($output);
         foreach ($domains as $domain => $domain_details) {

--- a/web/list/access-key/index.php
+++ b/web/list/access-key/index.php
@@ -6,7 +6,7 @@ $TAB = 'Access Key';
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user = escapeshellarg($_GET['user']);
+    $user = quoteshellarg($_GET['user']);
     $user_plain = $_GET['user'];
 }
 
@@ -18,7 +18,7 @@ if (($user_plain == 'admin' && $api_status < 1) || ($user_plain != 'admin' && $a
 }
 
 if (!empty($_GET['key'])) {
-    $v_key = escapeshellarg(trim($_GET['key']));
+    $v_key = quoteshellarg(trim($_GET['key']));
 
     // Key data
     exec(HESTIA_CMD."v-list-access-key ".$v_key." json", $output, $return_var);

--- a/web/list/backup/index.php
+++ b/web/list/backup/index.php
@@ -17,7 +17,7 @@ if (empty($_GET['backup'])){
 
     render_page($user, $TAB, 'list_backup');
 } else {
-    exec (HESTIA_CMD."v-list-user-backup $user ".escapeshellarg($_GET['backup'])." json", $output, $return_var);
+    exec (HESTIA_CMD."v-list-user-backup $user ".quoteshellarg($_GET['backup'])." json", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     $data = array_reverse($data,true);
     unset($output);

--- a/web/list/dns/index.php
+++ b/web/list/dns/index.php
@@ -17,7 +17,7 @@ if (empty($_GET['domain'])){
 
     render_page($user, $TAB, 'list_dns');
 } else {
-    exec (HESTIA_CMD."v-list-dns-records ".$user." ".escapeshellarg($_GET['domain'])." 'json'", $output, $return_var);
+    exec (HESTIA_CMD."v-list-dns-records ".$user." ".quoteshellarg($_GET['domain'])." 'json'", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     if($_SESSION['userSortOrder'] == 'name'){
         ksort($data);

--- a/web/list/key/index.php
+++ b/web/list/key/index.php
@@ -5,7 +5,7 @@ $TAB = 'USER';
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user = escapeshellarg($_GET['user']);
+    $user = quoteshellarg($_GET['user']);
 }
 
 exec (HESTIA_CMD . "v-list-user-ssh-key ".$user." json", $output, $return_var);

--- a/web/list/log/auth/index.php
+++ b/web/list/log/auth/index.php
@@ -8,9 +8,9 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 // Edit as someone else?
 if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']))) {
-    $user = escapeshellarg($_SESSION['look']);
+    $user = quoteshellarg($_SESSION['look']);
 } elseif (($_SESSION['userContext'] === 'admin') && (!empty($_GET['user']))) {
-    $user = escapeshellarg($_GET['user']);
+    $user = quoteshellarg($_GET['user']);
 }
 
 exec(HESTIA_CMD."v-list-user-auth-log ".$user." json", $output, $return_var);

--- a/web/list/log/index.php
+++ b/web/list/log/index.php
@@ -22,7 +22,7 @@ if (($_SESSION['userContext'] !== 'admin') && (!empty($_GET['user']))) {
 if (($_SESSION['userContext'] === "admin") && (!empty($_GET['user']))) {
     // Check token
     verify_csrf($_GET);
-    $user=escapeshellarg($_GET['user']);
+    $user=quoteshellarg($_GET['user']);
 }
 
 exec(HESTIA_CMD."v-list-user-log $user json", $output, $return_var);

--- a/web/list/mail/index.php
+++ b/web/list/mail/index.php
@@ -17,7 +17,7 @@ if (empty($_GET['domain'])){
 
     render_page($user, $TAB, 'list_mail');
 } else if (!empty($_GET['dns'])) {
-        exec (HESTIA_CMD."v-list-mail-domain ".$user." ".escapeshellarg($_GET['domain'])." json", $output, $return_var);
+        exec (HESTIA_CMD."v-list-mail-domain ".$user." ".quoteshellarg($_GET['domain'])." json", $output, $return_var);
         $data = json_decode(implode('', $output), true);
         $data = array_reverse($data, true);
         unset($output);
@@ -25,14 +25,14 @@ if (empty($_GET['domain'])){
         $ips = json_decode(implode('', $output), true);
         $ips = array_reverse($ips, true);
         unset($output);
-        exec (HESTIA_CMD."v-list-mail-domain-dkim-dns ".$user." ".escapeshellarg($_GET['domain'])." json", $output, $return_var);
+        exec (HESTIA_CMD."v-list-mail-domain-dkim-dns ".$user." ".quoteshellarg($_GET['domain'])." json", $output, $return_var);
         $dkim = json_decode(implode('', $output), true);
         $dkim = array_reverse($dkim, true);
         unset($output);
 
         render_page($user, $TAB, 'list_mail_dns');
 } else {
-    exec (HESTIA_CMD."v-list-mail-accounts ".$user." ".escapeshellarg($_GET['domain'])." json", $output, $return_var);
+    exec (HESTIA_CMD."v-list-mail-accounts ".$user." ".quoteshellarg($_GET['domain'])." json", $output, $return_var);
     $data = json_decode(implode('', $output), true);
     if($_SESSION['userSortOrder'] == 'name'){
         ksort($data);

--- a/web/list/stats/index.php
+++ b/web/list/stats/index.php
@@ -12,7 +12,7 @@ if (($_SESSION['userContext'] === 'admin') && (!isset($_SESSION['look']))) {
         $data = array_reverse($data, true);
         unset($output);
     } else {
-        $v_user = escapeshellarg($_GET['user']);
+        $v_user = quoteshellarg($_GET['user']);
         exec (HESTIA_CMD."v-list-user-stats $v_user json", $output, $return_var);
         $data = json_decode(implode('', $output), true);
         $data = array_reverse($data, true);

--- a/web/list/web-log/index.php
+++ b/web/list/web-log/index.php
@@ -4,7 +4,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 
 $TAB = "WEB";
 
-$v_domain = escapeshellarg($_GET['domain']);
+$v_domain = quoteshellarg($_GET['domain']);
 $type = 'access';
 if ($_GET['type'] == 'access') {
     $type = 'access';

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -23,8 +23,8 @@ if (isset($_SESSION['user'])) {
     if (($_SESSION['userContext'] === 'admin') && (!empty($_GET['loginas']))) {
         // Ensure token is passed and matches before granting user impersonation access
         if (verify_csrf($_GET)) {
-            $v_user = escapeshellarg($_GET['loginas']);
-            $v_impersonator = escapeshellarg($_SESSION['user']);
+            $v_user = quoteshellarg($_GET['loginas']);
+            $v_impersonator = quoteshellarg($_SESSION['user']);
             exec(HESTIA_CMD . "v-list-user ".$v_user." json", $output, $return_var);
             if ($return_var == 0) {
                 $data = json_decode(implode('', $output), true);
@@ -54,7 +54,7 @@ if (isset($_SESSION['user'])) {
         }
 
         // Obtain account properties
-        $v_user = escapeshellarg($_SESSION[(($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']))) ? 'look' : 'user']);
+        $v_user = quoteshellarg($_SESSION[(($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']))) ? 'look' : 'user']);
 
         exec(HESTIA_CMD . 'v-list-user ' . $v_user . ' json', $output, $return_var);
         $data = json_decode(implode('', $output), true);
@@ -92,7 +92,7 @@ function authenticate_user($user, $password, $twofa = '')
 {
     unset($_SESSION['login']);
     if (verify_csrf($_POST, true)) {
-        $v_user = escapeshellarg($user);
+        $v_user = quoteshellarg($user);
         $ip = $_SERVER['REMOTE_ADDR'];
         $user_agent = $_SERVER['HTTP_USER_AGENT'];
         if (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
@@ -100,8 +100,8 @@ function authenticate_user($user, $password, $twofa = '')
                 $ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
             }
         }
-        $v_ip = escapeshellarg($ip);
-        $v_user_agent = escapeshellarg($user_agent);
+        $v_ip = quoteshellarg($ip);
+        $v_user_agent = quoteshellarg($user_agent);
 
         // Get user's salt
         $output = '';
@@ -158,7 +158,7 @@ function authenticate_user($user, $password, $twofa = '')
             if ($return_var > 0) {
                 sleep(2);
                 $error = '<a class="error">' . _('Invalid username or password') . '</a>';
-                $v_session_id = escapeshellarg($_POST['token']);
+                $v_session_id = quoteshellarg($_POST['token']);
                 exec(HESTIA_CMD . 'v-log-user-login ' . $v_user . ' ' . $v_ip . ' failed ' . $v_session_id . ' ' . $v_user_agent, $output, $return_var);
                 return $error;
             } else {
@@ -170,7 +170,7 @@ function authenticate_user($user, $password, $twofa = '')
                 if ($data[$user]['LOGIN_DISABLED'] === 'yes') {
                     sleep(2);
                     $error = '<a class="error">' . _('Invalid username or password') . '</a>';
-                    $v_session_id = escapeshellarg($_POST['token']);
+                    $v_session_id = quoteshellarg($_POST['token']);
                     exec(HESTIA_CMD . 'v-log-user-login ' . $v_user . ' ' . $v_ip . ' failed ' . $v_session_id . ' ' . $v_user_agent .' yes "Login disabled for this user"', $output, $return_var);
                     return $error;
                 }
@@ -181,7 +181,7 @@ function authenticate_user($user, $password, $twofa = '')
                     if (!in_array($ip, $v_login_user_allowed_ips, true)) {
                         sleep(2);
                         $error = '<a class="error">' . _('Invalid username or password') . '</a>';
-                        $v_session_id = escapeshellarg($_POST['token']);
+                        $v_session_id = quoteshellarg($_POST['token']);
                         exec(HESTIA_CMD . 'v-log-user-login ' . $v_user . ' ' . $v_ip . ' failed ' . $v_session_id . ' ' . $v_user_agent .' yes "Ip not in allowed list"', $output, $return_var);
                         return $error;
                     }
@@ -195,7 +195,7 @@ function authenticate_user($user, $password, $twofa = '')
                         $_SESSION['login']['password'] = $password;
                         return false;
                     } else {
-                        $v_twofa = escapeshellarg($twofa);
+                        $v_twofa = quoteshellarg($twofa);
                         exec(HESTIA_CMD .'v-check-user-2fa '.$v_user.' '.$v_twofa, $output, $return_var);
                         unset($output);
                         if ($return_var > 0) {
@@ -203,7 +203,7 @@ function authenticate_user($user, $password, $twofa = '')
                             $error = '<a class="error">' ._('Invalid or missing 2FA token') . '</a>';
                             $_SESSION['login']['username'] = $user;
                             $_SESSION['login']['password'] = $password;
-                            $v_session_id = escapeshellarg($_POST['token']);
+                            $v_session_id = quoteshellarg($_POST['token']);
                             if (isset($_SESSION['failed_twofa'])) {
                                 //allow a few failed attemps before start of logging.
                                 if ($_SESSION['failed_twofa']  > 2) {
@@ -223,7 +223,7 @@ function authenticate_user($user, $password, $twofa = '')
                 $_SESSION['user'] = key($data);
                 $v_user = $_SESSION['user'];
                 //log successfull login attempt
-                $v_session_id = escapeshellarg($_POST['token']);
+                $v_session_id = quoteshellarg($_POST['token']);
                 exec(HESTIA_CMD."v-log-user-login ".$v_user." ".$v_ip." success ".$v_session_id." ".$v_user_agent, $output, $return_var);
 
                 $_SESSION['LAST_ACTIVITY'] = time();

--- a/web/logout/index.php
+++ b/web/logout/index.php
@@ -5,8 +5,8 @@ include($_SERVER['DOCUMENT_ROOT'] . '/inc/main.php');
 verify_csrf($_GET);
 
 if (!empty($_SESSION['look'])) {
-    $v_user = escapeshellarg($_SESSION['look']);
-    $v_impersonator = escapeshellarg($_SESSION['user']);
+    $v_user = quoteshellarg($_SESSION['look']);
+    $v_impersonator = quoteshellarg($_SESSION['user']);
     exec(HESTIA_CMD . "v-log-action system 'Warning' 'Security' 'User impersonation session ended (User: $v_user, Administrator: $v_impersonator)'", $output, $return_var);
     unset($_SESSION['look']);
     # Remove current path for filemanager
@@ -16,8 +16,8 @@ if (!empty($_SESSION['look'])) {
 } else {
     if ($_SESSION['token'] && $_SESSION['user']) {
         unset($_SESSION['userTheme']);
-        $v_user = escapeshellarg($_SESSION['user']);
-        $v_session_id = escapeshellarg($_SESSION['token']);
+        $v_user = quoteshellarg($_SESSION['user']);
+        $v_session_id = quoteshellarg($_SESSION['token']);
         exec(HESTIA_CMD . 'v-log-user-logout ' . $v_user . ' ' . $v_session_id, $output, $return_var);
     }
 

--- a/web/reset/index.php
+++ b/web/reset/index.php
@@ -18,7 +18,7 @@ if ($_SESSION['POLICY_SYSTEM_PASSWORD_RESET'] == 'no') {
 if ((!empty($_POST['user'])) && (empty($_POST['code']))) {
     // Check token
     verify_csrf($_POST);
-    $v_user = escapeshellarg($_POST['user']);
+    $v_user = quoteshellarg($_POST['user']);
     $user = $_POST['user'];
     $email = $_POST['email'];
     $cmd="/usr/bin/sudo /usr/local/hestia/bin/v-list-user";
@@ -83,7 +83,7 @@ if ((!empty($_POST['user'])) && (!empty($_POST['code'])) && (!empty($_POST['pass
     // Check token
     verify_csrf($_POST);
     if ($_POST['password'] == $_POST['password_confirm']) {
-        $v_user = escapeshellarg($_POST['user']);
+        $v_user = quoteshellarg($_POST['user']);
         $user = $_POST['user'];
         exec(HESTIA_CMD . "v-list-user ".$v_user." json", $output, $return_var);
         if ($return_var == 0) {

--- a/web/reset/mail/index.php
+++ b/web/reset/mail/index.php
@@ -120,8 +120,8 @@ function to64 ($v, $n)
 // Check arguments
 if ((!empty($_POST['email'])) && (!empty($_POST['password'])) && (!empty($_POST['new']))) {
     list($v_account, $v_domain) = explode('@', $_POST['email']);
-    $v_domain = escapeshellarg($v_domain);
-    $v_account = escapeshellarg($v_account);
+    $v_domain = quoteshellarg($v_domain);
+    $v_account = quoteshellarg($v_account);
     $v_password = $_POST['password'];
 
     // Get domain owner
@@ -133,7 +133,7 @@ if ((!empty($_POST['email'])) && (!empty($_POST['password'])) && (!empty($_POST[
 
     // Get current md5 hash
     if (!empty($v_user)) {
-        exec (HESTIA_CMD."v-get-mail-account-value ".escapeshellarg($v_user)." ".$v_domain." ".$v_account." 'md5'", $output, $return_var);
+        exec (HESTIA_CMD."v-get-mail-account-value ".quoteshellarg($v_user)." ".$v_domain." ".$v_account." 'md5'", $output, $return_var);
         if ($return_var == 0) {
             $v_hash = $output[0];
         }
@@ -147,8 +147,8 @@ if ((!empty($_POST['email'])) && (!empty($_POST['password'])) && (!empty($_POST[
         $n_hash = md5crypt($v_password, $salt[2]);
         $n_hash = '{MD5}'.$n_hash;
         }else{
-            $v_password = escapeshellarg($v_password);
-            $s_hash = escapeshellarg($v_hash);
+            $v_password = quoteshellarg($v_password);
+            $s_hash = quoteshellarg($v_hash);
             exec(HESTIA_CMD."v-check-mail-account-hash ARGONID2 ". $v_password ." ". $s_hash, $output, $return_var);
             if($return_var != 0){
                 $n_hash = '';
@@ -162,7 +162,7 @@ if ((!empty($_POST['email'])) && (!empty($_POST['password'])) && (!empty($_POST[
             $fp = fopen($v_new_password, "w");
             fwrite($fp, $_POST['new']."\n");
             fclose($fp);
-            exec (HESTIA_CMD."v-change-mail-account-password ".escapeshellarg($v_user)." ".$v_domain." ".$v_account." ".$v_new_password, $output, $return_var);
+            exec (HESTIA_CMD."v-change-mail-account-password ".quoteshellarg($v_user)." ".$v_domain." ".$v_account." ".$v_new_password, $output, $return_var);
             if ($return_var == 0) {
                 echo "==ok==";
                 exit;

--- a/web/reset2fa/index.php
+++ b/web/reset2fa/index.php
@@ -15,7 +15,7 @@ if (!empty($_POST['user']) && !empty($_POST['twofa'])) {
     // Check token
     verify_csrf($_POST);
     $error = true;
-    $v_user = escapeshellarg($_POST['user']);
+    $v_user = quoteshellarg($_POST['user']);
     $user = $_POST['user'];
     $twofa = $_POST['twofa'];
     exec(HESTIA_CMD . "v-list-user ".$v_user .' json', $output, $return_var);

--- a/web/restart/service/index.php
+++ b/web/restart/service/index.php
@@ -12,7 +12,7 @@ if ($_SESSION['userContext'] === 'admin') {
         if ($_GET['srv'] == 'iptables') {
             exec(HESTIA_CMD."v-update-firewall", $output, $return_var);
         } else {
-            $v_service = escapeshellarg($_GET['srv']);
+            $v_service = quoteshellarg($_GET['srv']);
             exec(HESTIA_CMD."v-restart-service ".$v_service. " yes", $output, $return_var);
         }
     }

--- a/web/schedule/restore/index.php
+++ b/web/schedule/restore/index.php
@@ -7,7 +7,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 // Check token
 verify_csrf($_GET);
 
-$backup = escapeshellarg($_GET['backup']);
+$backup = quoteshellarg($_GET['backup']);
 
 $web = 'no';
 $dns = 'no';
@@ -17,22 +17,22 @@ $cron = 'no';
 $udir = 'no';
 
 if ($_GET['type'] == 'web') {
-    $web = escapeshellarg($_GET['object']);
+    $web = quoteshellarg($_GET['object']);
 }
 if ($_GET['type'] == 'dns') {
-    $dns = escapeshellarg($_GET['object']);
+    $dns = quoteshellarg($_GET['object']);
 }
 if ($_GET['type'] == 'mail') {
-    $mail = escapeshellarg($_GET['object']);
+    $mail = quoteshellarg($_GET['object']);
 }
 if ($_GET['type'] == 'db') {
-    $db = escapeshellarg($_GET['object']);
+    $db = quoteshellarg($_GET['object']);
 }
 if ($_GET['type'] == 'cron') {
     $cron = 'yes';
 }
 if ($_GET['type'] == 'udir') {
-    $udir = escapeshellarg($_GET['object']);
+    $udir = quoteshellarg($_GET['object']);
 }
 
 if (!empty($_GET['type'])) {

--- a/web/search/index.php
+++ b/web/search/index.php
@@ -11,8 +11,8 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 // Data
-$q = escapeshellarg($_GET['q']);
-$u = escapeshellarg($_GET['u']);
+$q = quoteshellarg($_GET['q']);
+$u = quoteshellarg($_GET['u']);
 
 if (($_SESSION['userContext'] === 'admin') && (!isset($_SESSION['look']))) {
     if (!empty($_GET['u'])) {

--- a/web/src/app/System/HestiaApp.php
+++ b/web/src/app/System/HestiaApp.php
@@ -21,10 +21,10 @@ class HestiaApp
 
         if (!empty($args) && is_array($args)) {
             foreach ($args as $arg) {
-                $cli_arguments .= escapeshellarg((string)$arg) . ' ';
+                $cli_arguments .= quoteshellarg((string)$arg) . ' ';
             }
         } else {
-            $cli_arguments = escapeshellarg($args);
+            $cli_arguments = quoteshellarg($args);
         }
 
         exec($cli_script . ' ' . $cli_arguments . ' 2>&1', $output, $exit_code);
@@ -65,7 +65,7 @@ class HestiaApp
 
         $composer_setup = self::TMPDIR_DOWNLOADS . DIRECTORY_SEPARATOR . 'composer-setup-' . $signature . '.php';
 
-        exec("wget https://getcomposer.org/installer --quiet -O " . escapeshellarg($composer_setup), $output, $return_code);
+        exec("wget https://getcomposer.org/installer --quiet -O " . quoteshellarg($composer_setup), $output, $return_code);
         if ($return_code !== 0) {
             throw new \Exception("Error downloading composer");
         }
@@ -247,7 +247,7 @@ class HestiaApp
             return false;
         }
 
-        exec("/usr/bin/wget --tries 3 --timeout=30 --no-dns-cache -nv " . escapeshellarg($src). " -P " . escapeshellarg(self::TMPDIR_DOWNLOADS) . ' 2>&1', $output, $return_var);
+        exec("/usr/bin/wget --tries 3 --timeout=30 --no-dns-cache -nv " . quoteshellarg($src). " -P " . quoteshellarg(self::TMPDIR_DOWNLOADS) . ' 2>&1', $output, $return_var);
         if ($return_var !== 0) {
             return false;
         }

--- a/web/src/app/WebApp/Installers/Wordpress/WordpressSetup.php
+++ b/web/src/app/WebApp/Installers/Wordpress/WordpressSetup.php
@@ -110,8 +110,8 @@ class WordpressSetup extends BaseSetup
         }
 
         exec("/usr/bin/curl --location --post301 --insecure --resolve ".$this->domain.":$webPort:".$this->appcontext->getWebDomainIp($this->domain)." "
-            . escapeshellarg($webDomain.$options['install_directory']."/wp-admin/install.php?step=2")
-            . " -d " . escapeshellarg(
+            . quoteshellarg($webDomain.$options['install_directory']."/wp-admin/install.php?step=2")
+            . " -d " . quoteshellarg(
                 "weblog_title=" . rawurlencode($options['site_name'])
             . "&user_name="      . rawurlencode($options['wordpress_account_username'])
             . "&admin_password=" . rawurlencode($options['wordpress_account_password'])

--- a/web/start/service/index.php
+++ b/web/start/service/index.php
@@ -12,7 +12,7 @@ if ($_SESSION['userContext'] === 'admin') {
         if ($_GET['srv'] == 'iptables') {
             exec(HESTIA_CMD."v-update-firewall", $output, $return_var);
         } else {
-            $v_service = escapeshellarg($_GET['srv']);
+            $v_service = quoteshellarg($_GET['srv']);
             exec(HESTIA_CMD."v-start-service ".$v_service, $output, $return_var);
         }
     }

--- a/web/stop/service/index.php
+++ b/web/stop/service/index.php
@@ -12,7 +12,7 @@ if ($_SESSION['userContext'] === 'admin') {
         if ($_GET['srv'] == 'iptables') {
             exec(HESTIA_CMD."v-stop-firewall", $output, $return_var);
         } else {
-            $v_service = escapeshellarg($_GET['srv']);
+            $v_service = quoteshellarg($_GET['srv']);
             exec(HESTIA_CMD."v-stop-service ".$v_service, $output, $return_var);
         }
     }

--- a/web/suspend/cron/index.php
+++ b/web/suspend/cron/index.php
@@ -6,7 +6,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (!empty($_GET['job'])) {
-    $v_job = escapeshellarg($_GET['job']);
+    $v_job = quoteshellarg($_GET['job']);
     exec(HESTIA_CMD."v-suspend-cron-job ".$user." ".$v_job, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/suspend/db/index.php
+++ b/web/suspend/db/index.php
@@ -10,7 +10,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (!empty($_GET['database'])) {
-    $v_database = escapeshellarg($_GET['database']);
+    $v_database = quoteshellarg($_GET['database']);
     exec(HESTIA_CMD."v-suspend-database ".$user." ".$v_database, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/suspend/dns/index.php
+++ b/web/suspend/dns/index.php
@@ -11,7 +11,7 @@ verify_csrf($_GET);
 
 // DNS domain
 if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-suspend-dns-domain ".$user." ".$v_domain, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);
@@ -26,8 +26,8 @@ if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
 
 // DNS record
 if ((!empty($_GET['domain'])) && (!empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_record_id = escapeshellarg($_GET['record_id']);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_record_id = quoteshellarg($_GET['record_id']);
     exec(HESTIA_CMD."v-suspend-dns-record ".$user." ".$v_domain." ".$v_record_id, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/suspend/firewall/index.php
+++ b/web/suspend/firewall/index.php
@@ -16,7 +16,7 @@ if ($_SESSION['userContext'] != 'admin') {
 }
 
 if (!empty($_GET['rule'])) {
-    $v_rule = escapeshellarg($_GET['rule']);
+    $v_rule = quoteshellarg($_GET['rule']);
     exec(HESTIA_CMD."v-suspend-firewall-rule ".$v_rule, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/suspend/mail/index.php
+++ b/web/suspend/mail/index.php
@@ -11,7 +11,7 @@ verify_csrf($_GET);
 
 // Mail domain
 if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-suspend-mail-domain ".$user." ".$v_domain, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);
@@ -26,9 +26,9 @@ if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
 
 // Mail account
 if ((!empty($_GET['domain'])) && (!empty($_GET['account']))) {
-    $v_username = escapeshellarg($user);
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_account = escapeshellarg($_GET['account']);
+    $v_username = quoteshellarg($user);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_account = quoteshellarg($_GET['account']);
     exec(HESTIA_CMD."v-suspend-mail-account ".$user." ".$v_domain." ".$v_account, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/suspend/user/index.php
+++ b/web/suspend/user/index.php
@@ -16,7 +16,7 @@ if ($_SESSION['userContext'] != 'admin') {
 }
 
 if (!empty($_GET['user'])) {
-    $v_username = escapeshellarg($_GET['user']);
+    $v_username = quoteshellarg($_GET['user']);
     exec(HESTIA_CMD."v-suspend-user ".$v_username, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/suspend/web/index.php
+++ b/web/suspend/web/index.php
@@ -10,8 +10,8 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (!empty($_GET['domain'])) {
-    $v_username = escapeshellarg($user);
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_username = quoteshellarg($user);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-suspend-web-domain ".$user." ".$v_domain, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/unsuspend/cron/index.php
+++ b/web/unsuspend/cron/index.php
@@ -9,7 +9,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (!empty($_GET['job'])) {
-    $v_job = escapeshellarg($_GET['job']);
+    $v_job = quoteshellarg($_GET['job']);
     exec(HESTIA_CMD."v-unsuspend-cron-job ".$user." ".$v_job, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/unsuspend/db/index.php
+++ b/web/unsuspend/db/index.php
@@ -9,7 +9,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (!empty($_GET['database'])) {
-    $v_database = escapeshellarg($_GET['database']);
+    $v_database = quoteshellarg($_GET['database']);
     exec(HESTIA_CMD."v-unsuspend-database ".$user." ".$v_database, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/unsuspend/dns/index.php
+++ b/web/unsuspend/dns/index.php
@@ -9,7 +9,7 @@ verify_csrf($_GET);
 
 // DNS domain
 if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-unsuspend-dns-domain ".$user." ".$v_domain, $output, $return_var);
     if ($return_var != 0) {
         $error = implode('<br>', $output);
@@ -30,8 +30,8 @@ if ((!empty($_GET['domain'])) && (empty($_GET['record_id']))) {
 
 // DNS record
 if ((!empty($_GET['domain'])) && (!empty($_GET['record_id']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_record_id = escapeshellarg($_GET['record_id']);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_record_id = quoteshellarg($_GET['record_id']);
     exec(HESTIA_CMD."v-unsuspend-dns-record ".$user." ".$v_domain." ".$v_record_id, $output, $return_var);
     if ($return_var != 0) {
         $error = implode('<br>', $output);

--- a/web/unsuspend/firewall/index.php
+++ b/web/unsuspend/firewall/index.php
@@ -14,7 +14,7 @@ if ($_SESSION['userContext'] != 'admin') {
 }
 
 if (!empty($_GET['rule'])) {
-    $v_rule = escapeshellarg($_GET['rule']);
+    $v_rule = quoteshellarg($_GET['rule']);
     exec(HESTIA_CMD."v-unsuspend-firewall-rule ".$v_rule, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/unsuspend/mail/index.php
+++ b/web/unsuspend/mail/index.php
@@ -9,7 +9,7 @@ verify_csrf($_GET);
 
 // Mail domain
 if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-unsuspend-mail-domain ".$user." ".$v_domain, $output, $return_var);
     if ($return_var != 0) {
         $error = implode('<br>', $output);
@@ -30,9 +30,9 @@ if ((!empty($_GET['domain'])) && (empty($_GET['account']))) {
 
 // Mail account
 if ((!empty($_GET['domain'])) && (!empty($_GET['account']))) {
-    $v_username = escapeshellarg($user);
-    $v_domain = escapeshellarg($_GET['domain']);
-    $v_account = escapeshellarg($_GET['account']);
+    $v_username = quoteshellarg($user);
+    $v_domain = quoteshellarg($_GET['domain']);
+    $v_account = quoteshellarg($_GET['account']);
     exec(HESTIA_CMD."v-unsuspend-mail-account ".$user." ".$v_domain." ".$v_account, $output, $return_var);
     if ($return_var != 0) {
         $error = implode('<br>', $output);

--- a/web/unsuspend/user/index.php
+++ b/web/unsuspend/user/index.php
@@ -15,7 +15,7 @@ if ($_SESSION['userContext'] != 'admin') {
 }
 
 if (!empty($_GET['user'])) {
-    $v_username = escapeshellarg($_GET['user']);
+    $v_username = quoteshellarg($_GET['user']);
     exec(HESTIA_CMD."v-unsuspend-user ".$v_username, $output, $return_var);
 }
 check_return_code($return_var, $output);

--- a/web/unsuspend/web/index.php
+++ b/web/unsuspend/web/index.php
@@ -8,7 +8,7 @@ include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 verify_csrf($_GET);
 
 if (!empty($_GET['domain'])) {
-    $v_domain = escapeshellarg($_GET['domain']);
+    $v_domain = quoteshellarg($_GET['domain']);
     exec(HESTIA_CMD."v-unsuspend-domain ".$user." ".$v_domain, $output, $return_var);
     check_return_code($return_var, $output);
     unset($output);

--- a/web/update/hestia/index.php
+++ b/web/update/hestia/index.php
@@ -9,7 +9,7 @@ verify_csrf($_GET);
 
 if ($_SESSION['userContext'] === 'admin') {
     if (!empty($_GET['pkg'])) {
-        $v_pkg = escapeshellarg($_GET['pkg']);
+        $v_pkg = quoteshellarg($_GET['pkg']);
         exec(HESTIA_CMD."v-update-sys-hestia ".$v_pkg, $output, $return_var);
     }
 


### PR DESCRIPTION
PHP's built-in escapeshellarg() for linux is kindof garbage: https://3v4l.org/Hkv7h
corrupting-or-stripping UTF-8 unicode characters like "æøå" and non-printable characters like "\x01", both of which are fully legal in linux shell arguments. In single-quoted-linux-shell-arguments there are only 2 bytes that needs special attention: \x00 and \x27


So to prevent corruption of unicode characters, implement escapeshellarg() in userland php.

- I only replaced escapeshellarg in the web/* directory, there are instances of escapeshellarg in other folders I didn't touch.
- I suspect the same is true for all of `in_array(PHP_OS_FAMILY, array('BSD', 'Darwin', 'Solaris', 'Linux'), true)` but i don't know those platforms well enough to say for sure 🤔 