### PR TITLE
Check if sieve is already installed

### DIFF
--- a/install/upgrade/manual/install_sieve.sh
+++ b/install/upgrade/manual/install_sieve.sh
@@ -16,6 +16,20 @@ source $HESTIA/func/main.sh
 source_conf "$HESTIA/conf/hestia.conf"
 source_conf "$HESTIA/install/upgrade/upgrade.conf"
 
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+#check if string already exists
+if grep "dovecot_virtual_delivery" /etc/exim4/exim4.conf.template; then 
+    echo "Plugin allready enabled"
+    exit 0
+fi
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
 HAS_DOVECOT_SIEVE_INSTALLED=`dpkg --get-selections dovecot-sieve | grep dovecot-sieve | wc -l`
 
 # Folder paths


### PR DESCRIPTION
If sieve is already installed and install_sieve.sh is executed, a duplicate block of "dovecot_virtual_delivery" was added to /etc/exim4/exim.conf.template causing an error when restarting exim4 service

An if statement was added to exit the script in case that block already exists