### PR TITLE
Use secure RNG to generate passwords

### DIFF
--- a/web/js/init.js
+++ b/web/js/init.js
@@ -615,3 +615,64 @@ $(document).ready(function(){
             });
     });
 
+/**
+ * generates a random string
+ * using a cryptographically secure rng, 
+ * and ensuring it contains at least 1 lowercase, 1 uppercase, and 1 number.
+ * 
+ * @param int length 
+ * @throws Error if length is too small to create a "sufficiently secure" string
+ * @returns string
+ */
+function randomString2(length = 16) {
+  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+  var secure_rng = function (min, max) {
+    if (min < 0 || min > 0xffff) {
+      throw new Error(
+        "minimum supported number is 0, this generator can only make numbers between 0-65535 inclusive."
+      );
+    }
+    if (max > 0xffff || max < 0) {
+      throw new Error(
+        "max supported number is 65535, this generator can only make numbers between 0-65535 inclusive."
+      );
+    }
+    if (min > max) {
+      throw new Error("dude min>max wtf");
+    }
+    // micro-optimization
+    let randArr = max > 255 ? new Uint16Array(1) : new Uint8Array(1);
+    let ret;
+    let attempts = 0;
+    for (;;) {
+      crypto.getRandomValues(randArr);
+      ret = randArr[0];
+      if (ret >= min && ret <= max) {
+        return ret;
+      }
+      ++attempts;
+      if (attempts > 1000000) {
+        // should basically never happen with max 0xFFFF/Uint16Array.
+        throw new Error("tried a million times, something is wrong");
+      }
+    }
+  };
+  let attempts = 0;
+  let minimumStrengthRegex = new RegExp(
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/
+  );
+  let randmax = chars.length - 1;
+  for (;;) {
+    let ret = "";
+    for (let i = 0; i < length; ++i) {
+      ret += chars[secure_rng(0, randmax)];
+    }
+    if (minimumStrengthRegex.test(ret)) {
+      return ret;
+    }
+    ++attempts;
+    if (attempts > 1000000) {
+      throw new Error("tried a million times, something is wrong");
+    }
+  }
+};

--- a/web/js/pages/add_db.js
+++ b/web/js/pages/add_db.js
@@ -88,45 +88,7 @@ App.Listeners.DB.keypress_v_password();
 App.Listeners.DB.keypress_db_username();
 App.Listeners.DB.keypress_db_databasename();
 
-randomString = function(min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    var string_length = min_length;
-    var randomstring = '';
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length -1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
-        $('input[name=v_password]').val(randomstring);
+randomString = function(min_length = 16) {    
+        $('input[name=v_password]').val(randomString2(min_length));
         App.Actions.DB.update_v_password();
-    }    
 }

--- a/web/js/pages/add_db.js
+++ b/web/js/pages/add_db.js
@@ -90,7 +90,7 @@ App.Listeners.DB.keypress_db_databasename();
 
 randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -120,7 +120,7 @@ randomString = function(min_length = 16) {
     var string_length = min_length;
     var randomstring = '';
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length -1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length -1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/add_mail_acc.js
+++ b/web/js/pages/add_mail_acc.js
@@ -118,7 +118,7 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -147,7 +147,7 @@ randomString = function(min_length = 16) {
     };
 
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/add_mail_acc.js
+++ b/web/js/pages/add_mail_acc.js
@@ -115,53 +115,14 @@ App.Listeners.MAIL_ACC.keypress_v_password();
 
 
 randomString = function(min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = min_length;
-    var randomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
+    var randomstring = randomString2(min_length);
         $('input[name=v_password]').val(randomstring);
         if($('input[name=v_password]').attr('type') == 'text')
             $('#v_password').text(randomstring);
         else
-            $('#v_password').text(Array(randomstring.length+1).join('*'));
-        
+            $('#v_password').text(Array(randomstring.length+1).join('*'));s        
         App.Actions.MAIL_ACC.update_v_password();
         generate_mail_credentials();
-    }    
 }
 
 generate_mail_credentials = function() {

--- a/web/js/pages/add_mail_acc.js
+++ b/web/js/pages/add_mail_acc.js
@@ -118,9 +118,36 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
+
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        randomstring += chars.substr(rnum, 1);
+        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/add_user.js
+++ b/web/js/pages/add_user.js
@@ -18,9 +18,36 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
+
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        randomstring += chars.substr(rnum, 1);
+        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/add_user.js
+++ b/web/js/pages/add_user.js
@@ -18,7 +18,7 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -47,7 +47,7 @@ randomString = function(min_length = 16) {
     };
 
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/add_user.js
+++ b/web/js/pages/add_user.js
@@ -14,49 +14,10 @@ $(function() {
 });
 
 
-randomString = function(min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = min_length;
-    var randomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
-        $('input[name=v_password]').val(randomstring);
-        App.Actions.WEB.update_v_password();
-    }    
-}
+randomString = function (min_length = 16) {
+    $("input[name=v_password]").val(randomString2(min_length));
+    App.Actions.WEB.update_v_password();
+};
 
 App.Actions.WEB.update_v_password = function (){
     var password = $('input[name="v_password"]').val();

--- a/web/js/pages/add_web.js
+++ b/web/js/pages/add_web.js
@@ -274,39 +274,7 @@ function WEBrandom() {
 }
 
 function FTPrandom(elm) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = 16;
-    var ftprandomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        ftprandomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
+    var ftprandomstring = randomString2(16);
     $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(ftprandomstring);
 }
 

--- a/web/js/pages/add_web.js
+++ b/web/js/pages/add_web.js
@@ -240,7 +240,7 @@ function WEBrandom() {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var webrandom = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -268,7 +268,7 @@ function WEBrandom() {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        webrandom += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        webrandom += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
         document.v_add_web.v_stats_password.value = webrandom;
 }
@@ -277,7 +277,7 @@ function FTPrandom(elm) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var ftprandomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -305,7 +305,7 @@ function FTPrandom(elm) {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        ftprandomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        ftprandomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(ftprandomstring);
 }

--- a/web/js/pages/add_web.js
+++ b/web/js/pages/add_web.js
@@ -240,9 +240,35 @@ function WEBrandom() {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var webrandom = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        webrandom += chars.substr(rnum, 1);
+        webrandom += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
         document.v_add_web.v_stats_password.value = webrandom;
 }
@@ -251,9 +277,35 @@ function FTPrandom(elm) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var ftprandomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        ftprandomstring += chars.substr(rnum, 1);
+        ftprandomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(ftprandomstring);
 }

--- a/web/js/pages/add_web.js
+++ b/web/js/pages/add_web.js
@@ -237,40 +237,7 @@ $(function() {
 
 
 function WEBrandom() {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = 16;
-    var webrandom = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        webrandom += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-        document.v_add_web.v_stats_password.value = webrandom;
+        document.v_add_web.v_stats_password.value = randomString2(16);
 }
 
 function FTPrandom(elm) {

--- a/web/js/pages/edit_db.js
+++ b/web/js/pages/edit_db.js
@@ -94,46 +94,8 @@ App.Listeners.DB.keypress_db_databasename();
 
 
 randomString = function(min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = min_length;
-    var randomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
-        $('input[name=v_password]').val(randomstring);
-        App.Actions.DB.update_v_password();
-    }    
+    $('input[name=v_password]').val(randomString2(min_length));
+    App.Actions.DB.update_v_password();
 }
 
      

--- a/web/js/pages/edit_db.js
+++ b/web/js/pages/edit_db.js
@@ -97,7 +97,7 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -125,7 +125,7 @@ randomString = function(min_length = 16) {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/edit_db.js
+++ b/web/js/pages/edit_db.js
@@ -97,9 +97,35 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        randomstring += chars.substr(rnum, 1);
+        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/edit_mail_acc.js
+++ b/web/js/pages/edit_mail_acc.js
@@ -97,7 +97,7 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -125,7 +125,7 @@ randomString = function(min_length = 16) {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/edit_mail_acc.js
+++ b/web/js/pages/edit_mail_acc.js
@@ -97,9 +97,35 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        randomstring += chars.substr(rnum, 1);
+        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/edit_mail_acc.js
+++ b/web/js/pages/edit_mail_acc.js
@@ -93,54 +93,17 @@ $('#v_blackhole').on('click', function(evt){
 App.Listeners.MAIL_ACC.keypress_v_password();
 
 
-randomString = function(min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = min_length;
-    var randomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
-        $('input[name=v_password]').val(randomstring);
-        if($('input[name=v_password]').attr('type') == 'text')
-            $('#v_password').text(randomstring);
-        else
-            $('#v_password').text(Array(randomstring.length+1).join('*'));
-        
-        App.Actions.MAIL_ACC.update_v_password();
-        generate_mail_credentials();
-    }    
-}
+randomString = function (min_length = 16) {
+  var randomstring = randomString2(min_length);
+  $("input[name=v_password]").val(randomstring);
+  if ($("input[name=v_password]").attr("type") == "text")
+    $("#v_password").text(randomstring);
+  else 
+    $("#v_password").text(Array(randomstring.length + 1).join("*"));
+  App.Actions.MAIL_ACC.update_v_password();
+  generate_mail_credentials();
+};
+
 generate_mail_credentials = function() {
     var div = $('.mail-infoblock').clone();
     div.find('#mail_configuration').remove();

--- a/web/js/pages/edit_user.js
+++ b/web/js/pages/edit_user.js
@@ -2,7 +2,7 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -30,7 +30,7 @@ randomString = function(min_length = 16) {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/edit_user.js
+++ b/web/js/pages/edit_user.js
@@ -1,44 +1,6 @@
 randomString = function(min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = min_length;
-    var randomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
-        $('input[name=v_password]').val(randomstring);
+        $('input[name=v_password]').val(randomString2(min_length));
         App.Actions.WEB.update_v_password();
-    }    
 }
 
 App.Actions.WEB.update_v_password = function (){

--- a/web/js/pages/edit_user.js
+++ b/web/js/pages/edit_user.js
@@ -2,9 +2,35 @@ randomString = function(min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        randomstring += chars.substr(rnum, 1);
+        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/edit_web.js
+++ b/web/js/pages/edit_web.js
@@ -279,9 +279,36 @@ function WEBrandom() {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var webrandom = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
+
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        webrandom += chars.substr(rnum, 1);
+        webrandom += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     document.v_edit_web.v_stats_password.value = webrandom;
 }
@@ -290,9 +317,35 @@ function FTPrandom(elm) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var ftprandomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        ftprandomstring += chars.substr(rnum, 1);
+        ftprandomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
 
     $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(ftprandomstring);

--- a/web/js/pages/edit_web.js
+++ b/web/js/pages/edit_web.js
@@ -314,41 +314,7 @@ function WEBrandom() {
 }
 
 function FTPrandom(elm) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = 16;
-    var ftprandomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        ftprandomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-
-    $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(ftprandomstring);
+    $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(randomString2(16));
     App.Actions.WEB.randomPasswordGenerated && App.Actions.WEB.randomPasswordGenerated(elm);
 }
 

--- a/web/js/pages/edit_web.js
+++ b/web/js/pages/edit_web.js
@@ -276,41 +276,7 @@ $(function() {
 });
 
 function WEBrandom() {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = 16;
-    var webrandom = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-
-    for (var i = 0; i < string_length; i++) {
-        webrandom += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    document.v_edit_web.v_stats_password.value = webrandom;
+    document.v_edit_web.v_stats_password.value = randomString2(16);
 }
 
 function FTPrandom(elm) {

--- a/web/js/pages/edit_web.js
+++ b/web/js/pages/edit_web.js
@@ -279,7 +279,7 @@ function WEBrandom() {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var webrandom = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -308,7 +308,7 @@ function WEBrandom() {
     };
 
     for (var i = 0; i < string_length; i++) {
-        webrandom += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        webrandom += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     document.v_edit_web.v_stats_password.value = webrandom;
 }
@@ -317,7 +317,7 @@ function FTPrandom(elm) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = 16;
     var ftprandomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -345,7 +345,7 @@ function FTPrandom(elm) {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        ftprandomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        ftprandomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
 
     $(elm).parents('.ftptable').find('.v-ftp-user-psw').val(ftprandomstring);

--- a/web/js/pages/setup_webapp.js
+++ b/web/js/pages/setup_webapp.js
@@ -2,7 +2,7 @@ randomString = function(target, min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
-    var shitty_but_secure_rng = function(min, max) {
+    var secure_rng = function(min, max) {
         if (min < 0 || min > 0xFFFF) {
             throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
         }
@@ -30,7 +30,7 @@ randomString = function(target, min_length = 16) {
         }
     };
     for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
+        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){

--- a/web/js/pages/setup_webapp.js
+++ b/web/js/pages/setup_webapp.js
@@ -1,42 +1,4 @@
 randomString = function(target, min_length = 16) {
-    var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    var string_length = min_length;
-    var randomstring = '';
-    var secure_rng = function(min, max) {
-        if (min < 0 || min > 0xFFFF) {
-            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (max > 0xFFFF || max < 0) {
-            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
-        }
-        if (min > max) {
-            throw new Error("dude min>max wtf");
-        }
-        // micro-optimization
-        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
-        let ret;
-        let attempts = 0;
-        for(;;){
-            crypto.getRandomValues(randArr);
-            ret = randArr[0];
-            if(ret >= min && ret <= max) {
-                return ret;
-            }
-            ++attempts;
-            if (attempts > 1000000) {
-                // should basically never happen with max 0xFFFF/Uint16Array. 
-                throw new Error("tried a million times, something is wrong");
-            }
-        }
-    };
-    for (var i = 0; i < string_length; i++) {
-        randomstring += chars.substr(secure_rng(0, chars.length - 1), 1);
-    }
-    var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
-    if(!regex.test(randomstring)){
-        randomString();
-    }else{
-        elm = document.getElementById(target);
-        $(elm).val(randomstring);
-    }    
+    elm = document.getElementById(target);
+    $(elm).val(randomString2(min_length));
 }

--- a/web/js/pages/setup_webapp.js
+++ b/web/js/pages/setup_webapp.js
@@ -2,9 +2,35 @@ randomString = function(target, min_length = 16) {
     var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
     var string_length = min_length;
     var randomstring = '';
+    var shitty_but_secure_rng = function(min, max) {
+        if (min < 0 || min > 0xFFFF) {
+            throw new Error("minimum supported number is 0, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (max > 0xFFFF || max < 0) {
+            throw new Error("max supported number is 65535, this shitty generator can only make numbers between 0-65535 inclusive.");
+        }
+        if (min > max) {
+            throw new Error("dude min>max wtf");
+        }
+        // micro-optimization
+        let randArr = (max > 255 ? new Uint16Array(1) : new Uint8Array(1));
+        let ret;
+        let attempts = 0;
+        for(;;){
+            crypto.getRandomValues(randArr);
+            ret = randArr[0];
+            if(ret >= min && ret <= max) {
+                return ret;
+            }
+            ++attempts;
+            if (attempts > 1000000) {
+                // should basically never happen with max 0xFFFF/Uint16Array. 
+                throw new Error("tried a million times, something is wrong");
+            }
+        }
+    };
     for (var i = 0; i < string_length; i++) {
-        var rnum = Math.floor(Math.random() * chars.length);
-        randomstring += chars.substr(rnum, 1);
+        randomstring += chars.substr(shitty_but_secure_rng(0, chars.length - 1), 1);
     }
     var regex = new RegExp(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\d)[a-zA-Z\d]{8,}$/);
     if(!regex.test(randomstring)){


### PR DESCRIPTION
quoting [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random):
>Math.random() does not provide cryptographically secure random numbers. Do not use them for anything related to security. Use the Web Crypto API instead

and when using Math.random(), an attacker can try to guess the rng algorithm used (or the browser used), and the initial seed, which can be easier than bruteforcing a password.

Fwiw older php versions's initial seed was based on the unix timestamp, has been vulnerabilities using php's rand() where attackers could just guess WHEN the password was created, to guess the initial seed, to recover the password...

My rng is kinda shitty, i know there is some fast way to cut down higher digits to get a digit in range without introducing bias, but i also know that other people have introduced bias by trying to do that on an initially secure rng and getting it wrong (iirc it's discussed here? https://www.youtube.com/watch?v=LDPMpc-ENqY - been years since i saw the talk, but i know Lavavej discussed it in one of his presentations, i think it was that one)  , but anyway this is fast enough, and secure.