### PR TITLE
Fix Exim4 fastopen with Gmail services

### DIFF
--- a/install/deb/exim/exim4.conf.4.94.template
+++ b/install/deb/exim/exim4.conf.4.94.template
@@ -376,6 +376,7 @@ remote_smtp:
   dkim_private_key = DKIM_PRIVATE_KEY
   dkim_canon = relaxed
   dkim_strict = 0
+  hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
 
 procmail:

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -378,6 +378,7 @@ remote_smtp:
   dkim_private_key = DKIM_PRIVATE_KEY
   dkim_canon = relaxed
   dkim_strict = 0
+  hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
 
 procmail:

--- a/install/upgrade/versions/1.6.3.sh
+++ b/install/upgrade/versions/1.6.3.sh
@@ -21,3 +21,10 @@ upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'yes'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'yes'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 
+if [ -f /etc/exim4/exim4.conf.template ]; then 
+    host=$(cat /etc/exim4/exim4.conf.template | grep hosts_try_fastopen);
+    if [ -z "$host" ]; then
+        echo "[ * ] Fix an issue with sending large attachments to Google / Gmail"
+        sed -i '/dkim_strict = .*/a hosts_try_fastopen = !*.l.google.com' /etc/exim4/exim4.conf.template
+    fi
+fi


### PR DESCRIPTION
On Debian 11 when sending emails with attachments to gmail accounts, they got stuck on exim queue for a random period of time and sometimes they were not even being delivered