### PR TITLE
fix: utilize entire alphabet for random string

### DIFF
--- a/web/js/init.js
+++ b/web/js/init.js
@@ -625,7 +625,7 @@ $(document).ready(function(){
  * @returns string
  */
 function randomString2(length = 16) {
-  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghiklmnopqrstuvwxyz";
   var secure_rng = function (min, max) {
     if (min < 0 || min > 0xffff) {
       throw new Error(

--- a/web/js/init.js
+++ b/web/js/init.js
@@ -625,7 +625,7 @@ $(document).ready(function(){
  * @returns string
  */
 function randomString2(length = 16) {
-  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghiklmnopqrstuvwxyz";
+  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   var secure_rng = function (min, max) {
     if (min < 0 || min > 0xffff) {
       throw new Error(


### PR DESCRIPTION
Noticed that T was used twice and j was missing in the options of available characters for random string generation