### PR TITLE
don't disable show_source

### DIFF
--- a/src/deb/php/php.ini
+++ b/src/deb/php/php.ini
@@ -309,7 +309,7 @@ serialize_precision = -1
 ; This directive allows you to disable certain functions.
 ; It receives a comma-delimited list of function names.
 ; http://php.net/disable-functions
-disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,show_source,
+disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,
 
 ; This directive allows you to disable certain classes.
 ; It receives a comma-delimited list of class names.


### PR DESCRIPTION
i'm guessing it's inclusion is due to some paranoid sysadmin thinking the *name* sounds scary, without even looking at what the function actually does. 
Anyhow, the function is just an alias of highlight_file() , so either both highlight_file() and show_source() should be disabled, or neither of them should be. Also the function is as dangerous as readfile() / file_get_contents() (: