### PR TITLE
chmod o+x .ssh when creating hst-filemanager-key

### DIFF
--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -25,6 +25,9 @@ $dist_config['services']['Filegator\Services\Storage\Filesystem']['config']['ada
     # Create filemanager sftp key if missing and trash it after 30 min
     if (! file_exists('/home/'.basename($v_user).'/.ssh/hst-filemanager-key')) {
         exec("sudo /usr/local/hestia/bin/v-add-user-sftp-key " . escapeshellarg(basename($v_user)) . " 30", $output, $return_var);
+        // filemanager also requires .ssh chmod o+x ... hopefully we can improve it to g+x or u+x someday
+        // current minimum for filemanager: chmod 0701 .ssh
+        shell_exec("sudo chmod o+x " . escapeshellarg('/home/' . basename($v_user) . '/.ssh'));
     }
 
     if (!isset($_SESSION['SFTP_PORT'])) {


### PR DESCRIPTION
i habitually chmod my .ssh folders to 0700, that broke filemanager, wasted some time figuring out what the problem was, this will hopefully save someone else from having to figure out that the filemanager requires a minimum of o+x (interestingly it doesn't require o+r so i left it out)