### PR TITLE
prohibit MariaDB-sensitive usernames

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -30,6 +30,13 @@ source_conf "$HESTIA/conf/hestia.conf"
 
 
 is_user_free() {
+    # these names may cause issues with MariaDB/MySQL database names and should be reserved:
+    check_sysuser=$(php -r '$reserved_names=array("aria", "aria_log", "mysql", "mysql_upgrade", "ib", "ib_buffer",
+ "ddl", "ddl_recovery", "performance"); if(in_array(strtolower($argv[1]), $reserved_names, true)){echo implode(", ", $reserved_names);}' "$user" );
+    if [ -n "$check_sysuser" ]; then
+        check_result "$E_INVALID" "The user name '$user' is reserved and cannot be used. List of reserved names: $check_sysuser"
+        return
+    fi
     check_sysuser=$(cut -f 1 -d : /etc/passwd | grep "^$user$" )
     if [ -n "$check_sysuser" ] || [ -e "$USER_DATA" ]; then
         check_result "$E_EXISTS" "user $user exists"


### PR DESCRIPTION
For example: we don't want anyone creating a user named "aria" which then try to make a mysql database named "log", because that would conflict with the mariadb internal database name aria_log (HestiaCP adds {username}_ to all databases created by users, afaik)