### PR TITLE
fix mysql username rename

### DIFF
--- a/web/edit/db/index.php
+++ b/web/edit/db/index.php
@@ -50,11 +50,16 @@ if (!empty($_POST['save'])) {
 
     // Change database user
     if (($v_dbuser != $_POST['v_dbuser']) && (empty($_SESSION['error_msg']))) {
-        $v_dbuser = escapeshellarg($v_dbuser);
-        exec(HESTIA_CMD."v-change-database-user ".$user." ".escapeshellarg($v_database)." ".$v_dbuser, $output, $return_var);
+        $cmd = implode(" ",array(
+            HESTIA_CMD."v-change-database-user",
+            // $user is already shell-quoted
+            $user,
+            escapeshellarg($v_database),
+            escapeshellarg($_POST['v_dbuser'])
+        ));
+        exec($cmd, $output, $return_var);
         check_return_code($return_var, $output);
         unset($output);
-        $v_dbuser = $_POST['v_dbuser'];
     }
 
     // Change database password
@@ -78,6 +83,11 @@ if (!empty($_POST['save'])) {
     if (empty($_SESSION['error_msg'])) {
         $_SESSION['ok_msg'] = _('Changes has been saved.');
     }
+    // if the mysql username was changed, render_page() below will render with the OLD mysql username,
+    // to prvent that, make the browser refresh the page.
+    http_response_code(303);
+    header("Location: "  .$_SERVER['REQUEST_URI']);
+    die();
 }
 
 // Render page

--- a/web/edit/db/index.php
+++ b/web/edit/db/index.php
@@ -50,12 +50,12 @@ if (!empty($_POST['save'])) {
 
     // Change database user
     if (($v_dbuser != $_POST['v_dbuser']) && (empty($_SESSION['error_msg']))) {
-        $cmd = implode(" ",array(
-            HESTIA_CMD."v-change-database-user",
+        $cmd = implode(" ", array(
+            HESTIA_CMD . "v-change-database-user",
             // $user is already shell-quoted
             $user,
             escapeshellarg($v_database),
-            escapeshellarg($_POST['v_dbuser'])
+            escapeshellarg($_POST['v_dbuser']),
         ));
         exec($cmd, $output, $return_var);
         check_return_code($return_var, $output);
@@ -86,7 +86,7 @@ if (!empty($_POST['save'])) {
     // if the mysql username was changed, render_page() below will render with the OLD mysql username,
     // to prvent that, make the browser refresh the page.
     http_response_code(303);
-    header("Location: "  .$_SERVER['REQUEST_URI']);
+    header("Location: " . $_SERVER['REQUEST_URI']);
     die();
 }
 


### PR DESCRIPTION
there was actually 2 bugs here:

1: the 3rd argument to v-change-database-user mixed the old name with the new name, so the command became "rename old_name to old_name", which broke mysql username rename completely.

2: even if the username rename worked (which it didn't), render_page() would still render with the old mysql username, not the new one. fixed that by forcing a page GET reload after changing username.

afan#4297 on Discord support channel reported that mysql username rename wasn't working:

>afan — Yesterday at 6:53 PM
>
>Hey, I noticed another weird behavior with the panel. when I change a db username > save  I get : " Changes have been saved." now reload the DB tab. changes are not actually made and the db user still has the old name
