### PR TITLE
[Bug fix] Avoid duplicate database username

### DIFF
--- a/bin/v-add-database
+++ b/bin/v-add-database
@@ -52,6 +52,7 @@ is_type_valid "$DB_SYSTEM" "$type"
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
 is_object_new 'db' 'DB' "$database"
+is_object_new 'db' 'DBUSER' "$dbuser"
 get_next_dbhost
 is_object_valid "../../../conf/$type" 'HOST' "$host"
 is_object_unsuspended "../../../conf/$type" 'DBHOST' "$host"


### PR DESCRIPTION
When user "db_user" exists in "db_foo", creating "db_bar" and setting the username to "db_user" will broken the user "db_user" of "db_foo".