### PR TITLE
Information Disclosure Vulnerability

### DIFF
--- a/web/inc/2fa/secret.php
+++ b/web/inc/2fa/secret.php
@@ -1,5 +1,8 @@
 <?php
 
+session_start();
+if ((isset($_SESSION['userContext']) === False) && (php_sapi_name() !== 'cli'))  exit;
+
 require_once '/usr/local/hestia/web/inc/2fa/loader.php';
 Loader::register('./','RobThree\\Auth');
 


### PR DESCRIPTION
Hello,

I have detected the `web/inc/2fa/secret.php` does not check authentication because of It is used through the CLI. Since this code is generating QR code with an random secret key and the hostname of the system running the code, it leads to disclosure of the hostname to any unauthenticated user.

The fix ensures that `userContext` is presented in the session, or the output of the `php_sapi_name()` function call is `cli`.

References:
https://www.php.net/manual/en/function.gethostname.php
https://www.php.net/manual/en/function.php-sapi-name.php