### PR TITLE
Fix for CSRF Origin Check Bypass

### DIFF
--- a/web/inc/prevent_csrf.php
+++ b/web/inc/prevent_csrf.php
@@ -35,13 +35,16 @@
                 $hostname = explode(':', $_SERVER['HTTP_HOST']);
                 $port=$hostname[1];
                 $hostname=$hostname[0];
-                if (strpos($_SERVER['HTTP_ORIGIN'], gethostname()) !== false  && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
-                    return checkStrictness(2);
-                } else {
-                    if (strpos($_SERVER['HTTP_ORIGIN'], $hostname) !== false && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
-                        return checkStrictness(1);
+                if (isset($_SERVER['HTTP_ORIGIN'])) {
+                    $origin_host = parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST);
+                    if (strcmp($origin_host, gethostname()) === 0 && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
+                        return checkStrictness(2);
                     } else {
-                        return checkStrictness(0);
+                        if (strcmp($origin_host, $hostname) === 0 && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
+                            return checkStrictness(1);
+                        } else {
+                            return checkStrictness(0);
+                        }
                     }
                 }
             }
@@ -60,10 +63,11 @@
                     return true;
                 }
                 if (isset($_SERVER['HTTP_REFERER'])) {
-                    if (strpos($_SERVER['HTTP_REFERER'], gethostname()) !== false  && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
+                    $referrer_host = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_HOST);
+                    if (strcmp($referrer_host, gethostname()) === 0 && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
                         return checkStrictness(2);
                     } else {
-                        if (strpos($_SERVER['HTTP_REFERER'], $hostname) !== false && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
+                        if (strcmp($referrer_host, $hostname) === 0 && in_array($port, array('443',$_SERVER['SERVER_PORT']))) {
                             return checkStrictness(1);
                         } else {
                             return checkStrictness(0);


### PR DESCRIPTION
Hello,

I have detected the previous code was using the `strpos` function to check the host given in the referer or origin headers.
![image](https://user-images.githubusercontent.com/101548315/180168513-f03f5526-0d15-4e83-8f3f-7fd290f46f9c.png)
Since the `strpos` function only checks the existance of the given string on the another one, attacker could easily bypass this protection by creating a subdomain that contains the target hostname.
![image](https://user-images.githubusercontent.com/101548315/180169465-3ec42b6a-fafb-432d-8470-532b45195d01.png)

In order to fix that, I've parsed the hostname given in the `Origin` or `Referer` header by using [parseurl](https://www.php.net/manual/en/function.parse-url.php) function and then compared it by using the `strcmp` function.

Here is the after of the fix:
![image](https://user-images.githubusercontent.com/101548315/180171049-c29be212-bee2-4a82-bd75-c5642d29494c.png)