### PR TITLE
nginx: set proxy_buffer_size value

### DIFF
--- a/install/deb/nginx/nginx.conf
+++ b/install/deb/nginx/nginx.conf
@@ -54,6 +54,7 @@ http {
     proxy_set_header                X-Real-IP $remote_addr;
     proxy_set_header                X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass_header               Set-Cookie;
+    proxy_buffer_size               8k;
     proxy_buffers                   32 4k;
     proxy_connect_timeout           30s;
     proxy_read_timeout              300s;

--- a/install/rpm/nginx/nginx.conf
+++ b/install/rpm/nginx/nginx.conf
@@ -50,6 +50,7 @@ http {
     proxy_set_header                X-Real-IP $remote_addr;
     proxy_set_header                X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass_header               Set-Cookie;
+    proxy_buffer_size               8k;
     proxy_buffers                   32 4k;
     proxy_connect_timeout           30s;
     proxy_read_timeout              300s;


### PR DESCRIPTION
fix error: upstream sent too big header while reading response header from upstream