### PR TITLE
check if folder exist first.

### DIFF
--- a/bin/v-change-web-domain-docroot
+++ b/bin/v-change-web-domain-docroot
@@ -86,15 +86,12 @@ else
     # Check for existence of specified directory under target domain's public_html folder
     target_domain_directory="$HOMEDIR/$user/web/$target_domain"
     if [ -n "$target_directory" ]; then
-
         # Checking destination path
         real_target_directory="$(readlink -e "${target_domain_directory}/public_html/$target_directory/")"
-        if [ -z "$(echo $real_target_directory | egrep "^$target_domain_directory\b")" ]; then
-            check_result "$E_FORBIDEN" "Target dir outside of target domain dir"
-        fi
-
         if [ ! -e "$real_target_directory" ]; then
             check_result "$E_NOTEXIST" "Directory $target_directory does not exist under $HOMEDIR/$user/$target_domain/public_html/."
+        elif [ -z "$(echo $real_target_directory | egrep "^$target_domain_directory\b")" ]; then
+            check_result "$E_FORBIDEN" "Target dir outside of target domain dir"
         else
             CUSTOM_DOCROOT="$real_target_directory"
             if [ -n "$php" ]; then


### PR DESCRIPTION
there was a minor bug where if the folder didn't exist, we would say "Target dir outside of target domain dir" instead of "folder does not exist"

because we checked them in the wrong order ^^
PS untested as of writing, but in theory this should fix it.