### PR TITLE
Fix: nameserver A record validation

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -622,7 +622,7 @@ is_dns_nameserver_valid() {
         remote=$(echo $r |grep ".$domain.$")
         if [ -n "$remote" ]; then
             zone=$USER_DATA/dns/$d.conf
-            a_record=$(echo $r |cut -f 1 -d '.')
+            a_record=${r%.$d.}
             n_record=$(grep "RECORD='$a_record'" $zone| grep "TYPE='A'")
             if [ -z "$n_record" ]; then
                 check_result "$E_NOTEXIST" "IN A $a_record.$d does not exist"


### PR DESCRIPTION
Previously this would only validate first part of the nameserver. But a nameserver having multiple parts would get incorrectly validated if first part of the nameserver already had an A record. Now this validates the whole part. E.g

Previously:
Zone: test.com
NS: ns1.A.test.com
Incorrect A: ns1

Now
Zone: test.com
NS: ns1.A.test.com
Correct A: ns1.A