### PR TITLE
Add wp-password-bcrypt to default WP installs

### DIFF
--- a/web/src/app/WebApp/Installers/Wordpress/WordpressSetup.php
+++ b/web/src/app/WebApp/Installers/Wordpress/WordpressSetup.php
@@ -98,6 +98,12 @@ class WordpressSetup extends BaseSetup
             throw new \Exception("Error installing config file in: " . $tmp_configpath . " to:" . $this->getDocRoot("wp-config.php") . $result->text);
         }
 
+        $this->appcontext->downloadUrl('https://raw.githubusercontent.com/roots/wp-password-bcrypt/master/wp-password-bcrypt.php', null, $plugin_output);
+        $this->appcontext->runUser('v-add-fs-directory', [$this->getDocRoot("wp-content/mu-plugins/")], $result);
+        if (!$this->appcontext->runUser('v-copy-fs-file', [$plugin_output->file, $this->getDocRoot("wp-content/mu-plugins/wp-password-bcrypt.php")], $result)) {
+            throw new \Exception("Error installing wp-password-bcrypt file in: " . $plugin_output->file . " to:" . $this->getDocRoot("wp-content/mu-plugins/wp-password-bcrypt.php") . $result->text);
+        }
+
         $this->appcontext->run('v-list-web-domain', [$this->appcontext->user(), $this->domain, 'json'], $status);
         $sslEnabled = ($status->json[$this->domain]['SSL'] == 'no' ? 0 : 1);
         $webDomain = ($sslEnabled ? "https://" : "http://") . $this->domain . "/";


### PR DESCRIPTION
# Overview

wp-password-bcrypt is a WordPress plugin to replace WP's outdated and insecure MD5-based password hashing with the modern and secure [bcrypt](https://en.wikipedia.org/wiki/Bcrypt).

This plugin requires PHP >= 5.5.0 which introduced the built-in [`password_hash`](http://php.net/manual/en/function.password-hash.php) and [`password_verify`](http://php.net/manual/en/function.password-verify.php) functions.

See [Improving WordPress Password Security](https://roots.io/improving-wordpress-password-security/) for more background on this plugin and the password hashing issue.

## What this PR does

This PR modifies the WordPress Quick Install template to automatically install wp-password-bcrypt as a [mu-plugin](https://wordpress.org/support/article/must-use-plugins/). This enhances the security of default WordPress installations.