### PR TITLE
Fix #2820 and #2824

### DIFF
--- a/install/upgrade/versions/1.6.7.sh
+++ b/install/upgrade/versions/1.6.7.sh
@@ -20,3 +20,11 @@ upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'no'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'no'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
+if [ -f "/etc/roundcube/config.inc.php" ]; then
+    sed -i "s/\$config\['auto_create_user'] = false;/\$config\['auto_create_user'] = true;/g" /etc/roundcube/config.inc.php  
+    sed -i "s/\$config\['prefer_html'] = false;/\$config\['prefer_html'] = true;/g" /etc/roundcube/config.inc.php  
+          
+    #For older installs
+    sed -i "s/\$config\['default_host']/\$config\['imap_host']/g" /etc/roundcube/config.inc.php    
+fi


### PR DESCRIPTION
Upgrade containing no imap_host include both "auto_create_user" = false and prefer_html = "false" 

This will resolve the listed issue

For existing upgrades rename default_host to imap_host