### PR TITLE
Fix #2480 v-change-domain-owner mail only

### DIFF
--- a/bin/v-change-domain-owner
+++ b/bin/v-change-domain-owner
@@ -73,7 +73,7 @@ if [ -n "$web_data" ]; then
             new_php_docroot=$(echo $CUSTOM_PHPROOT | sed "s/\/home\/$owner/\/home\/$user/");
         fi
     fi
-    
+
     if [ -z "$(echo $(get_user_ips) | grep $IP)" ]; then
         echo "[*] IP dedicated to $owner select new ip adress..."
         get_user_ip
@@ -170,6 +170,7 @@ fi
 # MAIL domain
 mail_data=$(grep "DOMAIN='$domain'" $HESTIA/data/users/$owner/mail.conf)
 if [ -n "$mail_data" ]; then
+    $BIN/v-suspend-mail-domain "$owner" "$domain" >> /dev/null 2>&1
     echo "[*] Moving mail domain and accounts..."
 
     parse_object_kv_list "$mail_data"
@@ -181,6 +182,7 @@ if [ -n "$mail_data" ]; then
 
     # Move config
     sed -i "/DOMAIN='$domain'/d" $HESTIA/data/users/$owner/mail.conf
+    mail_data=$(echo "$mail_data" | sed "s/SUSPENDED='no'/SUSPENDED='yes'/")
     echo "$mail_data" >> $HESTIA/data/users/$user/mail.conf
     mv -f $HESTIA/data/users/$owner/mail/$domain.conf \
         $HESTIA/data/users/$user/mail/
@@ -192,7 +194,7 @@ if [ -n "$mail_data" ]; then
         mv -f $HESTIA/data/users/$owner/mail/$domain.pub \
             $HESTIA/data/users/$user/mail/
     fi
-
+    
     # Move SSL certificates
     if [ "$SSL" = 'yes' ]; then
          # Ensure that SSL directory exists and move certificates
@@ -274,7 +276,6 @@ if [ -n "$mail_data" ]; then
     if [ -e "$HESTIA/data/users/$owner/mail/$domain.conf" ]; then
         rm -f "$HESTIA/data/users/$owner/mail/$domain.conf"
     fi
-    
 
     # Rebuild config
     $BIN/v-unsuspend-mail-domain "$user" "$domain" no
@@ -286,14 +287,17 @@ fi
 $BIN/v-update-user-counters "$owner"
 $BIN/v-update-user-counters "$user"
 
-# Recalculate ip usage 
-if [ -n "$ip" ]; then
-    decrease_ip_value $old_ip $owner
-    increase_ip_value $new_ip 
-else
-    # recalculate ip 
-    decrease_ip_value $old_ip $owner
-    increase_ip_value $old_ip 
+# Mail domains currently don't have the IP variable set see #2306 
+if [ -n "$old_ip" ]; then
+    # Recalculate ip usage 
+    if [ -n "$ip" ]; then
+        decrease_ip_value $old_ip $owner
+        increase_ip_value $new_ip 
+    else
+        # recalculate ip 
+        decrease_ip_value $old_ip $owner
+        increase_ip_value $old_ip 
+    fi
 fi
 # Send notification to panel
 if [ -n "$web_data" ] || [ -n "$dns_data" ] || [ -n "$mail_data" ]; then


### PR DESCRIPTION
Mail domains don't have ip set in their config currently causing $oldip to be empty