### PR TITLE
Improve error reporting Letsencrypt

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -386,7 +386,7 @@ for auth in $authz; do
         status=$(echo "$answer"|grep HTTP/ |tail -n1 |cut -f 2 -d ' ')
         details=$(echo "$answer"| grep detail | cut -f 1 -d ',' | cut -f 2-4 -d ':' | cut -f 2 -d '"')
 
-        debug_log "Step 5" "- status: ${status}\n- nonce: ${nonce}\n- validation: ${validation}\n- details: ${details}\n- answer: ${answer}"
+        debug_log "Step 5" "- status: ${status}\n- url: ${url}\n- nonce: ${nonce}\n- validation: ${validation}\n- details: ${details}\n- answer: ${answer}"
 
         if [[ "$status" -ne 200 ]]; then
             # Delete DNS CAA record
@@ -400,8 +400,14 @@ for auth in $authz; do
                     fi
                 fi
             fi
-            debug_log "Abort Step 5" "=> Wrong status"
-            check_result "$E_CONNECT" "Let's Encrypt validation status $status ($domain). Details: $details"
+            # Download debug info from LE server
+            result=$(wget -qO- $url)
+            debug_log "Debug information Step 5"  "$result"
+            details=$(echo $result | jq '.error.detail' )
+            error_code=$(echo $result | jq '.error.status' )            
+            
+            debug_log "Abort Step 5" "=> Wrong status" 
+            check_result "$E_CONNECT" "Let's Encrypt validation status $status ($domain). Details: $error_code:$details"
         fi
 
         i=$((i + 1))

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -53,7 +53,7 @@ software="nginx apache2 apache2-utils apache2-suexec-custom
   dnsutils bsdmainutils cron hestia=${HESTIA_INSTALL_VER} hestia-nginx
   hestia-php expect libmail-dkim-perl unrar-free vim-common acl sysstat
   rsyslog openssh-server util-linux ipset libapache2-mpm-itk zstd
-  lsb-release"
+  lsb-release jq"
 
 
 installer_dependencies="apt-transport-https curl dirmngr gnupg wget ca-certificates"

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -52,7 +52,7 @@ software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
     php$fpm_v-opcache php$fpm_v-pspell php$fpm_v-readline php$fpm_v-xml
     postgresql postgresql-contrib proftpd-basic quota rrdtool spamassassin sudo hestia=${HESTIA_INSTALL_VER}
     hestia-nginx hestia-php vim-common vsftpd whois unzip zip acl sysstat setpriv rsyslog
-    ipset libonig5 libzip5 openssh-server lsb-release zstd"
+    ipset libonig5 libzip5 openssh-server lsb-release zstd jq"
 
 installer_dependencies="apt-transport-https curl dirmngr gnupg wget software-properties-common ca-certificates"
 

--- a/src/deb/hestia/control
+++ b/src/deb/hestia/control
@@ -6,7 +6,7 @@ Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com
 Architecture: amd64
-Depends: bash, awk, sed, acl, sysstat, setpriv | util-linux (>= 2.33), zstd, lsb-release, idn2
+Depends: bash, awk, sed, acl, sysstat, setpriv | util-linux (>= 2.33), zstd, lsb-release, idn2, jq
 Description: hestia
  hestia is an open source hosting control panel.
  hestia has a clean and focused interface without the clutter.

--- a/src/rpm/hestia/hestia.spec
+++ b/src/rpm/hestia/hestia.spec
@@ -15,6 +15,7 @@ Requires:       acl
 Requires:       sysstat
 Requires:       (setpriv or util-linux)
 Requires:       zstd
+Requires:       jq
 Conflicts:      vesta
 Provides:       hestia = %{version}
 BuildRequires:  systemd-rpm-macros


### PR DESCRIPTION
- Add support for JQ

We need to make sure RHEL will support JQ or we need to change. 

For "Easy" to use phrasing with JQ goes a lot faster and is a lot easier