### PR TITLE
Fix letsencrypt variable name causing error

### DIFF
--- a/web/templates/pages/edit_web.html
+++ b/web/templates/pages/edit_web.html
@@ -337,7 +337,7 @@
 															<?=$v_ssl_issuer?>
 														</td>
 													</tr>
-													<tr id="letsinfo" style="display:<?php if ($v_letsencrypt == 'yes' || $v_letencrypt == 'on' ) { echo 'block';} else {echo 'none';} ?>">
+													<tr id="letsinfo" style="display:<?php if ($v_letsencrypt == 'yes' || $v_letsencrypt == 'on' ) { echo 'block';} else {echo 'none';} ?>">
 														<td><a href="#" onclick="elementHideShow('ssl-details'); return false;" class="generate"><?=_('Show Certificate');?></a></td>
 													</tr>
 												</table>
@@ -517,7 +517,7 @@
 											</table>
 										</td>
 									</tr>
-									<?php if (in_array($_SESSION['FTP_SYSTEM'], array('vsftpd', 'proftpd'))) { ?>  
+									<?php if (in_array($_SESSION['FTP_SYSTEM'], array('vsftpd', 'proftpd'))) { ?>
 										<tr>
 											<td class="vst-text input-label">
 												<label><input type="checkbox" size="20" class="vst-checkbox" name="v_ftp" <?php if (!empty($v_ftp_user)) echo "checked=yes" ?> onclick="App.Actions.WEB.toggle_additional_ftp_accounts(this)"><?=_('Additional FTP Account');?></label>


### PR DESCRIPTION
I got an error when re-enabling letsencrypt ssl on a web domain and following the error I got to this typo here.