### PR TITLE
Fix #1834 Include extra config when restoring backups

### DIFF
--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -335,8 +335,25 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
                 $BIN/v-add-web-domain-backend $user $domain $BACKEND
             fi
         fi
-                
-        # Rebuilding vhost
+        
+        # Restoring custom user config
+        # Except certificates, .conf files
+        if [ ! -d "$HOMEDIR/$user/conf/web/$domain/" ]; then
+            mkdir -p $HOMEDIR/$user/conf/web/$domain/
+        fi
+        for file in $tmpdir/web/$domain/conf/*; do 
+            if [[ "$file" == *.ca ]] || [[ "$file" == *.crt ]]  || [[ "$file" == *.key ]]  || [[ "$file" == *.pem ]]  || [[ "$file" == *.conf ]]; then
+               continue;
+            fi
+            if grep "fastcgi_pass" file; then 
+               # Do not allow to run php under a different user
+               continue;
+            fi 
+            filename=$(basename $file) 
+            cp -f "$file" "$HOMEDIR/$user/conf/web/$domain/$filename"
+        done
+        
+        # Rebuilding vhost to prevent user overwrite default config changes not ideal 
         rebuild_web_domain_conf
         
         # Restoring web domain data

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -293,10 +293,10 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
             fi
             
             if [ -n "$CUSTOM_DOCROOT" ]; then
-               CUSTOM_DOCROOT=$(echo "$CUSTOM_DOCROOT" | sed -e "s|/home/${old_user}/web/|/home/${$user}/web/")
+               CUSTOM_DOCROOT=$(echo "$CUSTOM_DOCROOT" | sed -e "s|/home/${old_user}/web/|/home/${user}/web/")
             fi
             if [ -n "$CUSTOM_PHPROOT" ]; then
-               CUSTOM_PHPROOT=$(echo "$CUSTOM_PHPROOT" | sed -e "s|/home/${old_user}/web/|/home/${$user}/web/")
+               CUSTOM_PHPROOT=$(echo "$CUSTOM_PHPROOT" | sed -e "s|/home/${old_user}/web/|/home/${user}/web/")
             fi
 
             # Converting FTP users

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -291,6 +291,13 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
             if [ -n "$check_backend_tpl" ]; then
                 BACKEND='default'
             fi
+            
+            if [ -n "$CUSTOM_DOCROOT" ]; then
+               CUSTOM_DOCROOT=$(echo "$CUSTOM_DOCROOT" | sed -e "s|/home/${old_user}/web/|/home/${$user}/web/")
+            fi
+            if [ -n "$CUSTOM_PHPROOT" ]; then
+               CUSTOM_PHPROOT=$(echo "$CUSTOM_PHPROOT" | sed -e "s|/home/${old_user}/web/|/home/${$user}/web/")
+            fi
 
             # Converting FTP users
             if [ -n "$FTP_USER" ]; then

--- a/func/domain.sh
+++ b/func/domain.sh
@@ -230,7 +230,11 @@ prepare_web_domain_values() {
 
 # Add web config
 add_web_config() {
-    mkdir -p "$HOMEDIR/$user/conf/web/$domain"
+    # Check if folder already exists
+    if [ ! -d "$HOMEDIR/$user/conf/web/$domain" ]; then
+        mkdir -p "$HOMEDIR/$user/conf/web/$domain/"
+    fi
+    
     conf="$HOMEDIR/$user/conf/web/$domain/$1.conf"
     if [[ "$2" =~ stpl$ ]]; then
         conf="$HOMEDIR/$user/conf/web/$domain/$1.ssl.conf"

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -312,7 +312,7 @@ function validate_web_domain() {
 @test "Restore[3]: From Hestia [WEB] Custom rule" {
     # check if custom rule is still working
     local domain="test.hestia.com"
-    validate_web_domain_fake $userbk $domain 'hestia-yes' '/hestia/hestia'
+    validate_web_domain $userbk $domain 'hestia-yes' '/hestia/hestia' 'no'
 }
 
 
@@ -405,7 +405,7 @@ function validate_web_domain() {
 @test "Restore[4]: From Hestia [WEB] Custom rule" {
     # check if custom rule is still working
     local domain="test.hestia.com"
-    validate_web_domain_fake $userbk $domain 'hestia-yes' '/hestia/hestia'
+    validate_web_domain $userbk $domain 'hestia-yes' '/hestia/hestia' 'no'
 }
 
 

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -42,6 +42,7 @@ function validate_web_domain() {
     local domain=$2
     local webproof=$3
     local webpath=${4}
+    local valwebpath=${5}
     
     refute [ -z "$user" ]
     refute [ -z "$domain" ]
@@ -57,15 +58,16 @@ function validate_web_domain() {
     SSL=$(get_object_value 'web' 'DOMAIN' "$domain" '$SSL')
     domain_ip=$(get_real_ip "$domain_ip")
     
-    if [ ! -z $webpath ]; then
-        domain_docroot=$(get_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_DOCROOT')
-        if [ -n "$domain_docroot" ] && [ -d "$domain_docroot" ]; then
-            assert_file_exist "${domain_docroot}/${webpath}"
-        else
-            assert_file_exist "${HOMEDIR}/${user}/web/${domain}/public_html/${webpath}"
+    if [ -z $valwebpath ]; then
+        if [ ! -z $webpath ]; then
+            domain_docroot=$(get_object_value 'web' 'DOMAIN' "$domain" '$CUSTOM_DOCROOT')
+            if [ -n "$domain_docroot" ] && [ -d "$domain_docroot" ]; then
+                assert_file_exist "${domain_docroot}/${webpath}"
+            else
+                assert_file_exist "${HOMEDIR}/${user}/web/${domain}/public_html/${webpath}"
+            fi
         fi
     fi
-    
     # Test HTTP
     run curl --location --silent --show-error --insecure --resolve "${domain}:80:${domain_ip}" "http://${domain}/${webpath}"
     assert_success
@@ -101,18 +103,24 @@ function validate_web_domain() {
 #      - hestia111_db
 #    cron:
 #      - 1: /bin/true
-#  Hestia 1.3.1 archive contains (As zstd format)
+#  Hestia 1.7.0 archive contains (As zstd format)
 #    user: hestia131
 #    web:
 #      - test.hestia.com (+SSL self-signed)
+#        FTP Account 
+#        Awstats enabled
 #    dns:
 #      - test.hestia.com
 #    mail:
 #      - test.hestia.com
+#        Ratelimit: 10
 #    mail acc:
 #      - testaccount@test.hestia.com
+#           Alias: info@test.hestiacp.com
+#           Ratelimit: 20
+#      - support@test.hestia.com
 #    db:
-#      - hestia131_db
+#      - hestia170_db
 #    cron:
 #      - 1: /bin/true 
 #  Vesta 0.9.8-23 archive contains:
@@ -275,7 +283,7 @@ function validate_web_domain() {
     
     mkdir -p /backup
     
-    local archive_name="hestia131.2020-12-12"
+    local archive_name="hestia170.2022-08-23"
     run wget --quiet --tries=3 --timeout=15 --read-timeout=15 --waitretry=3 --no-dns-cache "https://hestiacp.com/testing/data/${archive_name}.tar" -O "/backup/${archive_name}.tar"
     assert_success
     
@@ -289,6 +297,24 @@ function validate_web_domain() {
     local domain="test.hestia.com"
     validate_web_domain $userbk $domain 'Hello Hestia'
 }
+
+@test "Restore[3]: From Hestia [WEB] FTP" {
+    local domain="test.hestia.com"
+    assert_file_contains /etc/passwd "$userbk_test"
+    assert_file_contains /etc/passwd "/home/$userbk/web/$domain"
+}
+
+@test "Restore[3]: From Hestia [WEB] Awstats" {
+    local domain="test.hestia.com"
+    assert_file_exist /home/$userbk/conf/web/$domain/awstats.conf
+}
+
+@test "Restore[3]: From Hestia [WEB] Custom rule" {
+    # check if custom rule is still working
+    local domain="test.hestia.com"
+    validate_web_domain_fake $userbk $domain 'hestia-yes' '/hestia/hestia'
+}
+
 
 @test "Restore[3]: From Hestia [DNS]" {
     local domain="test.hestia.com"
@@ -312,6 +338,11 @@ function validate_web_domain() {
     
     run v-list-mail-account $userbk $domain testaccount
     assert_success
+    # Check if alias is created
+    assert_file_contains /etc/exim4/domains/$domain/aliases "testaccount@$domain"
+    # Check if expected rate limits are set
+    assert_file_contains /etc/exim4/domains/$domain/limits "testaccount@$domain:20"
+    assert_file_contains /etc/exim4/domains/$domain/limits "support@$domain:10"  
 }
 
 @test "Restore[3]: From Hestia [DB]" {
@@ -323,6 +354,7 @@ function validate_web_domain() {
     run v-list-cron-job $userbk 1
     assert_success
 }
+
 
 @test "Restore[3]: From Hestia Cleanup" {
     run v-delete-user $userbk
@@ -359,6 +391,24 @@ function validate_web_domain() {
     validate_web_domain $userbk $domain 'Hello Hestia'
 }
 
+@test "Restore[4]: From Hestia [WEB] FTP" {
+    local domain="test.hestia.com"
+    assert_file_contains /etc/passwd "$userbk_test"
+    assert_file_contains /etc/passwd "/home/$userbk/web/$domain"
+}
+
+@test "Restore[4]: From Hestia [WEB] Awstats" {
+    local domain="test.hestia.com"
+    assert_file_exist /home/$userbk/conf/web/$domain/awstats.conf
+}
+
+@test "Restore[4]: From Hestia [WEB] Custom rule" {
+    # check if custom rule is still working
+    local domain="test.hestia.com"
+    validate_web_domain_fake $userbk $domain 'hestia-yes' '/hestia/hestia'
+}
+
+
 @test "Restore[4]: From Hestia [DNS]" {
     local domain="test.hestia.com"
     
@@ -381,6 +431,11 @@ function validate_web_domain() {
     
     run v-list-mail-account $userbk $domain testaccount
     assert_success
+    # Check if alias is created
+    assert_file_contains /etc/exim4/domains/$domain/aliases "testaccount@$domain"
+    # Check if expected rate limits are set
+    assert_file_contains /etc/exim4/domains/$domain/limits "testaccount@$domain:20"
+    assert_file_contains /etc/exim4/domains/$domain/limits "support@$domain:10"  
 }
 
 @test "Restore[4]: From Hestia [DB]" {

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -376,7 +376,7 @@ function validate_web_domain() {
 
     mkdir -p /backup
     
-    local archive_name="hestia131.2020-12-12"
+    local archive_name="hestia170.2022-08-23"
     run wget --quiet --tries=3 --timeout=15 --read-timeout=15 --waitretry=3 --no-dns-cache "https://hestiacp.com/testing/data/${archive_name}.tar" -O "/backup/${archive_name}.tar"
     assert_success
     


### PR DESCRIPTION
If a user create extra config files in /home/user/conf/web/domain.com/nginx.conf_extra_config they are backed up corrently how ever never restored. 