### PR TITLE
Adjust order of <title>

### DIFF
--- a/web/templates/includes/title.html
+++ b/web/templates/includes/title.html
@@ -1,2 +1,2 @@
 <meta charset="utf-8">
-<title><?=htmlentities($_SERVER['HTTP_HOST']); ?> - <?=_($TAB)?> - <?=_('Hestia Control Panel');?></title>
+<title><?=_($TAB)?> - <?=htmlentities($_SERVER['HTTP_HOST']); ?> - <?=_('Hestia Control Panel');?></title>


### PR DESCRIPTION
### Current problem

Since I started using Hestia, I assumed there was no <title> present on the control panel pages as my browser tab always just displayed the hostname, which is similar to the default display when there is no <title> present.

It turns out, there is a <title> on every page which includes a useful $TAB value, but I never see this value as the hostname is long and pushes the other text out of view.

### Proposed solution

Feels to me $TAB is by far the most important value to show first here, so that the user can see the tab changing as they navigate around.

I question how much value including the hostname has at all really. On all my instances this makes the <title> long and pushes the other content out of view. I've moved it to the second value in this PR, but would be happy to remove it 🙂 

### Screenshots

**Before:**
![before screenshot](https://i.imgur.com/LC3KGvh.png)

**After:**
![after screenshot](https://i.imgur.com/DsXNkic.png)