### PR TITLE
Insert Fail2ban rules in 5th place

### DIFF
--- a/bin/v-add-firewall-ban
+++ b/bin/v-add-firewall-ban
@@ -75,7 +75,7 @@ date=$(echo "$time_n_date" |cut -f 2 -d \ )
 
 # Adding ip to banlist
 echo "IP='$ip' CHAIN='$chain' TIME='$time' DATE='$date'" >> $conf
-$iptables -I fail2ban-$chain 1 -s $ip \
+$iptables -I fail2ban-$chain 5 -s $ip \
     -j REJECT --reject-with icmp-port-unreachable 2>/dev/null
 
 # Changing permissions

--- a/install/deb/fail2ban/action.d/iptables-multiport.local
+++ b/install/deb/fail2ban/action.d/iptables-multiport.local
@@ -1,0 +1,4 @@
+[Definition]
+actionstart = <iptables> -N f2b-<name>
+              <iptables> -A f2b-<name> -j <returntype>
+              <iptables> -I <chain> 5 -p <protocol> -m multiport --dports <port> -j f2b-<name>

--- a/install/rpm/fail2ban/action.d/iptables-multiport.local
+++ b/install/rpm/fail2ban/action.d/iptables-multiport.local
@@ -1,0 +1,4 @@
+[Definition]
+actionstart = <iptables> -N f2b-<name>
+              <iptables> -A f2b-<name> -j <returntype>
+              <iptables> -I <chain> 5 -p <protocol> -m multiport --dports <port> -j f2b-<name>


### PR DESCRIPTION
After a restart, fail2ban takes the first places and any iptables whitelisting action will be ignored.

`target     prot opt source               destination`
`fail2ban-HESTIA  tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:8083`
`fail2ban-MAIL  tcp  --  0.0.0.0/0            0.0.0.0/0            multiport dports 25,465,587,110,995,143,993`
`fail2ban-FTP  tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:21`
`fail2ban-SSH  tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:2220`
`fail2ban-RECIDIVE  tcp  --  0.0.0.0/0            0.0.0.0/0            multiport dports 1:65535`
`ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED`
`ACCEPT     all  --  1.2.3.4           0.0.0.0/0`
`ACCEPT     all  --  127.0.0.1            0.0.0.0/0`
`ACCEPT       tcp  --  0.0.0.0/0            0.0.0.0/0            match-set whitelist src`
