### PR TITLE
Fix casing inconsistency of $TAB on login page

### DIFF
--- a/web/login/index.php
+++ b/web/login/index.php
@@ -6,8 +6,7 @@ define('NO_AUTH_REQUIRED', true);
 
 include($_SERVER['DOCUMENT_ROOT'] . '/inc/main.php');
 
-$TAB = 'login';
-
+$TAB = 'LOGIN';
 
 if (isset($_GET['logout'])) {
     unset($_SESSION);


### PR DESCRIPTION
### Current problem

Now that $TAB is more visible in page <title> since #2871, I notice how the login page has inconsistent casing with all other pages. This happened in #926 but I'm not sure why.

### Proposed solution

Change it back to uppercase so it matches the other pages. If the casing is changed we should do it for all pages at once.

### Screenshots

**Before:**
![before screenshot](https://i.imgur.com/mBmrh16.png)

**After:**
![after screenshot](https://i.imgur.com/8845QPd.png)