### PR TITLE
Remove invalid "border" attribute from images

### DIFF
--- a/web/templates/pages/login/login.html
+++ b/web/templates/pages/login/login.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;">
 							<form method="post" action="/login/" id="form_login">

--- a/web/templates/pages/login/login_1.html
+++ b/web/templates/pages/login/login_1.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
 							<form method="post" action="/login/" id="form_login">

--- a/web/templates/pages/login/login_2.html
+++ b/web/templates/pages/login/login_2.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
 							<form method="post" action="/login/" id="form_login">

--- a/web/templates/pages/login/login_a.html
+++ b/web/templates/pages/login/login_a.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;">
 							<form method="post" action="/login/" id="form_login">

--- a/web/templates/pages/login/reset2fa.html
+++ b/web/templates/pages/login/reset2fa.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
 							<?php if ($success) {?>

--- a/web/templates/pages/login/reset_1.html
+++ b/web/templates/pages/login/reset_1.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
 							<form method="post" action="/reset/">

--- a/web/templates/pages/login/reset_2.html
+++ b/web/templates/pages/login/reset_2.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
 							<form method="get" action="/reset/">

--- a/web/templates/pages/login/reset_3.html
+++ b/web/templates/pages/login/reset_3.html
@@ -5,7 +5,7 @@
 				<table>
 					<tr>
 						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/"><img border=0 src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
+							<a href="/"><img src="/images/logo.svg" title="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;" /></a>
 						</td>
 						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
 							<form method="post">


### PR DESCRIPTION
Setting border attribute on image tags is invalid in HTML5 and unnecessary.

This is also already set globally on all images via normalize.css.