### PR TITLE
is_name_format_valid is only used for the name

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -1069,7 +1069,7 @@ is_cron_format_valid() {
 
 # Name validator
 is_name_format_valid() {
-    if ! [[ "$1" =~ ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+    if ! [[ "$1" =~ ^[-|\ |\.|_[:alnum:]]{0,50}$ ]]; then
         check_result "$E_INVALID" "invalid $2 format :: $1"
     fi
 }


### PR DESCRIPTION
Current rules allowes only names like:
Very-long-company-name-with-more-then-twenty-eight-chars-will-fall 

Or Jaap - 

As the Name is only for display in email and panel it doesn't need to follow the stricter username rules used for Debian / Ubuntu
