### PR TITLE
Fix v-add-backup-host for sftp servers with different login prompt

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -60,6 +60,11 @@ sftpc() {
                 exp_continue
             }
 
+            -re "Password for (.*)@(.*)" {
+                send "$password\r"
+                exp_continue
+            }
+
             -re "Couldn't|(.*)disconnect|(.*)stalled|(.*)not found" {
                 set count \$argc
                 set output "Disconnected."

--- a/func/backup.sh
+++ b/func/backup.sh
@@ -208,6 +208,11 @@ sftpc() {
                     send "$PASSWORD\r"
                     exp_continue
                 }
+
+                -re "Password for (.*)@(.*)" {
+                    send "$PASSWORD\r"
+                    exp_continue
+                }
     
                 -re "Couldn't|(.*)disconnect|(.*)stalled|(.*)not found" {
                     set count \$argc


### PR DESCRIPTION
On a FreeBSD hosted sftp server, the password prompt looks different. Example: `Password for user@host:` 

This pull-request fixes the issue.

1. Full SFTP login prompt fom the HestiaCP server
```
root@host1:/usr/local/hestia/log# /usr/bin/sftp -o StrictHostKeyChecking=no -o Port=22 uploads@XX.XXX.XXX.XXX
Password for uploads@backupserver:
Connected to XX.XXX.XXX.XXX.
```
2. FreeBSD SFTP configuration in `/etc/ssh/sshd_config`
```
Match Group sftponly
    ChrootDirectory /usr/home/%u
    AllowTcpForwarding no
    X11Forwarding no
    ForceCommand internal-sftp
```
3. FreeBSD version
```
root@backupserver:~ # freebsd-version
13.0-RELEASE-p13
```

4. FreeBSD sshd version
```
root@backupserver:~ # sshd -v
OpenSSH_7.9p1, OpenSSL 1.1.1k-freebsd  24 Aug 2021
```