### PR TITLE
fix: user not able to create different type of database of same name

### DIFF
--- a/bin/v-add-database
+++ b/bin/v-add-database
@@ -51,7 +51,7 @@ is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
 is_type_valid "$DB_SYSTEM" "$type"
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
-is_object_new 'db' 'DB' "$database"
+is_object_new 'db' 'DB' "$database" "$type"
 is_object_new 'db' 'DBUSER' "$dbuser"
 get_next_dbhost
 is_object_valid "../../../conf/$type" 'HOST' "$host"

--- a/bin/v-delete-database
+++ b/bin/v-delete-database
@@ -58,7 +58,7 @@ esac
 #----------------------------------------------------------#
 
 # Deleting database
-sed -i "/DB='$database' /d" $USER_DATA/db.conf
+sed -i "/DB='$database'/!b;/TYPE='$TYPE'/d" $USER_DATA/db.conf
 
 # Decreasing counters
 decrease_dbhost_values
@@ -72,7 +72,7 @@ if [ -n "$suspended" ]; then
 fi
 
 # Logging
-$BIN/v-log-action "$user" "Info" "Database" "Deleted database (Name: $database)."
+$BIN/v-log-action "$user" "Info" "Database" "Deleted database (Name: $database) $TYPE."
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/func/main.sh
+++ b/func/main.sh
@@ -281,6 +281,13 @@ is_object_new() {
         if [ -d "$USER_DATA" ]; then
             object="OK"
         fi
+    elif [ $2 = 'DB' ]; then
+        object=$(grep "$2='$3'" $USER_DATA/$1.conf)
+        dbtype=$(echo "$object" | grep "TYPE='$4'")
+        if [ -n "$object" ] && [ -n "$dbtype" ]; then
+        check_result "$E_EXISTS" "$2=$3 of TYPE=$4 already exists"
+        fi
+        return
     else
         object=$(grep "$2='$3'" $USER_DATA/$1.conf)
     fi


### PR DESCRIPTION
If user already have a mysql/pgsql database user_dbxyz they cannot create a database with same name (user_dbxyz) of different type mysql/pgsql. This is fix for that issue.