### PR TITLE
swith fopen with tmpfile

### DIFF
--- a/web/api/index.php
+++ b/web/api/index.php
@@ -95,14 +95,14 @@ function api_legacy(array $request_data) {
             $hash = str_replace('$rounds=5000', '', $hash);
         }
         if ($method == 'yescrypt') {
-            $v_password = tempnam("/tmp", "vst");
-            $fp = fopen($v_password, "w");
+            $fp = tmpfile();
+            $v_password = stream_get_meta_data($fp)['uri'];
             fwrite($fp, $password."\n");
-            fclose($fp);
             unset($output);
-            exec(HESTIA_CMD . 'v-check-user-password "admin" '. $password. ' '.$v_ip.' yes', $output, $return_var);
+            exec(HESTIA_CMD . 'v-check-user-password "admin" '. quoteshellarg($v_password). ' '.$v_ip.' yes', $output, $return_var);
             $hash = $output[0];
-            unset($output);
+            fclose($fp);
+            unset($output, $fp, $v_password);
         }
         if ($method == 'des') {
             $hash = crypt($password, $salt);

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -130,13 +130,13 @@ function authenticate_user($user, $password, $twofa = '')
                 $hash = str_replace('$rounds=5000', '', $hash);
             }
             if ($method == 'yescrypt') {
-                $v_password = tempnam("/tmp", "vst");
-                $fp = fopen($v_password, "w");
+                $fp = tmpfile();
+                $v_password = stream_get_meta_data($fp)['uri'];
                 fwrite($fp, $password."\n");
-                fclose($fp);
-                exec(HESTIA_CMD . 'v-check-user-password '. $v_user.' '. $v_password. ' '.$v_ip.' yes', $output, $return_var);
+                exec(HESTIA_CMD . 'v-check-user-password '. $v_user.' '. quoteshellarg($v_password). ' '.$v_ip.' yes', $output, $return_var);
                 $hash = $output[0];
-                unset($output);
+                fclose($fp);
+                unset($output,$fp, $v_password);
             }
             if ($method == 'des') {
                 $hash = crypt($password, $salt);


### PR DESCRIPTION
<strike>as pointed out by knurry81 in https://github.com/hestiacp/hestiacp/commit/59b7a81cf0d2ae3e137f5a2bd038a7610233594a#r86167514 , using fopen here might be a bad idea, fopen defaults to chmod 0644, which is world-readable, while tmpfile defaults to 0600, only hestiacp user can read tmpfile</strike>
@jaapmarcus clarified that it isn't actually a file access security issue, tmpnam() creates the file with chmod 0600. this patch makes sure the password file gets cleaned up though.

also replace password in argument with password in file.