### PR TITLE
fix download ssl change page content in firefox

### DIFF
--- a/web/js/pages/list_ssl.js
+++ b/web/js/pages/list_ssl.js
@@ -21,7 +21,6 @@ function saveTextToBlob ( file, element ){
     }
 
     downloadLink.click();
-    return false;
 }
 
 function destroyClickedElement(event)


### PR DESCRIPTION
i am not sure about spec. but from my test, if you use `<a href="javascript:someFunctionReturnValue()">` may different behavior on different browser.
for ex.
- in firefox if you return it convert to string and change page content
- in chrome/edge if you return string it change page content to that string.

you may test it by yourself in this link https://jsfiddle.net/h8jf1r5x/1/