### PR TITLE
Update WordpressSetup.php

### DIFF
--- a/web/src/app/WebApp/Installers/Wordpress/WordpressSetup.php
+++ b/web/src/app/WebApp/Installers/Wordpress/WordpressSetup.php
@@ -42,6 +42,7 @@ class WordpressSetup extends BaseSetup
                         'it_IT' => 'Italian',
                         'nl_NL' => 'Dutch',
                         'pt_PT' => 'Portuguese',
+                        'pt_BR' => 'Portuguese (Brazil)',
                         'sk_SK' => 'Slovak',
                         'sr_RS' => 'Serbian',
                         'tr_TR' => 'Turkish',


### PR DESCRIPTION
Add Brazilian Portuguese to the hestiaCP quick install language list. It would be possible? Thanks.