### PR TITLE
Replace tabs with spaces in HTML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.html]
+indent_size = 2
+indent_style = space

--- a/web/templates/includes/end_js.html
+++ b/web/templates/includes/end_js.html
@@ -8,46 +8,46 @@
 <script src="/js/i18n.js.php?<?=JS_LATEST_UPDATE?>"></script>
 <script src="/js/templates.js?<?=JS_LATEST_UPDATE?>"></script>
 <?php foreach(new DirectoryIterator($_SERVER['HESTIA'].'/web/js/custom_scripts') as $customScript){
-	if($customScript->getExtension() === 'js'){
-		echo '<script src="/js/custom_scripts/'.rawurlencode($customScript->getBasename()).'"></script>';
-	} elseif($customScript->getExtension() === "php"){
-		require_once($customScript->getPathname());
-	}
+  if($customScript->getExtension() === 'js'){
+    echo '<script src="/js/custom_scripts/'.rawurlencode($customScript->getBasename()).'"></script>';
+  } elseif($customScript->getExtension() === "php"){
+    require_once($customScript->getPathname());
+  }
  } ?>
 <script>
-	$(function() {
-		hover_menu();
-	});
+  $(function() {
+    hover_menu();
+  });
 </script>
 
 <?php
-	if (!empty($_SESSION['error_msg'])):
-	?>
-	<div>
-		<script>
-			$(function() {
-				$('#dialog:ui-dialog').dialog('destroy');
-				$('#dialog-message').dialog({
-					modal: true,
-					resizable: false,
-					buttons: {
-						Ok: function() {
-							$(this).dialog('close');
-						}
-					},
-					create: function() {
-						$(this)
-						.closest('.ui-dialog')
-						.find('.ui-button:first')
-						.addClass('submit');
-					}
-				});
-			});
-		</script>
-		<div id="dialog-message" title="">
-			<p><?=htmlentities($_SESSION['error_msg'])?></p>
-		</div>
-	</div>
+  if (!empty($_SESSION['error_msg'])):
+  ?>
+  <div>
+    <script>
+      $(function() {
+        $('#dialog:ui-dialog').dialog('destroy');
+        $('#dialog-message').dialog({
+          modal: true,
+          resizable: false,
+          buttons: {
+            Ok: function() {
+              $(this).dialog('close');
+            }
+          },
+          create: function() {
+            $(this)
+            .closest('.ui-dialog')
+            .find('.ui-button:first')
+            .addClass('submit');
+          }
+        });
+      });
+    </script>
+    <div id="dialog-message" title="">
+      <p><?=htmlentities($_SESSION['error_msg'])?></p>
+    </div>
+  </div>
 <?php
-	unset($_SESSION['error_msg']);
-	endif;
+  unset($_SESSION['error_msg']);
+  endif;

--- a/web/templates/includes/panel.html
+++ b/web/templates/includes/panel.html
@@ -1,209 +1,209 @@
 <div class="hidden" id="token" token="<?=$_SESSION['token']?>"></div>
 <a href="#" class="to-top" title="<?=_('Top');?>">
-	<i class="fas fa-arrow-up"></i>
+  <i class="fas fa-arrow-up"></i>
 </a>
 <a href="#" class="to-shortcuts" title="<?=_('Shortcuts');?>">
-	<i class="fas fa-keyboard"></i>
+  <i class="fas fa-keyboard"></i>
 </a>
 
 <div class="l-header">
-	<div class="l-center">
-		<!-- Logo / Home Button -->
-		<a href="<?=htmlspecialchars($home_url)?>" class="l-logo" title="<?=_('Hestia Control Panel');?>"></a>
+  <div class="l-center">
+    <!-- Logo / Home Button -->
+    <a href="<?=htmlspecialchars($home_url)?>" class="l-logo" title="<?=_('Hestia Control Panel');?>"></a>
 
-		<!-- Left Menu -->
-		<div class="l-menu clearfix noselect">
-			<!-- Records tab -->
-			<div class="l-menu__item <?php if(in_array($TAB, ['WEB', 'DNS', 'MAIL', 'DB', 'BACKUP', 'CRON', 'PACKAGE', 'USER', 'LOG'])) echo 'l-menu__item--active' ?>"><a href="<?=htmlspecialchars($home_url)?>"><i class="fas fa-tasks panel-icon"></i><?=_('Records');?></a></div>
+    <!-- Left Menu -->
+    <div class="l-menu clearfix noselect">
+      <!-- Records tab -->
+      <div class="l-menu__item <?php if(in_array($TAB, ['WEB', 'DNS', 'MAIL', 'DB', 'BACKUP', 'CRON', 'PACKAGE', 'USER', 'LOG'])) echo 'l-menu__item--active' ?>"><a href="<?=htmlspecialchars($home_url)?>"><i class="fas fa-tasks panel-icon"></i><?=_('Records');?></a></div>
 
-			<!-- File Manager tab -->
-			<?php if ((isset($_SESSION['FILE_MANAGER'])) && (!empty($_SESSION['FILE_MANAGER'])) && ($_SESSION['FILE_MANAGER'] == "true")) {?>
-				<?php if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']) && ($_SESSION['look'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] == 'yes'))) {?>
-						<!-- Hide file manager when impersonating admin-->
-					<?php } else { ?>
-						<div class="l-menu__item <?php if($TAB == 'FM') echo 'l-menu__item--active' ?>"><a href="/fm/"><i class="fas fa-folder-open panel-icon"></i><?=_('Files');?></a></div>
-				<?php } ?>
-			<?php } ?>
+      <!-- File Manager tab -->
+      <?php if ((isset($_SESSION['FILE_MANAGER'])) && (!empty($_SESSION['FILE_MANAGER'])) && ($_SESSION['FILE_MANAGER'] == "true")) {?>
+        <?php if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']) && ($_SESSION['look'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] == 'yes'))) {?>
+            <!-- Hide file manager when impersonating admin-->
+          <?php } else { ?>
+            <div class="l-menu__item <?php if($TAB == 'FM') echo 'l-menu__item--active' ?>"><a href="/fm/"><i class="fas fa-folder-open panel-icon"></i><?=_('Files');?></a></div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Statistics tab-->
-			<div class="l-menu__item <?php if($TAB == 'STATS') echo 'l-menu__item--active' ?>"><a href="/list/stats/"><i class="fas fa-chart-line panel-icon"></i><?=_('Statistics');?></a></div>
-		</div>
+      <!-- Statistics tab-->
+      <div class="l-menu__item <?php if($TAB == 'STATS') echo 'l-menu__item--active' ?>"><a href="/list/stats/"><i class="fas fa-chart-line panel-icon"></i><?=_('Statistics');?></a></div>
+    </div>
 
-		<!-- Right Menu -->
-		<div class="l-profile noselect">
-			<div class="l-menu__item">
-				<!-- Logged in as / Usage Statistics Overview -->
-				<span class="pill usage">
-					<?php
-						if (isset($_SESSION['look'])) {
-							$user_icon = 'fa-binoculars';
-						} else if ($_SESSION['userContext'] === 'admin') {
-							$user_icon = 'fa-user-tie';
-						} else {
-							$user_icon = 'fa-user';
-						}
-					?>
-					<span class="label-space-right"><i class="fas <?=$user_icon;?> icon-pad-right" title="<?=_('Logged in as');?>: <?=htmlspecialchars($panel[$user]['NAME'])?>"></i><b><?=htmlspecialchars($user)?></b></span>
-					<span class="label-space-right"><i class="fas fa-hdd icon-pad-right" title="<?=_('Disk');?>: <?=humanize_usage_size($panel[$user]['U_DISK'])?> <?=humanize_usage_measure($panel[$user]['U_DISK'])?>"></i><b><?=humanize_usage_size($panel[$user]['U_DISK'])?></b> <?=humanize_usage_measure($panel[$user]['U_DISK'])?></span>
-					<span><i class="fas fa-exchange-alt icon-pad-right" title="<?=_('Bandwidth');?>: <?=humanize_usage_size($panel[$user]['U_BANDWIDTH'])?> <?=humanize_usage_measure($panel[$user]['U_BANDWIDTH'])?>"></i><b><?=humanize_usage_size($panel[$user]['U_BANDWIDTH'])?></b> <?=humanize_usage_measure($panel[$user]['U_BANDWIDTH'])?></span>
-				</span>
-			</div>
+    <!-- Right Menu -->
+    <div class="l-profile noselect">
+      <div class="l-menu__item">
+        <!-- Logged in as / Usage Statistics Overview -->
+        <span class="pill usage">
+          <?php
+            if (isset($_SESSION['look'])) {
+              $user_icon = 'fa-binoculars';
+            } else if ($_SESSION['userContext'] === 'admin') {
+              $user_icon = 'fa-user-tie';
+            } else {
+              $user_icon = 'fa-user';
+            }
+          ?>
+          <span class="label-space-right"><i class="fas <?=$user_icon;?> icon-pad-right" title="<?=_('Logged in as');?>: <?=htmlspecialchars($panel[$user]['NAME'])?>"></i><b><?=htmlspecialchars($user)?></b></span>
+          <span class="label-space-right"><i class="fas fa-hdd icon-pad-right" title="<?=_('Disk');?>: <?=humanize_usage_size($panel[$user]['U_DISK'])?> <?=humanize_usage_measure($panel[$user]['U_DISK'])?>"></i><b><?=humanize_usage_size($panel[$user]['U_DISK'])?></b> <?=humanize_usage_measure($panel[$user]['U_DISK'])?></span>
+          <span><i class="fas fa-exchange-alt icon-pad-right" title="<?=_('Bandwidth');?>: <?=humanize_usage_size($panel[$user]['U_BANDWIDTH'])?> <?=humanize_usage_measure($panel[$user]['U_BANDWIDTH'])?>"></i><b><?=humanize_usage_size($panel[$user]['U_BANDWIDTH'])?></b> <?=humanize_usage_measure($panel[$user]['U_BANDWIDTH'])?></span>
+        </span>
+      </div>
 
-			<!-- Notifications -->
-			<?php if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']) && ($user == 'admin'))) {?>
-				<!-- Do not show notifications panel when impersonating 'admin' user -->
-			<?php } else { ?>
-				<div class="l-menu__item">
-					<a title="<?=_('Notifications');?>" class="l-profile__notifications <?php if ($panel[$user]['NOTIFICATIONS'] == 'yes') echo " updates"; ?>">
-						<i class="fas fa-bell <?php if ($panel[$user]['NOTIFICATIONS'] == 'yes') echo " animated extended swing status-icon orange"; ?>"></i>
-					</a>
-				</div>
-			<?php } ?>
+      <!-- Notifications -->
+      <?php if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']) && ($user == 'admin'))) {?>
+        <!-- Do not show notifications panel when impersonating 'admin' user -->
+      <?php } else { ?>
+        <div class="l-menu__item">
+          <a title="<?=_('Notifications');?>" class="l-profile__notifications <?php if ($panel[$user]['NOTIFICATIONS'] == 'yes') echo " updates"; ?>">
+            <i class="fas fa-bell <?php if ($panel[$user]['NOTIFICATIONS'] == 'yes') echo " animated extended swing status-icon orange"; ?>"></i>
+          </a>
+        </div>
+      <?php } ?>
 
-			<!-- Server Settings -->
-			<?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['POLICY_SYSTEM_HIDE_SERVICES'] !== 'yes') || ($_SESSION['user'] === 'admin')) {?>
-				<?php if (($_SESSION['userContext'] === 'admin') && (!empty($_SESSION['look']))) {?>
-					<!-- Hide 'Server Settings' button when impersonating 'admin' or other users -->
-				<?php } else { ?>
-					<div class="l-menu__item <?php if(in_array($TAB, ['SERVER', 'IP', 'RRD', 'FIREWALL'])) echo 'l-menu__item--active' ?>"><a href="/list/server/" class="l-profile__serversettings" title="<?=_('Server');?>"><i class="fas fa-cog"></i></a></div>
-				<?php } ?>
-			<?php } ?>
+      <!-- Server Settings -->
+      <?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['POLICY_SYSTEM_HIDE_SERVICES'] !== 'yes') || ($_SESSION['user'] === 'admin')) {?>
+        <?php if (($_SESSION['userContext'] === 'admin') && (!empty($_SESSION['look']))) {?>
+          <!-- Hide 'Server Settings' button when impersonating 'admin' or other users -->
+        <?php } else { ?>
+          <div class="l-menu__item <?php if(in_array($TAB, ['SERVER', 'IP', 'RRD', 'FIREWALL'])) echo 'l-menu__item--active' ?>"><a href="/list/server/" class="l-profile__serversettings" title="<?=_('Server');?>"><i class="fas fa-cog"></i></a></div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Edit User -->
-			<?php if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']) && ($user == 'admin'))) {?>
-				<!-- Hide 'edit user' entry point from other administrators for default 'admin' account-->
-				<div class="l-menu__item <?php if($TAB == 'LOG') echo 'l-menu__item--active' ?>"><a href="/list/log/" title="<?_('Logs');?>" class="l-profile__username"><i class="fas fa-history"></i></a></div>
-			<?php } else { ?>
-				<?php if ($panel[$user]['SUSPENDED'] === 'no') {?>
-					<div class="l-menu__item"><a href="/edit/user/?user=<?=$user; ?>&token=<?=$_SESSION['token']?>" title="<?=htmlspecialchars($user)?> (<?=htmlspecialchars($panel[$user]['NAME'])?>)" class="l-profile__username"><i class="fas fa-user-circle"></i></a></div>
-				<?php } ?>
-			<?php } ?>
+      <!-- Edit User -->
+      <?php if (($_SESSION['userContext'] === 'admin') && (isset($_SESSION['look']) && ($user == 'admin'))) {?>
+        <!-- Hide 'edit user' entry point from other administrators for default 'admin' account-->
+        <div class="l-menu__item <?php if($TAB == 'LOG') echo 'l-menu__item--active' ?>"><a href="/list/log/" title="<?_('Logs');?>" class="l-profile__username"><i class="fas fa-history"></i></a></div>
+      <?php } else { ?>
+        <?php if ($panel[$user]['SUSPENDED'] === 'no') {?>
+          <div class="l-menu__item"><a href="/edit/user/?user=<?=$user; ?>&token=<?=$_SESSION['token']?>" title="<?=htmlspecialchars($user)?> (<?=htmlspecialchars($panel[$user]['NAME'])?>)" class="l-profile__username"><i class="fas fa-user-circle"></i></a></div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Help / Documentation-->
-			<div class="l-menu__item"><a href="https://docs.hestiacp.com/" rel="noopener" title="<?=_('Help');?>" class="l-profile__help" target="_blank"><i class="fas fa-question-circle"></i></a></div>
+      <!-- Help / Documentation-->
+      <div class="l-menu__item"><a href="https://docs.hestiacp.com/" rel="noopener" title="<?=_('Help');?>" class="l-profile__help" target="_blank"><i class="fas fa-question-circle"></i></a></div>
 
-			<!-- Logout -->
-			<?php if (isset($_SESSION['look']) && (!empty($_SESSION['look']))) { ?>
-				<div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?> (<?=$user?>)" class="l-profile__logout"><i class="fas fa-arrow-alt-circle-up"></i></a></div>
-			<?php } else { ?>
-				<div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?>" class="l-profile__logout"><i class="fas fa-sign-out-alt"></i></a></div>
-			<?php } ?>
-		</div>
-	</div>
+      <!-- Logout -->
+      <?php if (isset($_SESSION['look']) && (!empty($_SESSION['look']))) { ?>
+        <div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?> (<?=$user?>)" class="l-profile__logout"><i class="fas fa-arrow-alt-circle-up"></i></a></div>
+      <?php } else { ?>
+        <div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?>" class="l-profile__logout"><i class="fas fa-sign-out-alt"></i></a></div>
+      <?php } ?>
+    </div>
+  </div>
 </div>
 
 <ul class="notification-container u-hidden animated fadeIn"></ul>
 
 <div class="l-content">
-	<div class="l-center">
-		<div class="l-stat">
-			<!-- Users tab -->
-			<?php if (($_SESSION['userContext'] == 'admin') && (empty($_SESSION['look']))) {?>
-				<?php
-					if (($_SESSION['user'] !== 'admin') && ($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes')) {
-						$user_count = $panel[$user]['U_USERS'] - 1;
-					} else {
-						$user_count = $panel[$user]['U_USERS'];
-					}
-				?>
-				<div class="l-stat__col <?php if(in_array($TAB, ['USER', 'LOG'])) echo 'l-stat__col--active' ?>">
-					<a href="/list/user/"  title="<?=_('Users');?>: <?=$user_count;?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_USERS']?>">
-						<div class="l-stat__col-title"><?=_('USER');?>&nbsp;&nbsp;<i class="fas fa-users"></i></div>
-						<ul>
-							<li><?=_('users');?>: <span><?=htmlspecialchars($user_count);?></span></li>
-							<li><?=_('spnd');?>: <span><?=$panel[$user]['SUSPENDED_USERS']?></span></li>
-						</ul>
-					</a>
-				</div>
-			<?php } ?>
+  <div class="l-center">
+    <div class="l-stat">
+      <!-- Users tab -->
+      <?php if (($_SESSION['userContext'] == 'admin') && (empty($_SESSION['look']))) {?>
+        <?php
+          if (($_SESSION['user'] !== 'admin') && ($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes')) {
+            $user_count = $panel[$user]['U_USERS'] - 1;
+          } else {
+            $user_count = $panel[$user]['U_USERS'];
+          }
+        ?>
+        <div class="l-stat__col <?php if(in_array($TAB, ['USER', 'LOG'])) echo 'l-stat__col--active' ?>">
+          <a href="/list/user/"  title="<?=_('Users');?>: <?=$user_count;?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_USERS']?>">
+            <div class="l-stat__col-title"><?=_('USER');?>&nbsp;&nbsp;<i class="fas fa-users"></i></div>
+            <ul>
+              <li><?=_('users');?>: <span><?=htmlspecialchars($user_count);?></span></li>
+              <li><?=_('spnd');?>: <span><?=$panel[$user]['SUSPENDED_USERS']?></span></li>
+            </ul>
+          </a>
+        </div>
+      <?php } ?>
 
-			<!-- Web tab -->
-			<?php if ((isset($_SESSION['WEB_SYSTEM'])) && (!empty($_SESSION['WEB_SYSTEM']))) {?>
-				<?php if($panel[$user]['WEB_DOMAINS'] != "0") { ?>
-					<div class="l-stat__col <?php if($TAB == 'WEB') echo 'l-stat__col--active' ?>">
-						<a href="/list/web/" title="<?=_('Domains');?>: <?=$panel[$user]['U_WEB_DOMAINS']?>&#13;<?=_('Aliases');?>: <?=$panel[$user]['U_WEB_ALIASES']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['WEB_DOMAINS']=='unlimited' ? "∞" : $panel[$user]['WEB_DOMAINS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_WEB']?>">
-							<div class="l-stat__col-title"><?=_('WEB');?>&nbsp;&nbsp;<i class="fas fa-globe-americas"></i></div>
-							<ul>
-								<li><?=_('domains');?>: <span><?=$panel[$user]['U_WEB_DOMAINS']?> / <?=$panel[$user]['WEB_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['WEB_DOMAINS']?> (<?=$panel[$user]['SUSPENDED_WEB']?>)</span></li>
-								<li><?=_('aliases');?>: <span><?=$panel[$user]['U_WEB_ALIASES']?> / <?=$panel[$user]['WEB_ALIASES']=='unlimited' || $panel[$user]['WEB_DOMAINS']=='unlimited'  ? "<b>∞</b>" : $panel[$user]['WEB_ALIASES'] * $panel[$user]['WEB_DOMAINS']?></span></li>
-							</ul>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
+      <!-- Web tab -->
+      <?php if ((isset($_SESSION['WEB_SYSTEM'])) && (!empty($_SESSION['WEB_SYSTEM']))) {?>
+        <?php if($panel[$user]['WEB_DOMAINS'] != "0") { ?>
+          <div class="l-stat__col <?php if($TAB == 'WEB') echo 'l-stat__col--active' ?>">
+            <a href="/list/web/" title="<?=_('Domains');?>: <?=$panel[$user]['U_WEB_DOMAINS']?>&#13;<?=_('Aliases');?>: <?=$panel[$user]['U_WEB_ALIASES']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['WEB_DOMAINS']=='unlimited' ? "∞" : $panel[$user]['WEB_DOMAINS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_WEB']?>">
+              <div class="l-stat__col-title"><?=_('WEB');?>&nbsp;&nbsp;<i class="fas fa-globe-americas"></i></div>
+              <ul>
+                <li><?=_('domains');?>: <span><?=$panel[$user]['U_WEB_DOMAINS']?> / <?=$panel[$user]['WEB_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['WEB_DOMAINS']?> (<?=$panel[$user]['SUSPENDED_WEB']?>)</span></li>
+                <li><?=_('aliases');?>: <span><?=$panel[$user]['U_WEB_ALIASES']?> / <?=$panel[$user]['WEB_ALIASES']=='unlimited' || $panel[$user]['WEB_DOMAINS']=='unlimited'  ? "<b>∞</b>" : $panel[$user]['WEB_ALIASES'] * $panel[$user]['WEB_DOMAINS']?></span></li>
+              </ul>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- DNS tab -->
-			<?php if ((isset($_SESSION['DNS_SYSTEM'])) && (!empty($_SESSION['DNS_SYSTEM']))) {?>
-				<?php if($panel[$user]['DNS_DOMAINS'] != "0") { ?>
-					<div class="l-stat__col <?php if($TAB == 'DNS') echo 'l-stat__col--active' ?>">
-						<a href="/list/dns/" title="<?=_('Domains');?>: <?=$panel[$user]['U_DNS_DOMAINS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['DNS_DOMAINS']=='unlimited' ? "∞" : $panel[$user]['DNS_DOMAINS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_DNS']?>">
-							<div class="l-stat__col-title"><?=_('DNS');?>&nbsp;&nbsp;<i class="fas fa-atlas"></i></div>
-							<ul>
-								<li><?=_('zones');?>: <span><?=$panel[$user]['U_DNS_DOMAINS']?> / <?=$panel[$user]['DNS_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['DNS_DOMAINS']?> (<?=$panel[$user]['SUSPENDED_DNS']?>)</span></li>
-								<li><?=_('records');?>: <span><?=$panel[$user]['U_DNS_RECORDS']?> / <?=$panel[$user]['DNS_RECORDS']=='unlimited' || $panel[$user]['DNS_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['DNS_RECORDS'] * $panel[$user]['DNS_DOMAINS']?></span></li>
-							</ul>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
+      <!-- DNS tab -->
+      <?php if ((isset($_SESSION['DNS_SYSTEM'])) && (!empty($_SESSION['DNS_SYSTEM']))) {?>
+        <?php if($panel[$user]['DNS_DOMAINS'] != "0") { ?>
+          <div class="l-stat__col <?php if($TAB == 'DNS') echo 'l-stat__col--active' ?>">
+            <a href="/list/dns/" title="<?=_('Domains');?>: <?=$panel[$user]['U_DNS_DOMAINS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['DNS_DOMAINS']=='unlimited' ? "∞" : $panel[$user]['DNS_DOMAINS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_DNS']?>">
+              <div class="l-stat__col-title"><?=_('DNS');?>&nbsp;&nbsp;<i class="fas fa-atlas"></i></div>
+              <ul>
+                <li><?=_('zones');?>: <span><?=$panel[$user]['U_DNS_DOMAINS']?> / <?=$panel[$user]['DNS_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['DNS_DOMAINS']?> (<?=$panel[$user]['SUSPENDED_DNS']?>)</span></li>
+                <li><?=_('records');?>: <span><?=$panel[$user]['U_DNS_RECORDS']?> / <?=$panel[$user]['DNS_RECORDS']=='unlimited' || $panel[$user]['DNS_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['DNS_RECORDS'] * $panel[$user]['DNS_DOMAINS']?></span></li>
+              </ul>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Mail tab -->
-			<?php if ((isset($_SESSION['MAIL_SYSTEM'])) && (!empty($_SESSION['MAIL_SYSTEM']))) {?>
-				<?php if($panel[$user]['MAIL_DOMAINS'] != "0") { ?>
-					<div class="l-stat__col <?php if($TAB == 'MAIL') echo 'l-stat__col--active' ?>">
-						<a href="/list/mail/"  title="<?=_('Domains');?>: <?=$panel[$user]['U_MAIL_DOMAINS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['MAIL_DOMAINS']=='unlimited' ? "∞" : $panel[$user]['MAIL_DOMAINS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_MAIL']?>">
-							<div class="l-stat__col-title"><?=_('MAIL');?>&nbsp;&nbsp;<i class="fas fa-mail-bulk"></i></div>
-							<ul>
-								<li><?=_('domains');?>: <span><?=$panel[$user]['U_MAIL_DOMAINS']?> / <?=$panel[$user]['MAIL_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['MAIL_DOMAINS']?> (<?=$panel[$user]['SUSPENDED_MAIL']?>)</span></li>
-								<li><?=_('accounts');?>: <span><?=$panel[$user]['U_MAIL_ACCOUNTS']?> / <?=$panel[$user]['MAIL_ACCOUNTS']=='unlimited' || $panel[$user]['MAIL_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['MAIL_ACCOUNTS'] * $panel[$user]['MAIL_DOMAINS']?></span></li>
-							</ul>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
+      <!-- Mail tab -->
+      <?php if ((isset($_SESSION['MAIL_SYSTEM'])) && (!empty($_SESSION['MAIL_SYSTEM']))) {?>
+        <?php if($panel[$user]['MAIL_DOMAINS'] != "0") { ?>
+          <div class="l-stat__col <?php if($TAB == 'MAIL') echo 'l-stat__col--active' ?>">
+            <a href="/list/mail/"  title="<?=_('Domains');?>: <?=$panel[$user]['U_MAIL_DOMAINS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['MAIL_DOMAINS']=='unlimited' ? "∞" : $panel[$user]['MAIL_DOMAINS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_MAIL']?>">
+              <div class="l-stat__col-title"><?=_('MAIL');?>&nbsp;&nbsp;<i class="fas fa-mail-bulk"></i></div>
+              <ul>
+                <li><?=_('domains');?>: <span><?=$panel[$user]['U_MAIL_DOMAINS']?> / <?=$panel[$user]['MAIL_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['MAIL_DOMAINS']?> (<?=$panel[$user]['SUSPENDED_MAIL']?>)</span></li>
+                <li><?=_('accounts');?>: <span><?=$panel[$user]['U_MAIL_ACCOUNTS']?> / <?=$panel[$user]['MAIL_ACCOUNTS']=='unlimited' || $panel[$user]['MAIL_DOMAINS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['MAIL_ACCOUNTS'] * $panel[$user]['MAIL_DOMAINS']?></span></li>
+              </ul>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Databases tab -->
-			<?php if ((isset($_SESSION['DB_SYSTEM'])) && (!empty($_SESSION['DB_SYSTEM']))) {?>
-				<?php if($panel[$user]['DATABASES'] != "0") { ?>
-					<div class="l-stat__col <?php if($TAB == 'DB') echo 'l-stat__col--active' ?>">
-						<a href="/list/db/" title="<?=_('Databases');?>: <?=$panel[$user]['U_DATABASES']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['DATABASES']=='unlimited' ? "∞" : $panel[$user]['DATABASES']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_DB']?>">
-							<div class="l-stat__col-title"><?=_('DB');?>&nbsp;&nbsp;<i class="fas fa-database"></i></div>
-							<ul>
-								<li><?=_('databases');?>: <span><?=$panel[$user]['U_DATABASES']?> / <?=$panel[$user]['DATABASES']=='unlimited' ? "<b>∞</b>" : $panel[$user]['DATABASES']?> (<?=$panel[$user]['SUSPENDED_DB']?>)</span></li>
-							</ul>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
+      <!-- Databases tab -->
+      <?php if ((isset($_SESSION['DB_SYSTEM'])) && (!empty($_SESSION['DB_SYSTEM']))) {?>
+        <?php if($panel[$user]['DATABASES'] != "0") { ?>
+          <div class="l-stat__col <?php if($TAB == 'DB') echo 'l-stat__col--active' ?>">
+            <a href="/list/db/" title="<?=_('Databases');?>: <?=$panel[$user]['U_DATABASES']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['DATABASES']=='unlimited' ? "∞" : $panel[$user]['DATABASES']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_DB']?>">
+              <div class="l-stat__col-title"><?=_('DB');?>&nbsp;&nbsp;<i class="fas fa-database"></i></div>
+              <ul>
+                <li><?=_('databases');?>: <span><?=$panel[$user]['U_DATABASES']?> / <?=$panel[$user]['DATABASES']=='unlimited' ? "<b>∞</b>" : $panel[$user]['DATABASES']?> (<?=$panel[$user]['SUSPENDED_DB']?>)</span></li>
+              </ul>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Cron tab -->
-			<?php if ((isset($_SESSION['CRON_SYSTEM'])) && (!empty($_SESSION['CRON_SYSTEM']))) {?>
-				<?php if($panel[$user]['CRON_JOBS'] != "0") { ?>
-					<div class="l-stat__col <?php if($TAB == 'CRON') echo 'l-stat__col--active' ?>">
-						<a href="/list/cron/" title="<?=_('Jobs');?>: <?=$panel[$user]['U_WEB_DOMAINS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['CRON_JOBS']=='unlimited' ? "∞" : $panel[$user]['CRON_JOBS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_CRON']?>">
-							<div class="l-stat__col-title"><?=_('CRON');?>&nbsp;&nbsp;<i class="fas fa-clock"></i></div>
-							<ul>
-								<li><?=_('jobs');?>: <span><?=$panel[$user]['U_CRON_JOBS']?> / <?=$panel[$user]['CRON_JOBS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['CRON_JOBS']?> (<?=$panel[$user]['SUSPENDED_CRON']?>)</span></li>
-							</ul>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
+      <!-- Cron tab -->
+      <?php if ((isset($_SESSION['CRON_SYSTEM'])) && (!empty($_SESSION['CRON_SYSTEM']))) {?>
+        <?php if($panel[$user]['CRON_JOBS'] != "0") { ?>
+          <div class="l-stat__col <?php if($TAB == 'CRON') echo 'l-stat__col--active' ?>">
+            <a href="/list/cron/" title="<?=_('Jobs');?>: <?=$panel[$user]['U_WEB_DOMAINS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['CRON_JOBS']=='unlimited' ? "∞" : $panel[$user]['CRON_JOBS']?>&#13;<?=_('Suspended');?>: <?=$panel[$user]['SUSPENDED_CRON']?>">
+              <div class="l-stat__col-title"><?=_('CRON');?>&nbsp;&nbsp;<i class="fas fa-clock"></i></div>
+              <ul>
+                <li><?=_('jobs');?>: <span><?=$panel[$user]['U_CRON_JOBS']?> / <?=$panel[$user]['CRON_JOBS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['CRON_JOBS']?> (<?=$panel[$user]['SUSPENDED_CRON']?>)</span></li>
+              </ul>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
 
-			<!-- Backups tab -->
-			<?php if ((isset($_SESSION['BACKUP_SYSTEM'])) && (!empty($_SESSION['BACKUP_SYSTEM']))) {?>
-				<?php if($panel[$user]['BACKUPS'] != "0") { ?>
-					<div class="l-stat__col <?php if($TAB == 'BACKUP') echo 'l-stat__col--active' ?>">
-						<a href="/list/backup/" title="<?=_('Backups');?>: <?=$panel[$user]['U_BACKUPS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['BACKUPS']=='unlimited' ? "∞" : $panel[$user]['BACKUPS']?>">
-							<div class="l-stat__col-title"><?=_('BACKUP');?>&nbsp;&nbsp;<i class="fas fa-file-archive"></i></div>
-							<ul>
-								<li><?=_('backups');?>: <span><?=$panel[$user]['U_BACKUPS']?> / <?=$panel[$user]['BACKUPS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['BACKUPS']?></span></li>
-							</ul>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
-		</div>
-	</div>
+      <!-- Backups tab -->
+      <?php if ((isset($_SESSION['BACKUP_SYSTEM'])) && (!empty($_SESSION['BACKUP_SYSTEM']))) {?>
+        <?php if($panel[$user]['BACKUPS'] != "0") { ?>
+          <div class="l-stat__col <?php if($TAB == 'BACKUP') echo 'l-stat__col--active' ?>">
+            <a href="/list/backup/" title="<?=_('Backups');?>: <?=$panel[$user]['U_BACKUPS']?>&#13;<?=_('Limit')?>: <?=$panel[$user]['BACKUPS']=='unlimited' ? "∞" : $panel[$user]['BACKUPS']?>">
+              <div class="l-stat__col-title"><?=_('BACKUP');?>&nbsp;&nbsp;<i class="fas fa-file-archive"></i></div>
+              <ul>
+                <li><?=_('backups');?>: <span><?=$panel[$user]['U_BACKUPS']?> / <?=$panel[$user]['BACKUPS']=='unlimited' ? "<b>∞</b>" : $panel[$user]['BACKUPS']?></span></li>
+              </ul>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
+    </div>
+  </div>
 
-	<div class="l-separator"></div>
+  <div class="l-separator"></div>

--- a/web/templates/pages/add_cron.html
+++ b/web/templates/pages/add_cron.html
@@ -1,13 +1,13 @@
 <!-- Begin toolbar -->
 <div class="l-center edit">
-	<div class="l-sort clearfix">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/cron/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-			<a href="#" class="ui-button" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i><?=_('Save');?></a>
-		</div>
-	</div>
+  <div class="l-sort clearfix">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/cron/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+      <a href="#" class="ui-button" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i><?=_('Save');?></a>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -15,383 +15,383 @@
 
 <div class="l-center animated fadeIn">
 
-	<div class="helper-container">
-		<div id="tabs" class="cron-helper-tabs">
-			<ul>
-				<li><a href="#tabs-1"><?=_('Minutes');?></a></li>
-				<li><a href="#tabs-2"><?=_('Hourly');?></a></li>
-				<li><a href="#tabs-3"><?=_('Daily');?></a></li>
-				<li><a href="#tabs-4"><?=_('Weekly');?></a></li>
-				<li><a href="#tabs-5"><?=_('Monthly');?></a></li>
-			</ul>
-			<div id="tabs-1">
-				<form>
-					<input type="hidden" name="h_hour" value="*">
-					<input type="hidden" name="h_day" value="*">
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb20">
-						<label for="h_min_1" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_1">
-							<option value="*" selected="selected"><?=_('every minute');?></option>
-							<option value="*/2"><?=_('every two minutes');?></option>
-							<option value="*/5"><?=_('every');?> 5</option>
-							<option value="*/10"><?=_('every');?> 10</option>
-							<option value="*/15"><?=_('every');?> 15</option>
-							<option value="*/30"><?=_('every');?> 30</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+  <div class="helper-container">
+    <div id="tabs" class="cron-helper-tabs">
+      <ul>
+        <li><a href="#tabs-1"><?=_('Minutes');?></a></li>
+        <li><a href="#tabs-2"><?=_('Hourly');?></a></li>
+        <li><a href="#tabs-3"><?=_('Daily');?></a></li>
+        <li><a href="#tabs-4"><?=_('Weekly');?></a></li>
+        <li><a href="#tabs-5"><?=_('Monthly');?></a></li>
+      </ul>
+      <div id="tabs-1">
+        <form>
+          <input type="hidden" name="h_hour" value="*">
+          <input type="hidden" name="h_day" value="*">
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb20">
+            <label for="h_min_1" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_1">
+              <option value="*" selected="selected"><?=_('every minute');?></option>
+              <option value="*/2"><?=_('every two minutes');?></option>
+              <option value="*/5"><?=_('every');?> 5</option>
+              <option value="*/10"><?=_('every');?> 10</option>
+              <option value="*/15"><?=_('every');?> 15</option>
+              <option value="*/30"><?=_('every');?> 30</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-2">
-				<form>
-					<input type="hidden" name="h_day" value="*">
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_hour_2" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_2">
-							<option value="*" selected="selected"><?=_('every hour');?></option>
-							<option value="*/2"><?=_('every two hours');?></option>
-							<option value="*/6"><?=_('every');?> 6</option>
-							<option value="*/12"><?=_('every');?> 12</option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_min_2" class="form-label first"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_2" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="15">15</option>
-							<option value="30">30</option>
-							<option value="45">45</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+      <div id="tabs-2">
+        <form>
+          <input type="hidden" name="h_day" value="*">
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_hour_2" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_2">
+              <option value="*" selected="selected"><?=_('every hour');?></option>
+              <option value="*/2"><?=_('every two hours');?></option>
+              <option value="*/6"><?=_('every');?> 6</option>
+              <option value="*/12"><?=_('every');?> 12</option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_min_2" class="form-label first"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_2" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="15">15</option>
+              <option value="30">30</option>
+              <option value="45">45</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-3">
-				<form>
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_day_3" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_day" id="h_day_3">
-							<option value="*" selected="selected"><?=_('every day');?></option>
-							<option value="1-31/2"><?=_('every odd day');?></option>
-							<option value="*/2"><?=_('every even day');?></option>
-							<option value="*/3"><?=_('every');?> 3</option>
-							<option value="*/5"><?=_('every');?> 5</option>
-							<option value="*/10"><?=_('every');?> 10</option>
-							<option value="*/15"><?=_('every');?> 15</option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_hour_3" class="form-label first"><?=_('Hour');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_3" style="width:70px;">
-							<option value="0">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="3">03</option>
-							<option value="4">04</option>
-							<option value="5">05</option>
-							<option value="6">06</option>
-							<option value="7">07</option>
-							<option value="8">08</option>
-							<option value="9">09</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12" selected="selected">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-						</select>
-						<label for="h_min_3" class="form-label"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_3" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="5">05</option>
-							<option value="10">10</option>
-							<option value="15">15</option>
-							<option value="20">20</option>
-							<option value="25">25</option>
-							<option value="30">30</option>
-							<option value="35">35</option>
-							<option value="40">40</option>
-							<option value="45">45</option>
-							<option value="50">50</option>
-							<option value="55">55</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+      <div id="tabs-3">
+        <form>
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_day_3" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_day" id="h_day_3">
+              <option value="*" selected="selected"><?=_('every day');?></option>
+              <option value="1-31/2"><?=_('every odd day');?></option>
+              <option value="*/2"><?=_('every even day');?></option>
+              <option value="*/3"><?=_('every');?> 3</option>
+              <option value="*/5"><?=_('every');?> 5</option>
+              <option value="*/10"><?=_('every');?> 10</option>
+              <option value="*/15"><?=_('every');?> 15</option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_hour_3" class="form-label first"><?=_('Hour');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_3" style="width:70px;">
+              <option value="0">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="3">03</option>
+              <option value="4">04</option>
+              <option value="5">05</option>
+              <option value="6">06</option>
+              <option value="7">07</option>
+              <option value="8">08</option>
+              <option value="9">09</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12" selected="selected">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+            </select>
+            <label for="h_min_3" class="form-label"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_3" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="5">05</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+              <option value="25">25</option>
+              <option value="30">30</option>
+              <option value="35">35</option>
+              <option value="40">40</option>
+              <option value="45">45</option>
+              <option value="50">50</option>
+              <option value="55">55</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-4">
-				<form>
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_day" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_wday_4" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_wday" id="h_wday_4">
-							<option value="*" selected="selected"><?=_('every day');?></option>
-							<option value="1,2,3,4,5"><?=_('weekdays (5 days)');?></option>
-							<option value="0,6"><?=_('weekend (2 days)');?></option>
-							<option value="1"><?=_('Monday');?></option>
-							<option value="2"><?=_('Tuesday');?></option>
-							<option value="3"><?=_('Wednesday');?></option>
-							<option value="4"><?=_('Thursday');?></option>
-							<option value="5"><?=_('Friday');?></option>
-							<option value="6"><?=_('Saturday');?></option>
-							<option value="0"><?=_('Sunday');?></option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_hour_4" class="form-label first"><?=_('Hour');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_4" style="width:70px;">
-							<option value="0">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="3">03</option>
-							<option value="4">04</option>
-							<option value="5">05</option>
-							<option value="6">06</option>
-							<option value="7">07</option>
-							<option value="8">08</option>
-							<option value="9">09</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12" selected="selected">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-						</select>
-						<label for="h_min_4" class="form-label"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_4" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="5">05</option>
-							<option value="10">10</option>
-							<option value="15">15</option>
-							<option value="20">20</option>
-							<option value="25">25</option>
-							<option value="30">30</option>
-							<option value="35">35</option>
-							<option value="40">40</option>
-							<option value="45">45</option>
-							<option value="50">50</option>
-							<option value="55">55</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+      <div id="tabs-4">
+        <form>
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_day" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_wday_4" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_wday" id="h_wday_4">
+              <option value="*" selected="selected"><?=_('every day');?></option>
+              <option value="1,2,3,4,5"><?=_('weekdays (5 days)');?></option>
+              <option value="0,6"><?=_('weekend (2 days)');?></option>
+              <option value="1"><?=_('Monday');?></option>
+              <option value="2"><?=_('Tuesday');?></option>
+              <option value="3"><?=_('Wednesday');?></option>
+              <option value="4"><?=_('Thursday');?></option>
+              <option value="5"><?=_('Friday');?></option>
+              <option value="6"><?=_('Saturday');?></option>
+              <option value="0"><?=_('Sunday');?></option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_hour_4" class="form-label first"><?=_('Hour');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_4" style="width:70px;">
+              <option value="0">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="3">03</option>
+              <option value="4">04</option>
+              <option value="5">05</option>
+              <option value="6">06</option>
+              <option value="7">07</option>
+              <option value="8">08</option>
+              <option value="9">09</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12" selected="selected">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+            </select>
+            <label for="h_min_4" class="form-label"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_4" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="5">05</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+              <option value="25">25</option>
+              <option value="30">30</option>
+              <option value="35">35</option>
+              <option value="40">40</option>
+              <option value="45">45</option>
+              <option value="50">50</option>
+              <option value="55">55</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-5">
-				<form>
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_month_5" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_month" id="h_month_5">
-							<option value="*" selected="selected"><?=_('every month');?></option>
-							<option value="1-11/2"><?=_('every odd month');?></option>
-							<option value="*/2"><?=_('every even month');?></option>
-							<option value="*/3"><?=_('every');?> 3</option>
-							<option value="*/6"><?=_('every');?> 6</option>
-							<option value="1"><?=_('Jan');?></option>
-							<option value="2"><?=_('Feb');?></option>
-							<option value="3"><?=_('Mar');?></option>
-							<option value="4"><?=_('Apr');?></option>
-							<option value="5"><?=_('May');?></option>
-							<option value="6"><?=_('Jun');?></option>
-							<option value="7"><?=_('Jul');?></option>
-							<option value="8"><?=_('Aug');?></option>
-							<option value="9"><?=_('Sep');?></option>
-							<option value="10"><?=_('Oct');?></option>
-							<option value="11"><?=_('Nov');?></option>
-							<option value="12"><?=_('Dec');?></option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_day_5" class="form-label first"><?=_('Date');?>:</label>
-						<select class="form-select" name="h_day" id="h_day_5" style="width:70px;">
-							<option value="1" selected="selected">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4">4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-							<option value="24">24</option>
-							<option value="25">25</option>
-							<option value="26">26</option>
-							<option value="27">27</option>
-							<option value="28">28</option>
-							<option value="29">29</option>
-							<option value="30">30</option>
-							<option value="31">31</option>
-						</select>
-						<label for="h_hour_5" class="form-label"><?=_('Hour');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_5" style="width:70px;">
-							<option value="0">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="3">03</option>
-							<option value="4">04</option>
-							<option value="5">05</option>
-							<option value="6">06</option>
-							<option value="7">07</option>
-							<option value="8">08</option>
-							<option value="9">09</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12" selected="selected">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-						</select>
-						<label for="h_min_5" class="form-label"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_5" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="5">05</option>
-							<option value="10">10</option>
-							<option value="15">15</option>
-							<option value="20">20</option>
-							<option value="25">25</option>
-							<option value="30">30</option>
-							<option value="35">35</option>
-							<option value="40">40</option>
-							<option value="45">45</option>
-							<option value="50">50</option>
-							<option value="55">55</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
-		</div>
-	</div>
+      <div id="tabs-5">
+        <form>
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_month_5" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_month" id="h_month_5">
+              <option value="*" selected="selected"><?=_('every month');?></option>
+              <option value="1-11/2"><?=_('every odd month');?></option>
+              <option value="*/2"><?=_('every even month');?></option>
+              <option value="*/3"><?=_('every');?> 3</option>
+              <option value="*/6"><?=_('every');?> 6</option>
+              <option value="1"><?=_('Jan');?></option>
+              <option value="2"><?=_('Feb');?></option>
+              <option value="3"><?=_('Mar');?></option>
+              <option value="4"><?=_('Apr');?></option>
+              <option value="5"><?=_('May');?></option>
+              <option value="6"><?=_('Jun');?></option>
+              <option value="7"><?=_('Jul');?></option>
+              <option value="8"><?=_('Aug');?></option>
+              <option value="9"><?=_('Sep');?></option>
+              <option value="10"><?=_('Oct');?></option>
+              <option value="11"><?=_('Nov');?></option>
+              <option value="12"><?=_('Dec');?></option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_day_5" class="form-label first"><?=_('Date');?>:</label>
+            <select class="form-select" name="h_day" id="h_day_5" style="width:70px;">
+              <option value="1" selected="selected">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+              <option value="6">6</option>
+              <option value="7">7</option>
+              <option value="8">8</option>
+              <option value="9">9</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+              <option value="24">24</option>
+              <option value="25">25</option>
+              <option value="26">26</option>
+              <option value="27">27</option>
+              <option value="28">28</option>
+              <option value="29">29</option>
+              <option value="30">30</option>
+              <option value="31">31</option>
+            </select>
+            <label for="h_hour_5" class="form-label"><?=_('Hour');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_5" style="width:70px;">
+              <option value="0">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="3">03</option>
+              <option value="4">04</option>
+              <option value="5">05</option>
+              <option value="6">06</option>
+              <option value="7">07</option>
+              <option value="8">08</option>
+              <option value="9">09</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12" selected="selected">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+            </select>
+            <label for="h_min_5" class="form-label"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_5" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="5">05</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+              <option value="25">25</option>
+              <option value="30">30</option>
+              <option value="35">35</option>
+              <option value="40">40</option>
+              <option value="45">45</option>
+              <option value="50">50</option>
+              <option value="55">55</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 
-	<form id="vstobjects" name="v_add_cron" method="post">
-		<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-		<input type="hidden" name="ok" value="Add">
-		<table class="data">
-			<tr class="data-add">
-				<td class="data-dotted">
-					<table class="data-col1">
-						<tr>
-							<td></td>
-						</tr>
-					</table>
-				</td>
-				<td class="data-dotted">
-					<table class="data-col2" width="850px">
-						<tr>
-							<td class="u-pt18">
-								<span class="page-title"><?=_('Adding Cron Job');?></span>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<?php show_alert_message($_SESSION);?>
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_cmd" class="form-label"><?=_('Command');?></label>
-								<input type="text" class="form-control" name="v_cmd" id="v_cmd" value="<?=htmlentities(trim($v_cmd, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt18">
-								<label for="v_min" class="form-label"><?=_('Minute');?></label>
-								<input type="text" class="form-control" name="v_min" id="v_min" style="width:220px;" value="<?=htmlentities(trim($v_min, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_hour" class="form-label"><?=_('Hour');?></label>
-								<input type="text" class="form-control" name="v_hour" id="v_hour" style="width:220px;" value="<?=htmlentities(trim($v_hour, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_day" class="form-label"><?=_('Day');?></label>
-								<input type="text" class="form-control" name="v_day" id="v_day" style="width:220px;" value="<?=htmlentities(trim($v_day, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_month" class="form-label"><?=_('Month');?></label>
-								<input type="text" class="form-control" name="v_month" id="v_month" style="width:220px;" value="<?=htmlentities(trim($v_month, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_wday" class="form-label"><?=_('Day of week');?></label>
-								<input type="text" class="form-control" name="v_wday" id="v_wday" style="width:220px;" value="<?=htmlentities(trim($v_wday, "'"))?>">
-							</td>
-						</tr>
-					</table>
-					<table class="data-col2"></table>
-				</td>
-			</tr>
-		</table>
-	</form>
+  <form id="vstobjects" name="v_add_cron" method="post">
+    <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+    <input type="hidden" name="ok" value="Add">
+    <table class="data">
+      <tr class="data-add">
+        <td class="data-dotted">
+          <table class="data-col1">
+            <tr>
+              <td></td>
+            </tr>
+          </table>
+        </td>
+        <td class="data-dotted">
+          <table class="data-col2" width="850px">
+            <tr>
+              <td class="u-pt18">
+                <span class="page-title"><?=_('Adding Cron Job');?></span>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <?php show_alert_message($_SESSION);?>
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_cmd" class="form-label"><?=_('Command');?></label>
+                <input type="text" class="form-control" name="v_cmd" id="v_cmd" value="<?=htmlentities(trim($v_cmd, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt18">
+                <label for="v_min" class="form-label"><?=_('Minute');?></label>
+                <input type="text" class="form-control" name="v_min" id="v_min" style="width:220px;" value="<?=htmlentities(trim($v_min, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_hour" class="form-label"><?=_('Hour');?></label>
+                <input type="text" class="form-control" name="v_hour" id="v_hour" style="width:220px;" value="<?=htmlentities(trim($v_hour, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_day" class="form-label"><?=_('Day');?></label>
+                <input type="text" class="form-control" name="v_day" id="v_day" style="width:220px;" value="<?=htmlentities(trim($v_day, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_month" class="form-label"><?=_('Month');?></label>
+                <input type="text" class="form-control" name="v_month" id="v_month" style="width:220px;" value="<?=htmlentities(trim($v_month, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_wday" class="form-label"><?=_('Day of week');?></label>
+                <input type="text" class="form-control" name="v_wday" id="v_wday" style="width:220px;" value="<?=htmlentities(trim($v_wday, "'"))?>">
+              </td>
+            </tr>
+          </table>
+          <table class="data-col2"></table>
+        </td>
+      </tr>
+    </table>
+  </form>
 </div>

--- a/web/templates/pages/add_firewall_ipset.html
+++ b/web/templates/pages/add_firewall_ipset.html
@@ -64,14 +64,14 @@
     <?php
       $country = array('ca' => 'Canada', 'cn' => 'China', 'fr' => 'French', 'de' => 'Germany', 'in' => 'India', 'nl' => 'Netherlands', 'ro' => 'Romania', 'ru' => 'Russia', 'es' => 'Spain', 'ch' => 'Switzerland', 'tr' => 'Turkey', 'ua' => 'Ukraine',  'gb' => 'United Kingdom', 'us' => 'United States');
       foreach($country as $iso =>$name){
-        echo '{name: "[IPv4] Country - '.$name.'",	source:"https://raw.githubusercontent.com/ipverse/rir-ip/master/country/'.$iso.'/ipv4-aggregated.txt"},'."\n";
+        echo '{name: "[IPv4] Country - '.$name.'",  source:"https://raw.githubusercontent.com/ipverse/rir-ip/master/country/'.$iso.'/ipv4-aggregated.txt"},'."\n";
       }
     ?>
     // Define IPv6 country lists
     /*
     <?php
       foreach($country as $iso =>$name){
-        echo '{name: "[IPv6] Country - '.$name.'",	source:"https://raw.githubusercontent.com/ipverse/rir-ip/master/country/'.$iso.'/ipv6-aggregated.txt"},'."\n";
+        echo '{name: "[IPv6] Country - '.$name.'",  source:"https://raw.githubusercontent.com/ipverse/rir-ip/master/country/'.$iso.'/ipv6-aggregated.txt"},'."\n";
       }
     ?>
     */

--- a/web/templates/pages/debug_panel.html
+++ b/web/templates/pages/debug_panel.html
@@ -1,23 +1,23 @@
 <div class="debug-panel-header"><?=_('Debug mode is enabled.');?> <a href="javascript:elementHideShow('debug-panel')"><?=_('Show / Hide Panel');?></a></div>
 <div class="debug-panel-contents animated fadeIn" id="debug-panel" style="display:none;">
-	<?php
-		echo "<h3>Server Variables</h3>";
-		foreach ($_SERVER as $key=>$val)
-		echo "<b>".$key."= </b> ".$val."  ";
-	?>
-	<?php
-		echo "<h3>Session Variables</h3>";
-		foreach ($_SESSION as $key=>$val)
-		echo "<b>".$key."= </b> ".$val."  ";
-	?>
-	<?php
-		echo "<h3>POST Variables</h3>";
-		foreach ($_POST as $key=>$val)
-		echo "<b>".$key."= </b> ".$val."  ";  
-	?>
-	<?php
-		echo "<h3>GET Variables</h3>";
-		foreach ($_GET as $key=>$val)
-		echo "<b>".$key."= </b> ".$val."  ";
-	?>
+  <?php
+    echo "<h3>Server Variables</h3>";
+    foreach ($_SERVER as $key=>$val)
+    echo "<b>".$key."= </b> ".$val."  ";
+  ?>
+  <?php
+    echo "<h3>Session Variables</h3>";
+    foreach ($_SESSION as $key=>$val)
+    echo "<b>".$key."= </b> ".$val."  ";
+  ?>
+  <?php
+    echo "<h3>POST Variables</h3>";
+    foreach ($_POST as $key=>$val)
+    echo "<b>".$key."= </b> ".$val."  ";  
+  ?>
+  <?php
+    echo "<h3>GET Variables</h3>";
+    foreach ($_GET as $key=>$val)
+    echo "<b>".$key."= </b> ".$val."  ";
+  ?>
 </div>

--- a/web/templates/pages/edit_cron.html
+++ b/web/templates/pages/edit_cron.html
@@ -1,13 +1,13 @@
 <!-- Begin toolbar -->
 <div class="l-center edit">
-	<div class="l-sort clearfix">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/cron/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-			<a href="#" class="ui-button" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i><?=_('Save');?></a>
-		</div>
-	</div>
+  <div class="l-sort clearfix">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/cron/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+      <a href="#" class="ui-button" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i><?=_('Save');?></a>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -15,383 +15,383 @@
 
 <div class="l-center animated fadeIn">
 
-	<div class="helper-container">
-		<div id="tabs" class="cron-helper-tabs">
-			<ul>
-				<li><a href="#tabs-1"><?=_('Minutes');?></a></li>
-				<li><a href="#tabs-2"><?=_('Hourly');?></a></li>
-				<li><a href="#tabs-3"><?=_('Daily');?></a></li>
-				<li><a href="#tabs-4"><?=_('Weekly');?></a></li>
-				<li><a href="#tabs-5"><?=_('Monthly');?></a></li>
-			</ul>
-			<div id="tabs-1">
-				<form>
-					<input type="hidden" name="h_hour" value="*">
-					<input type="hidden" name="h_day" value="*">
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb20">
-						<label for="h_min_1" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_1">
-							<option value="*" selected="selected"><?=_('every minute');?></option>
-							<option value="*/2"><?=_('every two minutes');?></option>
-							<option value="*/5"><?=_('every');?> 5</option>
-							<option value="*/10"><?=_('every');?> 10</option>
-							<option value="*/15"><?=_('every');?> 15</option>
-							<option value="*/30"><?=_('every');?> 30</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+  <div class="helper-container">
+    <div id="tabs" class="cron-helper-tabs">
+      <ul>
+        <li><a href="#tabs-1"><?=_('Minutes');?></a></li>
+        <li><a href="#tabs-2"><?=_('Hourly');?></a></li>
+        <li><a href="#tabs-3"><?=_('Daily');?></a></li>
+        <li><a href="#tabs-4"><?=_('Weekly');?></a></li>
+        <li><a href="#tabs-5"><?=_('Monthly');?></a></li>
+      </ul>
+      <div id="tabs-1">
+        <form>
+          <input type="hidden" name="h_hour" value="*">
+          <input type="hidden" name="h_day" value="*">
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb20">
+            <label for="h_min_1" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_1">
+              <option value="*" selected="selected"><?=_('every minute');?></option>
+              <option value="*/2"><?=_('every two minutes');?></option>
+              <option value="*/5"><?=_('every');?> 5</option>
+              <option value="*/10"><?=_('every');?> 10</option>
+              <option value="*/15"><?=_('every');?> 15</option>
+              <option value="*/30"><?=_('every');?> 30</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-2">
-				<form>
-					<input type="hidden" name="h_day" value="*">
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_hour_2" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_2">
-							<option value="*" selected="selected"><?=_('every hour');?></option>
-							<option value="*/2"><?=_('every two hours');?></option>
-							<option value="*/6"><?=_('every');?> 6</option>
-							<option value="*/12"><?=_('every');?> 12</option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_min_2" class="form-label first"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_2" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="15">15</option>
-							<option value="30">30</option>
-							<option value="45">45</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+      <div id="tabs-2">
+        <form>
+          <input type="hidden" name="h_day" value="*">
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_hour_2" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_2">
+              <option value="*" selected="selected"><?=_('every hour');?></option>
+              <option value="*/2"><?=_('every two hours');?></option>
+              <option value="*/6"><?=_('every');?> 6</option>
+              <option value="*/12"><?=_('every');?> 12</option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_min_2" class="form-label first"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_2" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="15">15</option>
+              <option value="30">30</option>
+              <option value="45">45</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-3">
-				<form>
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_day_3" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_day" id="h_day_3">
-							<option value="*" selected="selected"><?=_('every day');?></option>
-							<option value="1-31/2"><?=_('every odd day');?></option>
-							<option value="*/2"><?=_('every even day');?></option>
-							<option value="*/3"><?=_('every');?> 3</option>
-							<option value="*/5"><?=_('every');?> 5</option>
-							<option value="*/10"><?=_('every');?> 10</option>
-							<option value="*/15"><?=_('every');?> 15</option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_hour_3" class="form-label first"><?=_('Hour');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_3" style="width:70px;">
-							<option value="0">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="3">03</option>
-							<option value="4">04</option>
-							<option value="5">05</option>
-							<option value="6">06</option>
-							<option value="7">07</option>
-							<option value="8">08</option>
-							<option value="9">09</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12" selected="selected">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-						</select>
-						<label for="h_min_3" class="form-label"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_3" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="5">05</option>
-							<option value="10">10</option>
-							<option value="15">15</option>
-							<option value="20">20</option>
-							<option value="25">25</option>
-							<option value="30">30</option>
-							<option value="35">35</option>
-							<option value="40">40</option>
-							<option value="45">45</option>
-							<option value="50">50</option>
-							<option value="55">55</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+      <div id="tabs-3">
+        <form>
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_day_3" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_day" id="h_day_3">
+              <option value="*" selected="selected"><?=_('every day');?></option>
+              <option value="1-31/2"><?=_('every odd day');?></option>
+              <option value="*/2"><?=_('every even day');?></option>
+              <option value="*/3"><?=_('every');?> 3</option>
+              <option value="*/5"><?=_('every');?> 5</option>
+              <option value="*/10"><?=_('every');?> 10</option>
+              <option value="*/15"><?=_('every');?> 15</option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_hour_3" class="form-label first"><?=_('Hour');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_3" style="width:70px;">
+              <option value="0">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="3">03</option>
+              <option value="4">04</option>
+              <option value="5">05</option>
+              <option value="6">06</option>
+              <option value="7">07</option>
+              <option value="8">08</option>
+              <option value="9">09</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12" selected="selected">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+            </select>
+            <label for="h_min_3" class="form-label"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_3" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="5">05</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+              <option value="25">25</option>
+              <option value="30">30</option>
+              <option value="35">35</option>
+              <option value="40">40</option>
+              <option value="45">45</option>
+              <option value="50">50</option>
+              <option value="55">55</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-4">
-				<form>
-					<input type="hidden" name="h_month" value="*">
-					<input type="hidden" name="h_day" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_wday_4" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_wday" id="h_wday_4">
-							<option value="*" selected="selected"><?=_('every day');?></option>
-							<option value="1,2,3,4,5"><?=_('weekdays (5 days)');?></option>
-							<option value="0,6"><?=_('weekend (2 days)');?></option>
-							<option value="1"><?=_('Monday');?></option>
-							<option value="2"><?=_('Tuesday');?></option>
-							<option value="3"><?=_('Wednesday');?></option>
-							<option value="4"><?=_('Thursday');?></option>
-							<option value="5"><?=_('Friday');?></option>
-							<option value="6"><?=_('Saturday');?></option>
-							<option value="0"><?=_('Sunday');?></option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_hour_4" class="form-label first"><?=_('Hour');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_4" style="width:70px;">
-							<option value="0">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="3">03</option>
-							<option value="4">04</option>
-							<option value="5">05</option>
-							<option value="6">06</option>
-							<option value="7">07</option>
-							<option value="8">08</option>
-							<option value="9">09</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12" selected="selected">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-						</select>
-						<label for="h_min_4" class="form-label"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_4" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="5">05</option>
-							<option value="10">10</option>
-							<option value="15">15</option>
-							<option value="20">20</option>
-							<option value="25">25</option>
-							<option value="30">30</option>
-							<option value="35">35</option>
-							<option value="40">40</option>
-							<option value="45">45</option>
-							<option value="50">50</option>
-							<option value="55">55</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
+      <div id="tabs-4">
+        <form>
+          <input type="hidden" name="h_month" value="*">
+          <input type="hidden" name="h_day" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_wday_4" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_wday" id="h_wday_4">
+              <option value="*" selected="selected"><?=_('every day');?></option>
+              <option value="1,2,3,4,5"><?=_('weekdays (5 days)');?></option>
+              <option value="0,6"><?=_('weekend (2 days)');?></option>
+              <option value="1"><?=_('Monday');?></option>
+              <option value="2"><?=_('Tuesday');?></option>
+              <option value="3"><?=_('Wednesday');?></option>
+              <option value="4"><?=_('Thursday');?></option>
+              <option value="5"><?=_('Friday');?></option>
+              <option value="6"><?=_('Saturday');?></option>
+              <option value="0"><?=_('Sunday');?></option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_hour_4" class="form-label first"><?=_('Hour');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_4" style="width:70px;">
+              <option value="0">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="3">03</option>
+              <option value="4">04</option>
+              <option value="5">05</option>
+              <option value="6">06</option>
+              <option value="7">07</option>
+              <option value="8">08</option>
+              <option value="9">09</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12" selected="selected">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+            </select>
+            <label for="h_min_4" class="form-label"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_4" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="5">05</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+              <option value="25">25</option>
+              <option value="30">30</option>
+              <option value="35">35</option>
+              <option value="40">40</option>
+              <option value="45">45</option>
+              <option value="50">50</option>
+              <option value="55">55</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
 
-			<div id="tabs-5">
-				<form>
-					<input type="hidden" name="h_wday" value="*">
-					<div class="u-mt15 u-mb10">
-						<label for="h_month_5" class="form-label first"><?=_('Run Command');?>:</label>
-						<select class="form-select" name="h_month" id="h_month_5">
-							<option value="*" selected="selected"><?=_('every month');?></option>
-							<option value="1-11/2"><?=_('every odd month');?></option>
-							<option value="*/2"><?=_('every even month');?></option>
-							<option value="*/3"><?=_('every');?> 3</option>
-							<option value="*/6"><?=_('every');?> 6</option>
-							<option value="1"><?=_('Jan');?></option>
-							<option value="2"><?=_('Feb');?></option>
-							<option value="3"><?=_('Mar');?></option>
-							<option value="4"><?=_('Apr');?></option>
-							<option value="5"><?=_('May');?></option>
-							<option value="6"><?=_('Jun');?></option>
-							<option value="7"><?=_('Jul');?></option>
-							<option value="8"><?=_('Aug');?></option>
-							<option value="9"><?=_('Sep');?></option>
-							<option value="10"><?=_('Oct');?></option>
-							<option value="11"><?=_('Nov');?></option>
-							<option value="12"><?=_('Dec');?></option>
-						</select>
-					</div>
-					<div class="u-mb20">
-						<label for="h_day_5" class="form-label first"><?=_('Date');?>:</label>
-						<select class="form-select" name="h_day" id="h_day_5" style="width:70px;">
-							<option value="1" selected="selected">1</option>
-							<option value="2">2</option>
-							<option value="3">3</option>
-							<option value="4">4</option>
-							<option value="5">5</option>
-							<option value="6">6</option>
-							<option value="7">7</option>
-							<option value="8">8</option>
-							<option value="9">9</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-							<option value="24">24</option>
-							<option value="25">25</option>
-							<option value="26">26</option>
-							<option value="27">27</option>
-							<option value="28">28</option>
-							<option value="29">29</option>
-							<option value="30">30</option>
-							<option value="31">31</option>
-						</select>
-						<label for="h_hour_5" class="form-label"><?=_('Hour');?>:</label>
-						<select class="form-select" name="h_hour" id="h_hour_5" style="width:70px;">
-							<option value="0">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="3">03</option>
-							<option value="4">04</option>
-							<option value="5">05</option>
-							<option value="6">06</option>
-							<option value="7">07</option>
-							<option value="8">08</option>
-							<option value="9">09</option>
-							<option value="10">10</option>
-							<option value="11">11</option>
-							<option value="12" selected="selected">12</option>
-							<option value="13">13</option>
-							<option value="14">14</option>
-							<option value="15">15</option>
-							<option value="16">16</option>
-							<option value="17">17</option>
-							<option value="18">18</option>
-							<option value="19">19</option>
-							<option value="20">20</option>
-							<option value="21">21</option>
-							<option value="22">22</option>
-							<option value="23">23</option>
-						</select>
-						<label for="h_min_5" class="form-label"><?=_('Minute');?>:</label>
-						<select class="form-select" name="h_min" id="h_min_5" style="width:70px;">
-							<option value="0" selected="selected">00</option>
-							<option value="1">01</option>
-							<option value="2">02</option>
-							<option value="5">05</option>
-							<option value="10">10</option>
-							<option value="15">15</option>
-							<option value="20">20</option>
-							<option value="25">25</option>
-							<option value="30">30</option>
-							<option value="35">35</option>
-							<option value="40">40</option>
-							<option value="45">45</option>
-							<option value="50">50</option>
-							<option value="55">55</option>
-						</select>
-					</div>
-					<div class="u-pt10">
-						<input type="submit" value="<?=_('generate');?>" class="button">
-					</div>
-				</form>
-			</div>
-		</div>
-	</div>
+      <div id="tabs-5">
+        <form>
+          <input type="hidden" name="h_wday" value="*">
+          <div class="u-mt15 u-mb10">
+            <label for="h_month_5" class="form-label first"><?=_('Run Command');?>:</label>
+            <select class="form-select" name="h_month" id="h_month_5">
+              <option value="*" selected="selected"><?=_('every month');?></option>
+              <option value="1-11/2"><?=_('every odd month');?></option>
+              <option value="*/2"><?=_('every even month');?></option>
+              <option value="*/3"><?=_('every');?> 3</option>
+              <option value="*/6"><?=_('every');?> 6</option>
+              <option value="1"><?=_('Jan');?></option>
+              <option value="2"><?=_('Feb');?></option>
+              <option value="3"><?=_('Mar');?></option>
+              <option value="4"><?=_('Apr');?></option>
+              <option value="5"><?=_('May');?></option>
+              <option value="6"><?=_('Jun');?></option>
+              <option value="7"><?=_('Jul');?></option>
+              <option value="8"><?=_('Aug');?></option>
+              <option value="9"><?=_('Sep');?></option>
+              <option value="10"><?=_('Oct');?></option>
+              <option value="11"><?=_('Nov');?></option>
+              <option value="12"><?=_('Dec');?></option>
+            </select>
+          </div>
+          <div class="u-mb20">
+            <label for="h_day_5" class="form-label first"><?=_('Date');?>:</label>
+            <select class="form-select" name="h_day" id="h_day_5" style="width:70px;">
+              <option value="1" selected="selected">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+              <option value="6">6</option>
+              <option value="7">7</option>
+              <option value="8">8</option>
+              <option value="9">9</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+              <option value="24">24</option>
+              <option value="25">25</option>
+              <option value="26">26</option>
+              <option value="27">27</option>
+              <option value="28">28</option>
+              <option value="29">29</option>
+              <option value="30">30</option>
+              <option value="31">31</option>
+            </select>
+            <label for="h_hour_5" class="form-label"><?=_('Hour');?>:</label>
+            <select class="form-select" name="h_hour" id="h_hour_5" style="width:70px;">
+              <option value="0">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="3">03</option>
+              <option value="4">04</option>
+              <option value="5">05</option>
+              <option value="6">06</option>
+              <option value="7">07</option>
+              <option value="8">08</option>
+              <option value="9">09</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12" selected="selected">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+            </select>
+            <label for="h_min_5" class="form-label"><?=_('Minute');?>:</label>
+            <select class="form-select" name="h_min" id="h_min_5" style="width:70px;">
+              <option value="0" selected="selected">00</option>
+              <option value="1">01</option>
+              <option value="2">02</option>
+              <option value="5">05</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+              <option value="25">25</option>
+              <option value="30">30</option>
+              <option value="35">35</option>
+              <option value="40">40</option>
+              <option value="45">45</option>
+              <option value="50">50</option>
+              <option value="55">55</option>
+            </select>
+          </div>
+          <div class="u-pt10">
+            <input type="submit" value="<?=_('generate');?>" class="button">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 
-	<form id="vstobjects" name="v_edit_cron" method="post" class="<?=$v_status?>">
-		<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-		<input type="hidden" name="save" value="save">
-		<table class="data">
-			<tr class="data-add">
-				<td class="data-dotted">
-					<table class="data-col1">
-						<tr>
-							<td></td>
-						</tr>
-					</table>
-				</td>
-				<td class="data-dotted">
-					<table class="data-col2" width="850px">
-						<tr>
-							<td class="u-pt18">
-								<span class="page-title"><?=_('Editing Cron Job');?></span>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<?php show_alert_message($_SESSION);?>
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_cmd" class="form-label"><?=_('Command');?></label>
-								<input type="text" class="form-control" name="v_cmd" id="v_cmd" value="<?=htmlentities(trim($v_cmd, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt18">
-								<label for="v_min" class="form-label"><?=_('Minute');?></label>
-								<input type="text" class="form-control" name="v_min" id="v_min" style="width:220px;" value="<?=htmlentities(trim($v_min, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_hour" class="form-label"><?=_('Hour');?></label>
-								<input type="text" class="form-control" name="v_hour" id="v_hour" style="width:220px;" value="<?=htmlentities(trim($v_hour, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_day" class="form-label"><?=_('Day');?></label>
-								<input type="text" class="form-control" name="v_day" id="v_day" style="width:220px;" value="<?=htmlentities(trim($v_day, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_month" class="form-label"><?=_('Month');?></label>
-								<input type="text" class="form-control" name="v_month" id="v_month" style="width:220px;" value="<?=htmlentities(trim($v_month, "'"))?>">
-							</td>
-						</tr>
-						<tr>
-							<td class="u-pt6">
-								<label for="v_wday" class="form-label"><?=_('Day of week');?></label>
-								<input type="text" class="form-control" name="v_wday" id="v_wday" style="width:220px;" value="<?=htmlentities(trim($v_wday, "'"))?>">
-							</td>
-						</tr>
-					</table>
-					<table class="data-col2 u-mb20"></table>
-				</td>
-			</tr>
-		</table>
-	</form>
+  <form id="vstobjects" name="v_edit_cron" method="post" class="<?=$v_status?>">
+    <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+    <input type="hidden" name="save" value="save">
+    <table class="data">
+      <tr class="data-add">
+        <td class="data-dotted">
+          <table class="data-col1">
+            <tr>
+              <td></td>
+            </tr>
+          </table>
+        </td>
+        <td class="data-dotted">
+          <table class="data-col2" width="850px">
+            <tr>
+              <td class="u-pt18">
+                <span class="page-title"><?=_('Editing Cron Job');?></span>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <?php show_alert_message($_SESSION);?>
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_cmd" class="form-label"><?=_('Command');?></label>
+                <input type="text" class="form-control" name="v_cmd" id="v_cmd" value="<?=htmlentities(trim($v_cmd, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt18">
+                <label for="v_min" class="form-label"><?=_('Minute');?></label>
+                <input type="text" class="form-control" name="v_min" id="v_min" style="width:220px;" value="<?=htmlentities(trim($v_min, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_hour" class="form-label"><?=_('Hour');?></label>
+                <input type="text" class="form-control" name="v_hour" id="v_hour" style="width:220px;" value="<?=htmlentities(trim($v_hour, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_day" class="form-label"><?=_('Day');?></label>
+                <input type="text" class="form-control" name="v_day" id="v_day" style="width:220px;" value="<?=htmlentities(trim($v_day, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_month" class="form-label"><?=_('Month');?></label>
+                <input type="text" class="form-control" name="v_month" id="v_month" style="width:220px;" value="<?=htmlentities(trim($v_month, "'"))?>">
+              </td>
+            </tr>
+            <tr>
+              <td class="u-pt6">
+                <label for="v_wday" class="form-label"><?=_('Day of week');?></label>
+                <input type="text" class="form-control" name="v_wday" id="v_wday" style="width:220px;" value="<?=htmlentities(trim($v_wday, "'"))?>">
+              </td>
+            </tr>
+          </table>
+          <table class="data-col2 u-mb20"></table>
+        </td>
+      </tr>
+    </table>
+  </form>
 </div>

--- a/web/templates/pages/list_access_keys.html
+++ b/web/templates/pages/list_access_keys.html
@@ -1,115 +1,115 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/user/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/add/access-key/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Access Key');?></a>
-		</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/user/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/add/access-key/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Access Key');?></a>
+    </div>
 
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-key"><span class="name"><?=_('Access Key');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-comment"><span class="name"><?=_('Comment');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span><b><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></b></span>
-					</td>
-					<td>
-						<form action="/bulk/access-key/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select name="action" id="">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="delete"><?=_('delete');?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-key"><span class="name"><?=_('Access Key');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-comment"><span class="name"><?=_('Comment');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span><b><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></b></span>
+          </td>
+          <td>
+            <form action="/bulk/access-key/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select name="action" id="">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="delete"><?=_('delete');?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('Access Key');?></b></div>
-				<div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center wide-2"><b><?=_('Comment');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Date');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Time');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('Access Key');?></b></div>
+        <div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center wide-2"><b><?=_('Comment');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Date');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Time');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<!-- Begin Access Keys list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-				$key_user = !empty($value['USER']) ? $value['USER'] : 'admin';
-				$key_comment = !empty($value['COMMENT']) ? $value['COMMENT'] : '-';
-				//$key_permissions = !empty($value['PERMISSIONS']) ? $value['PERMISSIONS'] : '-';
-				//$key_permissions = implode(' ', $key_permissions);
-				$key_date = !empty($value['DATE']) ? $value['DATE'] : '-';
-				$key_time = !empty($value['TIME']) ? $value['TIME'] : '-';
-		?>
-		<div class="l-unit animated fadeIn" v_unit_id="<?=$key?>"
-			v_section="key" sort-key="<?=strtolower($key)?>"
-			sort-comment="<?=strtolower($key_comment)?>"
-			sort-date="<?=strtotime($data[$key]['DATE'] .' '. $data[$key]['TIME'] )?>">
+  <!-- Begin Access Keys list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+        $key_user = !empty($value['USER']) ? $value['USER'] : 'admin';
+        $key_comment = !empty($value['COMMENT']) ? $value['COMMENT'] : '-';
+        //$key_permissions = !empty($value['PERMISSIONS']) ? $value['PERMISSIONS'] : '-';
+        //$key_permissions = implode(' ', $key_permissions);
+        $key_date = !empty($value['DATE']) ? $value['DATE'] : '-';
+        $key_time = !empty($value['TIME']) ? $value['TIME'] : '-';
+    ?>
+    <div class="l-unit animated fadeIn" v_unit_id="<?=$key?>"
+      v_section="key" sort-key="<?=strtolower($key)?>"
+      sort-comment="<?=strtolower($key_comment)?>"
+      sort-date="<?=strtotime($data[$key]['DATE'] .' '. $data[$key]['TIME'] )?>">
 
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="key[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-6">
-					<b><a href="/list/access-key/?key=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('Access Key');?>: <?=$key;?>"><?=$key;?></a></b>
-				</div>
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="key[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-6">
+          <b><a href="/list/access-key/?key=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('Access Key');?>: <?=$key;?>"><?=$key;?></a></b>
+        </div>
 
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left compact text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-								<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-									<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-									<input type="hidden" name="delete_url" value="/delete/access-key/?key=<?=$key?>&token=<?=$_SESSION['token']?>">
-									<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-										<p><?=sprintf(_('DELETE_ACCESS_KEY_CONFIRMATION'),$key)?></p>
-									</div>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center wide-2"><b><?=_($key_comment)?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$key_date?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$key_time?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left compact text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                  <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                  <input type="hidden" name="delete_url" value="/delete/access-key/?key=<?=$key?>&token=<?=$_SESSION['token']?>">
+                  <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                    <p><?=sprintf(_('DELETE_ACCESS_KEY_CONFIRMATION'),$key)?></p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center wide-2"><b><?=_($key_comment)?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$key_date?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$key_time?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d Access Key', '%d Access Keys', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d Access Key', '%d Access Keys', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_backup.html
+++ b/web/templates/pages/list_backup.html
@@ -1,138 +1,138 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/schedule/backup/?token=<?=$_SESSION['token']?>" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Create Backup');?></a>
-				<a href="/list/backup/exclusions/" class="ui-button cancel" dir="ltr"><i class="fas fa-folder-minus status-icon orange"></i><?=_('backup exclusions');?></a>
-			<?php } ?>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') {?>
-						<td>
-							<form action="/bulk/backup/" method="post" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select name="action" id="">
-										<option value=""><?=_('apply to selected');?></option>
-										<option value="delete"><?=_('delete') ?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/schedule/backup/?token=<?=$_SESSION['token']?>" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Create Backup');?></a>
+        <a href="/list/backup/exclusions/" class="ui-button cancel" dir="ltr"><i class="fas fa-folder-minus status-icon orange"></i><?=_('backup exclusions');?></a>
+      <?php } ?>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') {?>
+            <td>
+              <form action="/bulk/backup/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <option value="delete"><?=_('delete') ?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-4"><b><?=_('File Name');?></b></div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Date');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Size');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Type');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Runtime');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-4"><b><?=_('File Name');?></b></div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right"><b>&nbsp;</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Date');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Size');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Type');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Runtime');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<!-- Begin user backup list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			$web = _('no');
-			$dns = _('no');
-			$mail = _('no');
-			$db = _('no');
-			$cron = _('no');
-			$udir = _('no');
+  <!-- Begin user backup list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      $web = _('no');
+      $dns = _('no');
+      $mail = _('no');
+      $db = _('no');
+      $cron = _('no');
+      $udir = _('no');
 
-			if (!empty($data[$key]['WEB'])) $web = _('yes');
-			if (!empty($data[$key]['DNS'])) $dns = _('yes');
-			if (!empty($data[$key]['MAIL'])) $mail = _('yes');
-			if (!empty($data[$key]['DB'])) $db = _('yes');
-			if (!empty($data[$key]['CRON'])) $cron = _('yes');
-			if (!empty($data[$key]['UDIR'])) $udir = _('yes');
-		?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div>
-					<div class="clearfix l-unit__stat-col--left super-compact">
-						<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="backup[]" value="<?=$key?>" <?=$display_mode;?>>
-					</div>
-					<div class="clearfix l-unit__stat-col--left wide-4 truncate">
-						<b>
-							<?php if ($read_only === 'true') {?>
-								<?=$key?>
-							<?php } else { ?>
-								<a href="/list/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('restore');?>"><?=$key?></a>
-							<?php } ?>
-						</b>
-					</div>
-					<!-- START QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-						<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-							<div class="actions-panel clearfix">
-								<?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin') && ($read_only === 'true')) {?>
-									<!-- Restrict ability to restore or delete backups when impersonating 'admin' account -->
-									&nbsp;
-								<?php } else { ?>
-									<div class="actions-panel__col actions-panel__download shortcut-d" key-action="href"><a href="/download/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('download');?>"><i class="fas fa-file-download status-icon lightblue status-icon dim"></i></a></div>
-									<?php if ($read_only !== 'true') {?>
-										<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href"><a href="/list/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('restore');?>"><i class="fas fa-undo status-icon green status-icon dim"></i></a></div>
-										<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-											<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-												<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-												<input type="hidden" name="delete_url" value="/delete/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>">
-												<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-													<p><?=sprintf(_('DELETE_BACKUP_CONFIRMATION'),$key)?></p>
-												</div>
-											</a>
-										</div>
-									<?php } ?>
-								<?php } ?>
-							</div>
-						</div>
-					</div>
-					<!-- END QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left text-center"><b><?=translate_date($data[$key]['DATE'])?></b></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_usage_size($data[$key]['SIZE'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['SIZE'])?></span></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['TYPE']?></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><?=humanize_time($data[$key]['RUNTIME'])?></div>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+      if (!empty($data[$key]['WEB'])) $web = _('yes');
+      if (!empty($data[$key]['DNS'])) $dns = _('yes');
+      if (!empty($data[$key]['MAIL'])) $mail = _('yes');
+      if (!empty($data[$key]['DB'])) $db = _('yes');
+      if (!empty($data[$key]['CRON'])) $cron = _('yes');
+      if (!empty($data[$key]['UDIR'])) $udir = _('yes');
+    ?>
+    <div class="l-unit animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div>
+          <div class="clearfix l-unit__stat-col--left super-compact">
+            <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="backup[]" value="<?=$key?>" <?=$display_mode;?>>
+          </div>
+          <div class="clearfix l-unit__stat-col--left wide-4 truncate">
+            <b>
+              <?php if ($read_only === 'true') {?>
+                <?=$key?>
+              <?php } else { ?>
+                <a href="/list/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('restore');?>"><?=$key?></a>
+              <?php } ?>
+            </b>
+          </div>
+          <!-- START QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+            <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+              <div class="actions-panel clearfix">
+                <?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin') && ($read_only === 'true')) {?>
+                  <!-- Restrict ability to restore or delete backups when impersonating 'admin' account -->
+                  &nbsp;
+                <?php } else { ?>
+                  <div class="actions-panel__col actions-panel__download shortcut-d" key-action="href"><a href="/download/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('download');?>"><i class="fas fa-file-download status-icon lightblue status-icon dim"></i></a></div>
+                  <?php if ($read_only !== 'true') {?>
+                    <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href"><a href="/list/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('restore');?>"><i class="fas fa-undo status-icon green status-icon dim"></i></a></div>
+                    <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                      <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                        <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                        <input type="hidden" name="delete_url" value="/delete/backup/?backup=<?=$key?>&token=<?=$_SESSION['token']?>">
+                        <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                          <p><?=sprintf(_('DELETE_BACKUP_CONFIRMATION'),$key)?></p>
+                        </div>
+                      </a>
+                    </div>
+                  <?php } ?>
+                <?php } ?>
+              </div>
+            </div>
+          </div>
+          <!-- END QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left text-center"><b><?=translate_date($data[$key]['DATE'])?></b></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_usage_size($data[$key]['SIZE'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['SIZE'])?></span></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['TYPE']?></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><?=humanize_time($data[$key]['RUNTIME'])?></div>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d backup', '%d backups', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d backup', '%d backups', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_backup_detail.html
+++ b/web/templates/pages/list_backup_detail.html
@@ -1,259 +1,259 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/backup/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/schedule/restore/?token=<?=$_SESSION['token']?>&backup=<?=htmlentities($_GET['backup'])?>" class="ui-button cancel" dir="ltr"><i class="fas fa-undo status-icon green"></i><?=_('Restore All');?></a>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value=""><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<td>
-						<form action="/bulk/restore/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="hidden" name="backup" value="<?=htmlentities($_GET['backup']); ?>">
-							<div class="l-select">
-								<select name="action">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="restore"><?=_('restore') ?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value=""><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/backup/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/schedule/restore/?token=<?=$_SESSION['token']?>&backup=<?=htmlentities($_GET['backup'])?>" class="ui-button cancel" dir="ltr"><i class="fas fa-undo status-icon green"></i><?=_('Restore All');?></a>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value=""><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <td>
+            <form action="/bulk/restore/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="hidden" name="backup" value="<?=htmlentities($_GET['backup']); ?>">
+              <div class="l-select">
+                <select name="action">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="restore"><?=_('restore') ?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value=""><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" onchange="checkedAll('objects');">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4"><b><?=_('Type');?></b></div>
-				<div class="clearfix l-unit__stat-col--left wide-7"><b><?=_('Details');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-right compact-4"><b><?=_('Restore');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" onchange="checkedAll('objects');">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4"><b><?=_('Type');?></b></div>
+        <div class="clearfix l-unit__stat-col--left wide-7"><b><?=_('Details');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-right compact-4"><b><?=_('Restore');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<!-- List web domains -->
-	<?php
-		$backup = htmlentities($_GET['backup']);
-		$web = explode(',',$data[$backup]['WEB']);
-		foreach ($web as $key) {
-			if (!empty($key)) {
-				++$i;
-		?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i?>" class="ch-toggle" type="checkbox" name="web[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Web domain');?></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7">
-					<div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
-								<a href="/schedule/restore/?backup=<?=$backup?>&type=web&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
-									<i class="fas fa-undo status-icon green status-icon dim icon-pad-right"></i>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php }} ?>
+  <!-- List web domains -->
+  <?php
+    $backup = htmlentities($_GET['backup']);
+    $web = explode(',',$data[$backup]['WEB']);
+    foreach ($web as $key) {
+      if (!empty($key)) {
+        ++$i;
+    ?>
+    <div class="l-unit animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i?>" class="ch-toggle" type="checkbox" name="web[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Web domain');?></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7">
+          <div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
+                <a href="/schedule/restore/?backup=<?=$backup?>&type=web&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
+                  <i class="fas fa-undo status-icon green status-icon dim icon-pad-right"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php }} ?>
 
-	<!-- List mail domains -->
-	<?php
-		$mail = explode(',',$data[$backup]['MAIL']);
-		foreach ($mail as $key) {
-			if (!empty($key)) {
-		?>
-		<div class="l-unit">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check2<?=$i?>" class="ch-toggle" type="checkbox" name="mail[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Mail domain');?></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7">
-					<div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
-								<a href="/schedule/restore/?backup=<?=$backup?>&type=mail&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
-									<i class="fas fa-undo status-icon green status-icon dim"></i>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php }} ?>
+  <!-- List mail domains -->
+  <?php
+    $mail = explode(',',$data[$backup]['MAIL']);
+    foreach ($mail as $key) {
+      if (!empty($key)) {
+    ?>
+    <div class="l-unit">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check2<?=$i?>" class="ch-toggle" type="checkbox" name="mail[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Mail domain');?></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7">
+          <div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
+                <a href="/schedule/restore/?backup=<?=$backup?>&type=mail&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
+                  <i class="fas fa-undo status-icon green status-icon dim"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php }} ?>
 
-	<!-- List DNS zones -->
-	<?php
-		$dns = explode(',',$data[$backup]['DNS']);
-		foreach ($dns as $key) {
-			if (!empty($key)) {
-		?>
-		<div class="l-unit">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check3<?=$i?>" class="ch-toggle" type="checkbox" name="dns[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit__stat-col l-unit__stat-col--left"><?=_('DNS domain');?></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7">
-					<div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
-								<a href="/schedule/restore/?backup=<?=$backup?>&type=dns&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
-									<i class="fas fa-undo status-icon green status-icon dim"></i>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php }} ?>
+  <!-- List DNS zones -->
+  <?php
+    $dns = explode(',',$data[$backup]['DNS']);
+    foreach ($dns as $key) {
+      if (!empty($key)) {
+    ?>
+    <div class="l-unit">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check3<?=$i?>" class="ch-toggle" type="checkbox" name="dns[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit__stat-col l-unit__stat-col--left"><?=_('DNS domain');?></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7">
+          <div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
+                <a href="/schedule/restore/?backup=<?=$backup?>&type=dns&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
+                  <i class="fas fa-undo status-icon green status-icon dim"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php }} ?>
 
-	<!-- List Databases -->
-	<?php
-		$db = explode(',',$data[$backup]['DB']);
-		foreach ($db as $key) {
-			if (!empty($key)) {
-		?>
-		<div class="l-unit">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check4<?=$i?>" class="ch-toggle" type="checkbox" name="db[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Database');?></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7">
-					<div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
-								<a href="/schedule/restore/?backup=<?=$backup?>&type=db&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
-									<i class="fas fa-undo status-icon green status-icon dim"></i>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php }} ?>
+  <!-- List Databases -->
+  <?php
+    $db = explode(',',$data[$backup]['DB']);
+    foreach ($db as $key) {
+      if (!empty($key)) {
+    ?>
+    <div class="l-unit">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check4<?=$i?>" class="ch-toggle" type="checkbox" name="db[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Database');?></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7">
+          <div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
+                <a href="/schedule/restore/?backup=<?=$backup?>&type=db&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
+                  <i class="fas fa-undo status-icon green status-icon dim"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php }} ?>
 
-	<!-- List Cron Jobs -->
-	<?php
-		if (!empty($data[$backup]['CRON'])) {
-			if (!empty($key)) {
-		?>
-		<div class="l-unit">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check5<?=$i?>" class="ch-toggle" type="checkbox" name="check" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Cron Records');?></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7">
-					<div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?='cron '._('records');?></b></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
-								<a href="/schedule/restore/?backup=<?=$backup?>&type=cron&object=records&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
-									<i class="fas fa-undo status-icon green status-icon dim"></i>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php }} ?>
+  <!-- List Cron Jobs -->
+  <?php
+    if (!empty($data[$backup]['CRON'])) {
+      if (!empty($key)) {
+    ?>
+    <div class="l-unit">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check5<?=$i?>" class="ch-toggle" type="checkbox" name="check" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit__stat-col l-unit__stat-col--left"><?=_('Cron Records');?></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7">
+          <div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?='cron '._('records');?></b></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
+                <a href="/schedule/restore/?backup=<?=$backup?>&type=cron&object=records&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
+                  <i class="fas fa-undo status-icon green status-icon dim"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php }} ?>
 
-	<!-- List user directories -->
-	<?php
-		$udir = explode(',',$data[$backup]['UDIR']);
-		foreach ($udir as $key) {
-			if (!empty($key)) {
-		?>
-		<div class="l-unit">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check6<?=$i?>" class="ch-toggle" type="checkbox" name="udir[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit__stat-col l-unit__stat-col--left"><?=_('user dir');?></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7">
-					<div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
-								<a href="/schedule/restore/?backup=<?=$backup?>&type=udir&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
-									<i class="fas fa-undo status-icon green status-icon dim"></i>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php }} ?>
+  <!-- List user directories -->
+  <?php
+    $udir = explode(',',$data[$backup]['UDIR']);
+    foreach ($udir as $key) {
+      if (!empty($key)) {
+    ?>
+    <div class="l-unit">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check6<?=$i?>" class="ch-toggle" type="checkbox" name="udir[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit__stat-col l-unit__stat-col--left"><?=_('user dir');?></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7">
+          <div class="l-unit__stat-col l-unit__stat-col--left wide-7"><b><?=$key?></b></div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__list shortcut-enter" key-action="href">
+                <a href="/schedule/restore/?backup=<?=$backup?>&type=udir&object=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Restore');?>">
+                  <i class="fas fa-undo status-icon green status-icon dim"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php }} ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right total clearfix">
-				<?php printf(ngettext('%d item', '%d items', $i),$i); ?>
-			</div>
-			<div class="data-count l-unit__col l-unit__col--right back clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right total clearfix">
+        <?php printf(ngettext('%d item', '%d items', $i),$i); ?>
+      </div>
+      <div class="data-count l-unit__col l-unit__col--right back clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_backup_exclusions.html
+++ b/web/templates/pages/list_backup_exclusions.html
@@ -1,68 +1,68 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/backup/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/edit/backup/exclusions/" class="ui-button cancel" dir="ltr"><i class="fas fa-pencil-alt status-icon orange"></i><?=_('Editing Backup Exclusions');?></a>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/backup/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/edit/backup/exclusions/" class="ui-button cancel" dir="ltr"><i class="fas fa-pencil-alt status-icon orange"></i><?=_('Editing Backup Exclusions');?></a>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">&nbsp;</div>
-			<div class="clearfix l-unit__stat-col--left wide-1"><b><?=_('Type');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Value');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">&nbsp;</div>
+      <div class="clearfix l-unit__stat-col--left wide-1"><b><?=_('Type');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Value');?></b></div>
+    </div>
+  </div>
 
-	<div class="l-center units animated fadeIn">
-		<!-- Begin list of backup exclusions by type -->
-		<?php
-			foreach ($data as $key => $value) {
-			?>
-			<div class="l-unit header">
-				<div class="l-unit__col l-unit__col--right">
-					<div class="clearfix l-unit__stat-col--left super-compact">&nbsp;</div>
-					<div class="clearfix l-unit__stat-col--left wide-1"><b><?=$key?></b></div>
-					<div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
-					<div class="clearfix l-unit__stat-col--left wide-3">
-						<?php
-							if (empty($value)) echo _('no exclusions');
-							foreach ($value as $ex_key => $ex_value) {
-								echo '<b>'.$ex_key.' </b>'.$ex_value.'<br>';
-							}
-						?>
-					</div>
-				</div>
-			</div>
-		<?php } ?>
-	</div>
+  <div class="l-center units animated fadeIn">
+    <!-- Begin list of backup exclusions by type -->
+    <?php
+      foreach ($data as $key => $value) {
+      ?>
+      <div class="l-unit header">
+        <div class="l-unit__col l-unit__col--right">
+          <div class="clearfix l-unit__stat-col--left super-compact">&nbsp;</div>
+          <div class="clearfix l-unit__stat-col--left wide-1"><b><?=$key?></b></div>
+          <div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
+          <div class="clearfix l-unit__stat-col--left wide-3">
+            <?php
+              if (empty($value)) echo _('no exclusions');
+              foreach ($value as $ex_key => $ex_value) {
+                echo '<b>'.$ex_key.' </b>'.$ex_value.'<br>';
+              }
+            ?>
+          </div>
+        </div>
+      </div>
+    <?php } ?>
+  </div>
 
-	<div id="vstobjects">
-		<div class="l-separator"></div>
-		<div class="l-center">
-			<div class="l-unit-ft">
-				<div class="data-count l-unit__col l-unit__col--right total clearfix">
-				</div>
-			</div>
-		</div>
-	</div>
+  <div id="vstobjects">
+    <div class="l-separator"></div>
+    <div class="l-center">
+      <div class="l-unit-ft">
+        <div class="data-count l-unit__col l-unit__col--right total clearfix">
+        </div>
+      </div>
+    </div>
+  </div>

--- a/web/templates/pages/list_cron.html
+++ b/web/templates/pages/list_cron.html
@@ -1,161 +1,161 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/cron/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Cron Job');?></a>
-				<?php if($panel[$user_plain]['CRON_REPORTS'] == 'yes') { ?>
-					<a class="ui-button cancel" dir="ltr" href="/delete/cron/reports/?token=<?=$_SESSION['token'];?>"><i class="fas fa-toggle-off status-icon green"></i><?=_('turn off notifications');?></a>
-				<?php } else { ?>
-					<a class="ui-button cancel" dir="ltr" href="/add/cron/reports/?token=<?=$_SESSION['token'];?>"><i class="fas fa-toggle-off status-icon grey"></i><?=_('turn on notifications');?></a>
-				<?php } ?>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Command');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') {?>
-						<td class="">
-							<form action="/bulk/cron/" method="post" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select name="action" id="">
-										<option value=""><?=_('apply to selected');?></option>
-										<?php if($panel[$user_plain]['CRON_REPORTS'] == 'yes') echo '<option value="delete-cron-reports">'._('turn off notifications').'</option>'; ?>
-										<?php if($panel[$user_plain]['CRON_REPORTS'] == 'no') echo '<option value="add-cron-reports">'._('turn on notifications').'</option>'; ?>
-										<option value="suspend"><?=_('suspend');?></option>
-										<option value="unsuspend"><?=_('unsuspend');?></option>
-										<option value="delete"><?=_('delete');?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/cron/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Cron Job');?></a>
+        <?php if($panel[$user_plain]['CRON_REPORTS'] == 'yes') { ?>
+          <a class="ui-button cancel" dir="ltr" href="/delete/cron/reports/?token=<?=$_SESSION['token'];?>"><i class="fas fa-toggle-off status-icon green"></i><?=_('turn off notifications');?></a>
+        <?php } else { ?>
+          <a class="ui-button cancel" dir="ltr" href="/add/cron/reports/?token=<?=$_SESSION['token'];?>"><i class="fas fa-toggle-off status-icon grey"></i><?=_('turn on notifications');?></a>
+        <?php } ?>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Command');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') {?>
+            <td class="">
+              <form action="/bulk/cron/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <?php if($panel[$user_plain]['CRON_REPORTS'] == 'yes') echo '<option value="delete-cron-reports">'._('turn off notifications').'</option>'; ?>
+                    <?php if($panel[$user_plain]['CRON_REPORTS'] == 'no') echo '<option value="add-cron-reports">'._('turn on notifications').'</option>'; ?>
+                    <option value="suspend"><?=_('suspend');?></option>
+                    <option value="unsuspend"><?=_('unsuspend');?></option>
+                    <option value="delete"><?=_('delete');?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-5"><b><?=_('Command');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-2 text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Min');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Hour');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Day');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Month');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Day of week');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-5"><b><?=_('Command');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-2 text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Min');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Hour');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Day');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Month');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3 text-center"><b><?=_('Day of week');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin cron job list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_CRON_CONFIRMATION') ;
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_CRON_CONFIRMATION') ;
-			}
-		?>
-		<div class="l-unit <?php if($status == 'suspended') echo 'l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=$key?>" v_section="cron"
-			sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="job[]" value="<?=$key?>" <?=$display_mode;?>>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-5 truncate">
-					<?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) {?>
-						<b><?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?></b>
-					<?php } else { ?>
-						<b><a href="/edit/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Cron Job');?>: <?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?>"><?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?></a></b>
-					<?php } ?>
-				</div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left compact-2 text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<?php if ($read_only === 'true') {?>
-								<!-- Restrict other administrators from editing, deleting, or suspending 'admin' user cron jobs -->
-								&nbsp;
-							<?php } else { ?>
-								<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-									<div class="actions-panel__col actions-panel__download shortcut-enter" key-action="href"><a href="/edit/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Cron Job');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-								<?php } ?>
-								<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-									<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-										<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-										<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>">
-										<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-											<p><?=sprintf($spnd_confirmation,$key)?></p>
-										</div>
-									</a>
-								</div>
-								<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-									<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-										<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-										<input type="hidden" name="delete_url" value="/delete/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>">
-										<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-											<p><?=sprintf(_('DELETE_CRON_CONFIRMATION'),$key)?></p>
-										</div>
-									</a>
-								</div>
-							<?php } ?>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['MIN']?></div>
-				<div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['HOUR']?></div>
-				<div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['DAY']?></div>
-				<div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['MONTH']?></div>
-				<div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['WDAY']?></div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin cron job list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_CRON_CONFIRMATION') ;
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_CRON_CONFIRMATION') ;
+      }
+    ?>
+    <div class="l-unit <?php if($status == 'suspended') echo 'l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=$key?>" v_section="cron"
+      sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="job[]" value="<?=$key?>" <?=$display_mode;?>>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-5 truncate">
+          <?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) {?>
+            <b><?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?></b>
+          <?php } else { ?>
+            <b><a href="/edit/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Cron Job');?>: <?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?>"><?=htmlspecialchars($data[$key]['CMD'], ENT_NOQUOTES)?></a></b>
+          <?php } ?>
+        </div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left compact-2 text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <?php if ($read_only === 'true') {?>
+                <!-- Restrict other administrators from editing, deleting, or suspending 'admin' user cron jobs -->
+                &nbsp;
+              <?php } else { ?>
+                <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                  <div class="actions-panel__col actions-panel__download shortcut-enter" key-action="href"><a href="/edit/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Cron Job');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                <?php } ?>
+                <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                  <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                    <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                    <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>">
+                    <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf($spnd_confirmation,$key)?></p>
+                    </div>
+                  </a>
+                </div>
+                <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                  <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                    <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                    <input type="hidden" name="delete_url" value="/delete/cron/?job=<?=$data[$key]['JOB']?>&token=<?=$_SESSION['token']?>">
+                    <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf(_('DELETE_CRON_CONFIRMATION'),$key)?></p>
+                    </div>
+                  </a>
+                </div>
+              <?php } ?>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['MIN']?></div>
+        <div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['HOUR']?></div>
+        <div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['DAY']?></div>
+        <div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['MONTH']?></div>
+        <div class="clearfix l-unit__stat-col--left compact-3 text-center"><?=$data[$key]['WDAY']?></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d cron job', '%d cron jobs', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d cron job', '%d cron jobs', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_db.html
+++ b/web/templates/pages/list_db.html
@@ -1,199 +1,199 @@
 <?php
-	list($http_host, $port) = explode(':', $_SERVER["HTTP_HOST"].":");
-	$db_myadmin_link = "//".$http_host."/phpmyadmin/";
-	$db_pgadmin_link = "//".$http_host."/phppgadmin/";
+  list($http_host, $port) = explode(':', $_SERVER["HTTP_HOST"].":");
+  $db_myadmin_link = "//".$http_host."/phpmyadmin/";
+  $db_pgadmin_link = "//".$http_host."/phppgadmin/";
 
-	if (!empty($_SESSION['DB_PMA_ALIAS'])) {
-		$db_myadmin_link = "//".$http_host."/".$_SESSION['DB_PMA_ALIAS']."/";
-	}
-	if (!empty($_SESSION['DB_PGA_ALIAS'])) {
-		$db_pgadmin_link = "//".$http_host."/".$_SESSION['DB_PGA_ALIAS']."/";
-	}
+  if (!empty($_SESSION['DB_PMA_ALIAS'])) {
+    $db_myadmin_link = "//".$http_host."/".$_SESSION['DB_PMA_ALIAS']."/";
+  }
+  if (!empty($_SESSION['DB_PGA_ALIAS'])) {
+    $db_pgadmin_link = "//".$http_host."/".$_SESSION['DB_PGA_ALIAS']."/";
+  }
 ?>
 
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/db/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Database');?></a>
-				<?php if (($_SESSION['DB_SYSTEM'] === 'mysql') || ($_SESSION['DB_SYSTEM'] === 'mysql,pgsql') || ($_SESSION['DB_SYSTEM'] === 'pgsql,mysql')) {?>
-					<a class="ui-button cancel <?=(ipUsed() ? 'button-suspended':'');?>" dir="ltr" href="<?=$db_myadmin_link; ?>" target="_blank"><i class="fas fa-database status-icon orange"></i>phpMyAdmin</a>
-				<?php } ?>
-				<?php if (($_SESSION['DB_SYSTEM'] === 'pgsql') || ($_SESSION['DB_SYSTEM'] === 'mysql,pgsql') || ($_SESSION['DB_SYSTEM'] === 'pgsql,mysql')) {?>
-					<a class="ui-button cancel <?=(ipUsed() ? 'button-suspended':'');?>" dir="ltr" href="<?=$db_pgadmin_link; ?>" target="_blank"><i class="fas fa-database status-icon orange"></i>phpPgAdmin</a>
-				<?php } ?>
-				<?php if(ipUsed()){
-				?>
-				<a target="_blank" href="https://docs.hestiacp.com/admin_docs/database.html#why-i-can-t-use-http-ip-phpmyadmin"><i class="fas fa-question-circle"></i></a>
-				<?
-				}?>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-charset"><span class="name"><?=_('Charset');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-server"><span class="name"><?=_('Host');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-user"><span class="name"><?=_('Username');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') {?>
-						<td>
-							<form action="/bulk/db/" method="post" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select name="action" id="">
-										<option value=""><?=_('apply to selected');?></option>
-										<?php if ($_SESSION['userContext'] === 'admin') {?>
-											<option value="rebuild"><?=_('rebuild');?></option>
-											<option value="suspend"><?=_('suspend');?></option>
-											<option value="unsuspend"><?=_('unsuspend');?></option>
-										<?php } ?>
-										<option value="delete"><?=_('delete');?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/db/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Database');?></a>
+        <?php if (($_SESSION['DB_SYSTEM'] === 'mysql') || ($_SESSION['DB_SYSTEM'] === 'mysql,pgsql') || ($_SESSION['DB_SYSTEM'] === 'pgsql,mysql')) {?>
+          <a class="ui-button cancel <?=(ipUsed() ? 'button-suspended':'');?>" dir="ltr" href="<?=$db_myadmin_link; ?>" target="_blank"><i class="fas fa-database status-icon orange"></i>phpMyAdmin</a>
+        <?php } ?>
+        <?php if (($_SESSION['DB_SYSTEM'] === 'pgsql') || ($_SESSION['DB_SYSTEM'] === 'mysql,pgsql') || ($_SESSION['DB_SYSTEM'] === 'pgsql,mysql')) {?>
+          <a class="ui-button cancel <?=(ipUsed() ? 'button-suspended':'');?>" dir="ltr" href="<?=$db_pgadmin_link; ?>" target="_blank"><i class="fas fa-database status-icon orange"></i>phpPgAdmin</a>
+        <?php } ?>
+        <?php if(ipUsed()){
+        ?>
+        <a target="_blank" href="https://docs.hestiacp.com/admin_docs/database.html#why-i-can-t-use-http-ip-phpmyadmin"><i class="fas fa-question-circle"></i></a>
+        <?
+        }?>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-charset"><span class="name"><?=_('Charset');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-server"><span class="name"><?=_('Host');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-user"><span class="name"><?=_('Username');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') {?>
+            <td>
+              <form action="/bulk/db/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <?php if ($_SESSION['userContext'] === 'admin') {?>
+                      <option value="rebuild"><?=_('rebuild');?></option>
+                      <option value="suspend"><?=_('suspend');?></option>
+                      <option value="unsuspend"><?=_('unsuspend');?></option>
+                    <?php } ?>
+                    <option value="delete"><?=_('delete');?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-right compact-3"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Disk');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Type');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center wide"><b><?=_('Username');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Hostname');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Charset');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-right compact-3"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Disk');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Type');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center wide"><b><?=_('Username');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Hostname');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Charset');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin database list item loop -->
-	<?php
-		list($http_host, $port) = explode(':', $_SERVER["HTTP_HOST"].":");
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_DATABASE_CONFIRMATION') ;
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_DATABASE_CONFIRMATION') ;
-			}
-			if ($data[$key]['HOST'] != 'localhost' ) $http_host = $data[$key]['HOST'];
-			if ($data[$key]['TYPE'] == 'mysql') $db_admin = "phpMyAdmin";
-			if ($data[$key]['TYPE'] == 'mysql') $db_admin_link = "https://".$http_host."/phpmyadmin/";
-			if (($data[$key]['TYPE'] == 'mysql') && (!empty($_SESSION['DB_PMA_ALIAS']))) $db_admin_link = $_SESSION['DB_PMA_ALIAS'];
-			if ($data[$key]['TYPE'] == 'pgsql') $db_admin = "phpPgAdmin";
-			if ($data[$key]['TYPE'] == 'pgsql') $db_admin_link = "https://".$http_host."/phppgadmin/";
-			if (($data[$key]['TYPE'] == 'pgsql') && (!empty($_SESSION['DB_PGA_ALIAS']))) $db_admin_link = $_SESSION['DB_PGA_ALIAS'];
-		?>
-		<div class="l-unit <?php if($status == 'suspended') echo 'l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=$key?>" v_section="db"
-			sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>" sort-disk="<?=$data[$key]['U_DISK']?>"
-			sort-user="<?=$data[$key]['DBUSER']?>" sort-server="<?=$data[$key]['HOST']?>" sort-charset="<?=$data[$key]['CHARSET']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div>
-					<div class="clearfix l-unit__stat-col--left super-compact">
-						<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="database[]" value="<?=$key?>" <?=$display_mode;?>>
-					</div>
-					<div class="clearfix l-unit__stat-col--left wide-3 truncate">
-						<?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) {?>
-							<b><?=$key?></b>
-						<?php } else { ?>
-							<b><a href="/edit/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Database');?>: <?=$key?>"><?=$key?></a></b>
-						<?php } ?>
-					</div>
-					<!-- START QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left text-right compact-3">
-						<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-							<div class="actions-panel clearfix">
-								<?php if ($read_only === 'true') {?>
-									<!-- Restrict the ability to edit, delete, or suspend domain items when impersonating 'admin' user -->
-									&nbsp;
-								<?php } else { ?>
-									<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-										<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Database');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-									<?php } ?>
-									<?php if ($data[$key]['TYPE'] == 'mysql' && isset($_SESSION['PHPMYADMIN_KEY']) && $_SESSION['PHPMYADMIN_KEY'] != '' && !ipUsed()) { $time = time(); ?>
-										<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a target="_blank" href="<?=$db_myadmin_link;?>/hestia-sso.php?database=<?=$key;?>&user=<?=$user_plain;?>&exp=<?=$time;?>&hestia_token=<?=password_hash($key.$user_plain.$_SESSION['user_combined_ip'].$time.$_SESSION['PHPMYADMIN_KEY'], PASSWORD_DEFAULT)?>" title="<?=_('phpMyAdmin');?>"><i class="fas fa-sign-in-alt status-icon orange status-icon dim"></i></a></div>
-									<?php } ?>
-									<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-										<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-											<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-											<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>">
-											<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-												<p><?=sprintf($spnd_confirmation,$key)?></p>
-											</div>
-										</a>
-									</div>
-									<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-										<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-											<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-											<input type="hidden" name="delete_url" value="/delete/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>">
-											<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-												<p><?=sprintf(_('DELETE_DATABASE_CONFIRMATION'),$key)?></p>
-											</div>
-										</a>
-									</div>
-								<?php } ?>
-							</div>
-						</div>
-					</div>
-					<!-- END QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
-					<div class="clearfix l-unit__stat-col--left text-center compact"><?=$data[$key]['TYPE']?></div>
-					<div class="clearfix l-unit__stat-col--left text-center wide"><b><?=$data[$key]['DBUSER']?></b></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['HOST']?></b></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['CHARSET']?></div>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin database list item loop -->
+  <?php
+    list($http_host, $port) = explode(':', $_SERVER["HTTP_HOST"].":");
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_DATABASE_CONFIRMATION') ;
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_DATABASE_CONFIRMATION') ;
+      }
+      if ($data[$key]['HOST'] != 'localhost' ) $http_host = $data[$key]['HOST'];
+      if ($data[$key]['TYPE'] == 'mysql') $db_admin = "phpMyAdmin";
+      if ($data[$key]['TYPE'] == 'mysql') $db_admin_link = "https://".$http_host."/phpmyadmin/";
+      if (($data[$key]['TYPE'] == 'mysql') && (!empty($_SESSION['DB_PMA_ALIAS']))) $db_admin_link = $_SESSION['DB_PMA_ALIAS'];
+      if ($data[$key]['TYPE'] == 'pgsql') $db_admin = "phpPgAdmin";
+      if ($data[$key]['TYPE'] == 'pgsql') $db_admin_link = "https://".$http_host."/phppgadmin/";
+      if (($data[$key]['TYPE'] == 'pgsql') && (!empty($_SESSION['DB_PGA_ALIAS']))) $db_admin_link = $_SESSION['DB_PGA_ALIAS'];
+    ?>
+    <div class="l-unit <?php if($status == 'suspended') echo 'l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=$key?>" v_section="db"
+      sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>" sort-disk="<?=$data[$key]['U_DISK']?>"
+      sort-user="<?=$data[$key]['DBUSER']?>" sort-server="<?=$data[$key]['HOST']?>" sort-charset="<?=$data[$key]['CHARSET']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div>
+          <div class="clearfix l-unit__stat-col--left super-compact">
+            <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="database[]" value="<?=$key?>" <?=$display_mode;?>>
+          </div>
+          <div class="clearfix l-unit__stat-col--left wide-3 truncate">
+            <?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) {?>
+              <b><?=$key?></b>
+            <?php } else { ?>
+              <b><a href="/edit/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Database');?>: <?=$key?>"><?=$key?></a></b>
+            <?php } ?>
+          </div>
+          <!-- START QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left text-right compact-3">
+            <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+              <div class="actions-panel clearfix">
+                <?php if ($read_only === 'true') {?>
+                  <!-- Restrict the ability to edit, delete, or suspend domain items when impersonating 'admin' user -->
+                  &nbsp;
+                <?php } else { ?>
+                  <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                    <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Database');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                  <?php } ?>
+                  <?php if ($data[$key]['TYPE'] == 'mysql' && isset($_SESSION['PHPMYADMIN_KEY']) && $_SESSION['PHPMYADMIN_KEY'] != '' && !ipUsed()) { $time = time(); ?>
+                    <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a target="_blank" href="<?=$db_myadmin_link;?>/hestia-sso.php?database=<?=$key;?>&user=<?=$user_plain;?>&exp=<?=$time;?>&hestia_token=<?=password_hash($key.$user_plain.$_SESSION['user_combined_ip'].$time.$_SESSION['PHPMYADMIN_KEY'], PASSWORD_DEFAULT)?>" title="<?=_('phpMyAdmin');?>"><i class="fas fa-sign-in-alt status-icon orange status-icon dim"></i></a></div>
+                  <?php } ?>
+                  <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                    <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                      <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                      <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>">
+                      <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                        <p><?=sprintf($spnd_confirmation,$key)?></p>
+                      </div>
+                    </a>
+                  </div>
+                  <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                    <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                      <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                      <input type="hidden" name="delete_url" value="/delete/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>">
+                      <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                        <p><?=sprintf(_('DELETE_DATABASE_CONFIRMATION'),$key)?></p>
+                      </div>
+                    </a>
+                  </div>
+                <?php } ?>
+              </div>
+            </div>
+          </div>
+          <!-- END QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
+          <div class="clearfix l-unit__stat-col--left text-center compact"><?=$data[$key]['TYPE']?></div>
+          <div class="clearfix l-unit__stat-col--left text-center wide"><b><?=$data[$key]['DBUSER']?></b></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['HOST']?></b></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['CHARSET']?></div>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d SQL database', '%d SQL databases', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d SQL database', '%d SQL databases', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_dns.html
+++ b/web/templates/pages/list_dns.html
@@ -1,174 +1,174 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/dns/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add DNS Domain');?></a>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display: none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-expire" sort_as_int="1"><span class="name"><?=_('Expire');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-ip"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-records"><span class="name"><?=_('Records');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>">
-			<div class="l-sort-toolbar clearfix">
-				<table>
-					<tr>
-						<td class="sort-by" title="<?=_('Sort items');?>">
-							<?=_('sort by');?>: <span>
-								<b>
-									<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-									<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-								</b>
-							</span>
-						</td>
-						<td class="l-sort-toolbar__search-box">
-							<form action="/search/" method="get">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-								<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-							</form>
-						</td>
-						<?php if ($read_only !== 'true') {?>
-							<td>
-								<form action="/bulk/dns/" method="post" id="objects">
-									<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-									<div class="l-select">
-										<select name="action" id="">
-											<option value=""><?=_('apply to selected');?></option>
-											<?php if ($_SESSION['userContext'] === 'admin') {?>
-												<option value="rebuild"><?=_('rebuild');?></option>
-											<?php } ?>
-											<option value="suspend"><?=_('suspend');?></option>
-											<option value="unsuspend"><?=_('unsuspend');?></option>
-											<option value="delete"><?=_('delete');?></option>
-										</select>
-									</div>
-									<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-								</form>
-							</td>
-						<?php } ?>
-					</tr>
-				</table>
-			</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/dns/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add DNS Domain');?></a>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display: none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-expire" sort_as_int="1"><span class="name"><?=_('Expire');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-ip"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-records"><span class="name"><?=_('Records');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>">
+      <div class="l-sort-toolbar clearfix">
+        <table>
+          <tr>
+            <td class="sort-by" title="<?=_('Sort items');?>">
+              <?=_('sort by');?>: <span>
+                <b>
+                  <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                  <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+                </b>
+              </span>
+            </td>
+            <td class="l-sort-toolbar__search-box">
+              <form action="/search/" method="get">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+                <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+              </form>
+            </td>
+            <?php if ($read_only !== 'true') {?>
+              <td>
+                <form action="/bulk/dns/" method="post" id="objects">
+                  <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                  <div class="l-select">
+                    <select name="action" id="">
+                      <option value=""><?=_('apply to selected');?></option>
+                      <?php if ($_SESSION['userContext'] === 'admin') {?>
+                        <option value="rebuild"><?=_('rebuild');?></option>
+                      <?php } ?>
+                      <option value="suspend"><?=_('suspend');?></option>
+                      <option value="unsuspend"><?=_('unsuspend');?></option>
+                      <option value="delete"><?=_('delete');?></option>
+                    </select>
+                  </div>
+                  <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+                </form>
+              </td>
+            <?php } ?>
+          </tr>
+        </table>
+      </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Records_DNS');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Template');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('TTL');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('SOA');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('DNSSEC');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Expiration Date');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Records_DNS');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Template');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('TTL');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('SOA');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('DNSSEC');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Expiration Date');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin DNS zone list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
-			}
-			if ($data[$key]['DNSSEC'] == 'no') {
-				$dnssec_icon = 'fa-times-circle';
-			} else {
-				$dnssec_icon = 'fa-check-circle';
-			}
-		?>
-		<div class="l-unit <?php if ($status == 'suspended') echo ' l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=htmlentities($key);?>"
-			v_section="dns" sort-ip="<?=str_replace('.', '', $data[$key]['IP'])?>" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=htmlentities($key);?>"
-			sort-expire="<?=strtotime($data[$key]['EXP'])?>" sort-records="<?=(int)$data[$key]['RECORDS']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="domain[]" value="<?=$key?>" <?=$display_mode;?>>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3 truncate">
-					<b><a href="/list/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('DNS records');?>: <?=htmlentities($key);?>"><?=htmlentities($key);?></a></b>
-					<?=empty($data[$key]['SRC'])? '' : '<br>⇢ <span style="font-size:11px;">' . htmlspecialchars($data[$key]['SRC'], ENT_QUOTES) . '</span>'; ?>
-				</div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<?php if ($read_only === 'true') {?>
-								<!-- Restrict administrators from editing domain items when impersonating the 'admin' user -->
-								&nbsp;
-							<?php } else { ?>
-								<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-									<div class="actions-panel__col actions-panel__logs shortcut-n" key-action="href"><a href="/add/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('Add DNS Record');?>"><i class="fas fa-plus-circle status-icon green status-icon dim"></i></a></div>
-									<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing DNS Domain');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-									<?php if($data[$key]['DNSSEC'] == "yes"){?><div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/list/dns/?domain=<?=htmlentities($key);?>&action=dnssec&token=<?=$_SESSION['token']?>" title="<?=_('View Public DNSSEC key');?>"><i class="fas fa-key status-icon orange status-icon dim"></i></a></div>
-									<?php } ?>
-								<?php } ?>
-								<div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="/list/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('DNS records');?>"><i class="fas fa-list status-icon lightblue status-icon dim"></i></a></div>
-								<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-									<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-										<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-										<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>">
-										<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-											<p><?=sprintf($spnd_confirmation,$key)?></p>
-										</div>
-									</a>
-								</div>
-								<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-									<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-										<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-										<input type="hidden" name="delete_url" value="/delete/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>">
-										<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-											<p><?=sprintf(_('DELETE_DOMAIN_CONFIRMATION'),$key)?></p>
-										</div>
-									</a>
-								</div>
-							<?php } ?>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center compact">
-					<?php if ($data[$key]['RECORDS']) echo '<span>'.$data[$key]['RECORDS'].'</span>';?>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['TPL']?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact"><?=$data[$key]['TTL']?></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['SOA']?></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-3">
-					<i class="fas <?=$dnssec_icon;?>"></i>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['EXP']?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin DNS zone list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
+      }
+      if ($data[$key]['DNSSEC'] == 'no') {
+        $dnssec_icon = 'fa-times-circle';
+      } else {
+        $dnssec_icon = 'fa-check-circle';
+      }
+    ?>
+    <div class="l-unit <?php if ($status == 'suspended') echo ' l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=htmlentities($key);?>"
+      v_section="dns" sort-ip="<?=str_replace('.', '', $data[$key]['IP'])?>" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=htmlentities($key);?>"
+      sort-expire="<?=strtotime($data[$key]['EXP'])?>" sort-records="<?=(int)$data[$key]['RECORDS']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="domain[]" value="<?=$key?>" <?=$display_mode;?>>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3 truncate">
+          <b><a href="/list/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('DNS records');?>: <?=htmlentities($key);?>"><?=htmlentities($key);?></a></b>
+          <?=empty($data[$key]['SRC'])? '' : '<br>⇢ <span style="font-size:11px;">' . htmlspecialchars($data[$key]['SRC'], ENT_QUOTES) . '</span>'; ?>
+        </div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <?php if ($read_only === 'true') {?>
+                <!-- Restrict administrators from editing domain items when impersonating the 'admin' user -->
+                &nbsp;
+              <?php } else { ?>
+                <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                  <div class="actions-panel__col actions-panel__logs shortcut-n" key-action="href"><a href="/add/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('Add DNS Record');?>"><i class="fas fa-plus-circle status-icon green status-icon dim"></i></a></div>
+                  <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing DNS Domain');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                  <?php if($data[$key]['DNSSEC'] == "yes"){?><div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/list/dns/?domain=<?=htmlentities($key);?>&action=dnssec&token=<?=$_SESSION['token']?>" title="<?=_('View Public DNSSEC key');?>"><i class="fas fa-key status-icon orange status-icon dim"></i></a></div>
+                  <?php } ?>
+                <?php } ?>
+                <div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="/list/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>" title="<?=_('DNS records');?>"><i class="fas fa-list status-icon lightblue status-icon dim"></i></a></div>
+                <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                  <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                    <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                    <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>">
+                    <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf($spnd_confirmation,$key)?></p>
+                    </div>
+                  </a>
+                </div>
+                <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                  <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                    <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                    <input type="hidden" name="delete_url" value="/delete/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>">
+                    <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf(_('DELETE_DOMAIN_CONFIRMATION'),$key)?></p>
+                    </div>
+                  </a>
+                </div>
+              <?php } ?>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center compact">
+          <?php if ($data[$key]['RECORDS']) echo '<span>'.$data[$key]['RECORDS'].'</span>';?>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['TPL']?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact"><?=$data[$key]['TTL']?></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['SOA']?></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-3">
+          <i class="fas <?=$dnssec_icon;?>"></i>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['EXP']?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d DNS zone', '%d DNS zones', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d DNS zone', '%d DNS zones', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_dns_public.html
+++ b/web/templates/pages/list_dns_public.html
@@ -1,60 +1,60 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/dns/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add DNS Domain');?></a>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display: none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-expire" sort_as_int="1"><span class="name"><?=_('Expire');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-ip"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-records"><span class="name"><?=_('Records');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>">
-			<div class="l-sort-toolbar clearfix">
-				<table>
-					<tr>
-						<td class="sort-by" title="<?=_('Sort items');?>">
-							<?=_('sort by');?>: <span>
-								<b>
-									<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-									<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-								</b>
-							</span>
-						</td>
-						<td class="l-sort-toolbar__search-box">
-							<form action="/search/" method="get">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
-								<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-								<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-							</form>
-						</td>
-						<?php if ($read_only !== 'true') {?>
-							<td>
-								<form action="/bulk/dns/" method="post" id="objects">
-									<input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
-									<div class="l-select">
-										<select name="action" id="">
-											<option value=""><?=_('apply to selected');?></option>
-											<?php if ($_SESSION['userContext'] === 'admin') {?>
-												<option value="rebuild"><?=_('rebuild');?></option>
-											<?php } ?>
-											<option value="suspend"><?=_('suspend');?></option>
-											<option value="unsuspend"><?=_('unsuspend');?></option>
-											<option value="delete"><?=_('delete');?></option>
-										</select>
-									</div>
-									<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-								</form>
-							</td>
-						<?php } ?>
-					</tr>
-				</table>
-			</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/dns/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add DNS Domain');?></a>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display: none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-expire" sort_as_int="1"><span class="name"><?=_('Expire');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-ip"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-records"><span class="name"><?=_('Records');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>">
+      <div class="l-sort-toolbar clearfix">
+        <table>
+          <tr>
+            <td class="sort-by" title="<?=_('Sort items');?>">
+              <?=_('sort by');?>: <span>
+                <b>
+                  <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                  <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+                </b>
+              </span>
+            </td>
+            <td class="l-sort-toolbar__search-box">
+              <form action="/search/" method="get">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
+                <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+                <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+              </form>
+            </td>
+            <?php if ($read_only !== 'true') {?>
+              <td>
+                <form action="/bulk/dns/" method="post" id="objects">
+                  <input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
+                  <div class="l-select">
+                    <select name="action" id="">
+                      <option value=""><?=_('apply to selected');?></option>
+                      <?php if ($_SESSION['userContext'] === 'admin') {?>
+                        <option value="rebuild"><?=_('rebuild');?></option>
+                      <?php } ?>
+                      <option value="suspend"><?=_('suspend');?></option>
+                      <option value="unsuspend"><?=_('unsuspend');?></option>
+                      <option value="delete"><?=_('delete');?></option>
+                    </select>
+                  </div>
+                  <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+                </form>
+              </td>
+            <?php } ?>
+          </tr>
+        </table>
+      </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -63,32 +63,32 @@
 <div class="l-center units">
 
 <div class="l-unit animated fadeIn">
-	<div class="l-unit__col l-unit__col--right">
-		<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('DNSKEY record');?></b></div>
-		<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $data[$domain]['RECORD'];?>"></b></div>
-	</div>
+  <div class="l-unit__col l-unit__col--right">
+    <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('DNSKEY record');?></b></div>
+    <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $data[$domain]['RECORD'];?>"></b></div>
+  </div>
 </div>
 <div class="l-unit animated fadeIn">
-	<div class="l-unit__col l-unit__col--right">
-		<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('DS record');?></b></div>
-		<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $data[$domain]['DS'];?>"></b></div>
-	</div>
+  <div class="l-unit__col l-unit__col--right">
+    <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('DS record');?></b></div>
+    <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $data[$domain]['DS'];?>"></b></div>
+  </div>
 </div>
 <div class="l-unit animated fadeIn">
-	<div class="l-unit__col l-unit__col--right">
-		<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('Public key');?></b></div>
-		<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $data[$domain]['KEY'];?>"></b></div>
-	</div>
+  <div class="l-unit__col l-unit__col--right">
+    <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('Public key');?></b></div>
+    <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $data[$domain]['KEY'];?>"></b></div>
+  </div>
 </div>
 <div class="l-unit animated fadeIn">
-	<div class="l-unit__col l-unit__col--right">
-		<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('Key Tag / Flag');?></b></div>
-		<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $flag;?>"></b></div>
-	</div>
+  <div class="l-unit__col l-unit__col--right">
+    <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('Key Tag / Flag');?></b></div>
+    <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $flag;?>"></b></div>
+  </div>
 </div>
 <div class="l-unit animated fadeIn">
-	<div class="l-unit__col l-unit__col--right">
-		<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('Algorithm');?></b></div>
-		<div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $algorithm;?>"></b></div>
-	</div>
+  <div class="l-unit__col l-unit__col--right">
+    <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b><?=_('Algorithm');?></b></div>
+    <div class="clearfix l-unit__stat-col--left wide-3"><b><input type="text" class="form-control" value="<?php echo $algorithm;?>"></b></div>
+  </div>
 </div>

--- a/web/templates/pages/list_dns_rec.html
+++ b/web/templates/pages/list_dns_rec.html
@@ -1,156 +1,156 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/dns/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/dns/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i> <?=_('Add Record');?></a>
-				<a href="/edit/dns/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-pencil-alt status-icon blue"></i> <?=_('Editing DNS Domain');?></a>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-value"><span class="name"><?=_('IP or Value');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-record"><span class="name"><?=_('Record');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-ttl" sort_as_int="1"><span class="name"><?=_('TTL');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-type"><span class="name"><?=_('Type');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Record'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') {?>
-						<td>
-							<form action="/bulk/dns/" method="post" id="objects">
-								<input type="hidden" name="domain" value="<?=htmlentities($_GET['domain'])?>">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select name="action" id="">
-										<option value=""><?=_('apply to selected');?></option>
-										<option value="suspend"><?=_('suspend');?></option>
-										<option value="unsuspend"><?=_('unsuspend');?></option>
-										<option value="delete"><?=_('delete');?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/dns/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/dns/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i> <?=_('Add Record');?></a>
+        <a href="/edit/dns/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-pencil-alt status-icon blue"></i> <?=_('Editing DNS Domain');?></a>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-value"><span class="name"><?=_('IP or Value');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-record"><span class="name"><?=_('Record');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-ttl" sort_as_int="1"><span class="name"><?=_('TTL');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-type"><span class="name"><?=_('Type');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Record'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') {?>
+            <td>
+              <form action="/bulk/dns/" method="post" id="objects">
+                <input type="hidden" name="domain" value="<?=htmlentities($_GET['domain'])?>">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <option value="suspend"><?=_('suspend');?></option>
+                    <option value="unsuspend"><?=_('unsuspend');?></option>
+                    <option value="delete"><?=_('delete');?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-			</div>
-			<div class="clearfix l-unit__stat-col--left small"><b><?=_('Record');?></b></div>
-			<div class="clearfix l-unit__stat-col--left super-compact text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left compact text-center" style="padding-left: 32px;"><b><?=_('Type');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact text-center"><b><?=_('Priority');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact text-center"><b><?=_('TTL');?></b></div>
-			<div class="clearfix l-unit__stat-col--left super-compact"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('IP or Value');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+      </div>
+      <div class="clearfix l-unit__stat-col--left small"><b><?=_('Record');?></b></div>
+      <div class="clearfix l-unit__stat-col--left super-compact text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left compact text-center" style="padding-left: 32px;"><b><?=_('Type');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact text-center"><b><?=_('Priority');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact text-center"><b><?=_('TTL');?></b></div>
+      <div class="clearfix l-unit__stat-col--left super-compact"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('IP or Value');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin DNS record list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
-			}
-		?>
-		<div class="l-unit<?php if ($status == 'suspended') echo ' l-unit--suspended';?> animated fadeIn"
-			v_unit_id="<?=htmlentities($key);?>" v_section="dns_rec" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-record="<?=$data[$key]['RECORD']?>" sort-type="<?=$data[$key]['TYPE']?>" sort-ttl="<?=$data[$key]['TTL']?>" sort-value="<?=$data[$key]['VALUE']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$data[$key]['ID']?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="record[]" value="<?=$data[$key]['ID']?>" <?=$display_mode;?>>
-				</div>
-				<div class="clearfix l-unit__stat-col--left small truncate">
-					<b>
-					<?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) {?>
-						<?=substr($data[$key]['RECORD'], 0, 12); if(strlen($data[$key]['RECORD']) > 12 ) echo '...'; ?>
-					<?php } else { ?>
-						<a href="/edit/dns/?domain=<?=htmlspecialchars($_GET['domain'])?>&record_id=<?=$data[$key]['ID']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing DNS Record').': '.htmlspecialchars($data[$key]['RECORD'])?>"><? echo substr($data[$key]['RECORD'], 0, 12); if(strlen($data[$key]['RECORD']) > 12 ) echo '...'; ?></a>
-					<?php } ?>
-					</b>
-				</div>
-			<!-- START QUICK ACTION TOOLBAR AREA -->
-			<div class="clearfix l-unit__stat-col--left super-compact text-right">
-				<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-					<div class="actions-panel clearfix">
-						<?php if ($read_only === 'true') {?>
-							<!-- Restrict editing of DNS records when impersonating 'admin' account -->
-							&nbsp;
-						<?php } else { ?>
-							<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-								<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/dns/?domain=<?=htmlspecialchars($_GET['domain'])?>&record_id=<?=$data[$key]['ID']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing DNS Record');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-							<?php } ?>
-							<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-								<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-									<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-									<input type="hidden" name="delete_url" value="/delete/dns/?domain=<?=htmlspecialchars($_GET['domain'])?>&record_id=<?=$data[$key]['ID']?>&token=<?=$_SESSION['token']?>">
-									<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-										<p><?=sprintf(_('DELETE_RECORD_CONFIRMATION'),$key)?></p>
-									</div>
-								</a>
-							</div>
-						<?php } ?>
-					</div>
-				</div>
-			</div>
-			<!-- END QUICK ACTION TOOLBAR AREA -->
-			<div class="clearfix l-unit__stat-col--left compact text-center" style="padding-left: 32px;"><b><?=$data[$key]['TYPE']?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact text-center"><?=$data[$key]['PRIORITY']?>&nbsp;</div>
-			<div class="clearfix l-unit__stat-col--left compact text-center"><?php if($data[$key]['TTL'] == ''){ echo _('Default'); }else{ echo $data[$key]['TTL'];} ?></div>
-			<div class="clearfix l-unit__stat-col--left super-compact"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-6 truncate" style="word-break: break-word;"><?=htmlspecialchars($data[$key]['VALUE'], ENT_QUOTES, 'UTF-8');?></div>
-		</div>
-	</div>
+  <!-- Begin DNS record list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
+      }
+    ?>
+    <div class="l-unit<?php if ($status == 'suspended') echo ' l-unit--suspended';?> animated fadeIn"
+      v_unit_id="<?=htmlentities($key);?>" v_section="dns_rec" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-record="<?=$data[$key]['RECORD']?>" sort-type="<?=$data[$key]['TYPE']?>" sort-ttl="<?=$data[$key]['TTL']?>" sort-value="<?=$data[$key]['VALUE']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$data[$key]['ID']?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="record[]" value="<?=$data[$key]['ID']?>" <?=$display_mode;?>>
+        </div>
+        <div class="clearfix l-unit__stat-col--left small truncate">
+          <b>
+          <?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) {?>
+            <?=substr($data[$key]['RECORD'], 0, 12); if(strlen($data[$key]['RECORD']) > 12 ) echo '...'; ?>
+          <?php } else { ?>
+            <a href="/edit/dns/?domain=<?=htmlspecialchars($_GET['domain'])?>&record_id=<?=$data[$key]['ID']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing DNS Record').': '.htmlspecialchars($data[$key]['RECORD'])?>"><? echo substr($data[$key]['RECORD'], 0, 12); if(strlen($data[$key]['RECORD']) > 12 ) echo '...'; ?></a>
+          <?php } ?>
+          </b>
+        </div>
+      <!-- START QUICK ACTION TOOLBAR AREA -->
+      <div class="clearfix l-unit__stat-col--left super-compact text-right">
+        <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+          <div class="actions-panel clearfix">
+            <?php if ($read_only === 'true') {?>
+              <!-- Restrict editing of DNS records when impersonating 'admin' account -->
+              &nbsp;
+            <?php } else { ?>
+              <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/dns/?domain=<?=htmlspecialchars($_GET['domain'])?>&record_id=<?=$data[$key]['ID']?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing DNS Record');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+              <?php } ?>
+              <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                  <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                  <input type="hidden" name="delete_url" value="/delete/dns/?domain=<?=htmlspecialchars($_GET['domain'])?>&record_id=<?=$data[$key]['ID']?>&token=<?=$_SESSION['token']?>">
+                  <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                    <p><?=sprintf(_('DELETE_RECORD_CONFIRMATION'),$key)?></p>
+                  </div>
+                </a>
+              </div>
+            <?php } ?>
+          </div>
+        </div>
+      </div>
+      <!-- END QUICK ACTION TOOLBAR AREA -->
+      <div class="clearfix l-unit__stat-col--left compact text-center" style="padding-left: 32px;"><b><?=$data[$key]['TYPE']?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact text-center"><?=$data[$key]['PRIORITY']?>&nbsp;</div>
+      <div class="clearfix l-unit__stat-col--left compact text-center"><?php if($data[$key]['TTL'] == ''){ echo _('Default'); }else{ echo $data[$key]['TTL'];} ?></div>
+      <div class="clearfix l-unit__stat-col--left super-compact"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-6 truncate" style="word-break: break-word;"><?=htmlspecialchars($data[$key]['VALUE'], ENT_QUOTES, 'UTF-8');?></div>
+    </div>
+  </div>
 <?php } ?>
 
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right total clearfix">
-				<?php printf(ngettext('%d DNS record', '%d DNS records', $i),$i); ?>
-			</div>
-			<div class="data-count l-unit__col l-unit__col--right back clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right total clearfix">
+        <?php printf(ngettext('%d DNS record', '%d DNS records', $i),$i); ?>
+      </div>
+      <div class="data-count l-unit__col l-unit__col--right back clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_firewall.html
+++ b/web/templates/pages/list_firewall.html
@@ -1,150 +1,150 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/add/firewall/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Rule');?></a>
-			<?php if(!empty($_SESSION['FIREWALL_EXTENSION'])): ?>
-				<a class="ui-button cancel" dir="ltr" href="/list/firewall/banlist/"><i class="fas fa-eye status-icon red"></i><?=_('list fail2ban');?></a>
-				<a class="ui-button cancel" dir="ltr" href="/list/firewall/ipset/"><i class="fas fa-list status-icon blue"></i><?=_('list ipset');?></a>
-			<?php endif; ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-action"><span class="name"><?=_('Action');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up active"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-protocol"><span class="name"><?=_('Protocol');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-port"><span class="name"><?=_('Port');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-ip" sort_as_int="1"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-comment"><span class="name"><?=_('Comment');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span><b><?=_('Action');?> <i class="fas fa-sort-alpha-up"></i></b></span>
-					</td>
-					<td>
-						<form action="/bulk/firewall/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select name="action" id="">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="delete"><?=_('delete') ?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/add/firewall/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Rule');?></a>
+      <?php if(!empty($_SESSION['FIREWALL_EXTENSION'])): ?>
+        <a class="ui-button cancel" dir="ltr" href="/list/firewall/banlist/"><i class="fas fa-eye status-icon red"></i><?=_('list fail2ban');?></a>
+        <a class="ui-button cancel" dir="ltr" href="/list/firewall/ipset/"><i class="fas fa-list status-icon blue"></i><?=_('list ipset');?></a>
+      <?php endif; ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-action"><span class="name"><?=_('Action');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up active"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-protocol"><span class="name"><?=_('Protocol');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-port"><span class="name"><?=_('Port');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-ip" sort_as_int="1"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-comment"><span class="name"><?=_('Comment');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span><b><?=_('Action');?> <i class="fas fa-sort-alpha-up"></i></b></span>
+          </td>
+          <td>
+            <form action="/bulk/firewall/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select name="action" id="">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="delete"><?=_('delete') ?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units compact">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-1"><b><?=_('Action');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-2 text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Comment');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Protocol');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-3 text-center"><b><?=_('Port');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('IP address');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-1"><b><?=_('Action');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-2 text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Comment');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Protocol');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-3 text-center"><b><?=_('Port');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('IP address');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin firewall chain/action list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_RULE_CONFIRMATION') ;
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_RULE_CONFIRMATION') ;
-			}
-		?>
-		<div class="l-unit<?php if ($status == 'suspended') echo ' l-unit--suspended';?> animated fadeIn" v_unit_id="<?=$key?>" v_section="firewall"
-			sort-action="<?=$data[$key]['ACTION']?>" sort-protocol="<?=$data[$key]['PROTOCOL']?>" sort-port="<?=$data[$key]['PORT']?>"
-			sort-ip="<?=str_replace('.', '', $data[$key]['IP'])?>" sort-comment="<?=$data[$key]['COMMENT']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div>
-					<div class="clearfix l-unit__stat-col--left super-compact">
-						<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="rule[]" value="<?=$key?>">
-					</div>
-					<div class="clearfix l-unit__stat-col--left wide-1">
-						<b>
-							<a href="/edit/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Firewall Rule');?>">
-							<?php if ($data[$key]['SUSPENDED'] == 'no') { ?>
-								<?php if ($data[$key]['ACTION'] == 'DROP') { ?>
-									<i class="fas fa-minus-circle status-icon red icon-pad-right"></i> <?=_($data[$key]['ACTION'])?>
-								<?php } else {?>
-									<i class="fas fa-check-circle status-icon green icon-pad-right"></i> <?=_($data[$key]['ACTION'])?>
-								<?php } ?>
-							<?php } else {?>
-								<?php if ($data[$key]['ACTION'] == 'DROP') { ?>
-									<i class="fas fa-minus-circle icon-pad-right" style=""></i> <?=_($data[$key]['ACTION'])?>
-								<?php } else {?>
-									<i class="fas fa-check-circle icon-pad-right"></i> <?=_($data[$key]['ACTION'])?>
-								<?php } ?>
-							<?php } ?>
-							</a>
-						</b>
-					</div>
-					<!-- START QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left compact-2 text-right">
-						<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-							<div class="actions-panel clearfix" style="padding-right: 10px;">
-								<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Firewall Rule');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-								<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-									<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-										<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-										<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-											<p><?=sprintf($spnd_confirmation,$key)?></p>
-										</div>
-									</a>
-								</div>
-								<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-									<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-										<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-										<input type="hidden" name="delete_url" value="/delete/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-											<p><?=sprintf(_('DELETE_RULE_CONFIRMATION'),$key)?></p>
-										</div>
-									</a>
-								</div>
-							</div>
-						</div>
-					</div>
-					<!-- END QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left wide-3"><b><?php if (!empty($data[$key]['COMMENT'])) echo '' . $data[$key]['COMMENT']; else echo "&nbsp;"; ?></b></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><?=_($data[$key]['PROTOCOL'])?></div>
-					<div class="clearfix l-unit__stat-col--left wide-3 text-center"><b><?=$data[$key]['PORT']?></b></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['IP']?></div>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin firewall chain/action list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_RULE_CONFIRMATION') ;
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_RULE_CONFIRMATION') ;
+      }
+    ?>
+    <div class="l-unit<?php if ($status == 'suspended') echo ' l-unit--suspended';?> animated fadeIn" v_unit_id="<?=$key?>" v_section="firewall"
+      sort-action="<?=$data[$key]['ACTION']?>" sort-protocol="<?=$data[$key]['PROTOCOL']?>" sort-port="<?=$data[$key]['PORT']?>"
+      sort-ip="<?=str_replace('.', '', $data[$key]['IP'])?>" sort-comment="<?=$data[$key]['COMMENT']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div>
+          <div class="clearfix l-unit__stat-col--left super-compact">
+            <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="rule[]" value="<?=$key?>">
+          </div>
+          <div class="clearfix l-unit__stat-col--left wide-1">
+            <b>
+              <a href="/edit/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Firewall Rule');?>">
+              <?php if ($data[$key]['SUSPENDED'] == 'no') { ?>
+                <?php if ($data[$key]['ACTION'] == 'DROP') { ?>
+                  <i class="fas fa-minus-circle status-icon red icon-pad-right"></i> <?=_($data[$key]['ACTION'])?>
+                <?php } else {?>
+                  <i class="fas fa-check-circle status-icon green icon-pad-right"></i> <?=_($data[$key]['ACTION'])?>
+                <?php } ?>
+              <?php } else {?>
+                <?php if ($data[$key]['ACTION'] == 'DROP') { ?>
+                  <i class="fas fa-minus-circle icon-pad-right" style=""></i> <?=_($data[$key]['ACTION'])?>
+                <?php } else {?>
+                  <i class="fas fa-check-circle icon-pad-right"></i> <?=_($data[$key]['ACTION'])?>
+                <?php } ?>
+              <?php } ?>
+              </a>
+            </b>
+          </div>
+          <!-- START QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left compact-2 text-right">
+            <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+              <div class="actions-panel clearfix" style="padding-right: 10px;">
+                <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Firewall Rule');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                  <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                    <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                    <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf($spnd_confirmation,$key)?></p>
+                    </div>
+                  </a>
+                </div>
+                <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                  <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                    <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                    <input type="hidden" name="delete_url" value="/delete/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf(_('DELETE_RULE_CONFIRMATION'),$key)?></p>
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- END QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left wide-3"><b><?php if (!empty($data[$key]['COMMENT'])) echo '' . $data[$key]['COMMENT']; else echo "&nbsp;"; ?></b></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><?=_($data[$key]['PROTOCOL'])?></div>
+          <div class="clearfix l-unit__stat-col--left wide-3 text-center"><b><?=$data[$key]['PORT']?></b></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['IP']?></div>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d firewall rule', '%d firewall rules', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d firewall rule', '%d firewall rules', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_firewall_banlist.html
+++ b/web/templates/pages/list_firewall_banlist.html
@@ -1,100 +1,100 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/firewall/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/add/firewall/banlist/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Ban IP Address');?></a>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td>
-						<form action="/bulk/firewall/banlist/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select name="action" id="">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="delete"><?=_('delete') ?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/firewall/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/add/firewall/banlist/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Ban IP Address');?></a>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td>
+            <form action="/bulk/firewall/banlist/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select name="action" id="">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="delete"><?=_('delete') ?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('IP address');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-4"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Date');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Time');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide text-center"><b><?=_('Comment');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('IP address');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-4"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Date');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Time');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide text-center"><b><?=_('Comment');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin banned IP address list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			$ip = $key;
-		?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="ipchain[]" value="<?=$ip . ':' . $value['CHAIN'] ?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=$ip?></b></div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-								<a id="delete_link_<?=$i?>" class="data-controls do_delete">
-									<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-									<input type="hidden" name="delete_url" value="/delete/firewall/banlist/?ip=<?=$ip?>&chain=<?=$value['CHAIN']?>&token=<?=$_SESSION['token']?>">
-									<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-										<p><?=sprintf(_('DELETE_IP_CONFIRMATION'),$key)?></p>
-									</div>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center compact-5"><?=_($data[$key]['DATE'])?></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-5"><?=$data[$key]['TIME']?></div>
-				<div class="clearfix l-unit__stat-col--left text-center wide"><b><?=_($value['CHAIN'])?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin banned IP address list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      $ip = $key;
+    ?>
+    <div class="l-unit animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="ipchain[]" value="<?=$ip . ':' . $value['CHAIN'] ?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=$ip?></b></div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                <a id="delete_link_<?=$i?>" class="data-controls do_delete">
+                  <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                  <input type="hidden" name="delete_url" value="/delete/firewall/banlist/?ip=<?=$ip?>&chain=<?=$value['CHAIN']?>&token=<?=$_SESSION['token']?>">
+                  <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                    <p><?=sprintf(_('DELETE_IP_CONFIRMATION'),$key)?></p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center compact-5"><?=_($data[$key]['DATE'])?></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-5"><?=$data[$key]['TIME']?></div>
+        <div class="clearfix l-unit__stat-col--left text-center wide"><b><?=_($value['CHAIN'])?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php
-					if ( $i == 0) {
-						echo _('There are currently no banned IP addresses.');
-					} else {
-						printf(ngettext('%d banned IP address', '%d banned IP addresses', $i),$i);
-					}
-				?>
-			</div>
-			<div class="data-count l-unit__col l-unit__col--right back clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php
+          if ( $i == 0) {
+            echo _('There are currently no banned IP addresses.');
+          } else {
+            printf(ngettext('%d banned IP address', '%d banned IP addresses', $i),$i);
+          }
+        ?>
+      </div>
+      <div class="data-count l-unit__col l-unit__col--right back clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_firewall_ipset.html
+++ b/web/templates/pages/list_firewall_ipset.html
@@ -1,108 +1,108 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/firewall/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/add/firewall/ipset/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add IP list');?></a>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td>
-						<form action="/bulk/firewall/ipset/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select name="action" id="">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="delete"><?=_('delete') ?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/firewall/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/add/firewall/ipset/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add IP list');?></a>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td>
+            <form action="/bulk/firewall/ipset/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select name="action" id="">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="delete"><?=_('delete') ?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Ip List Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-4"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Autoupdate');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?=_('Ip Version');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?=_('Date');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?=_('Time');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Ip List Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-4"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Autoupdate');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?=_('Ip Version');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?=_('Date');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-4"><b><?=_('Time');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin firewall IP address list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			$listname = $key;
-		?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="setname[]" value="<?=$listname ?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=$listname?></b></div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left compact-4">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-								<a id="delete_link_<?=$i?>" class="data-controls do_delete">
-									<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-									<input type="hidden" name="delete_url" value="/delete/firewall/ipset/?listname=<?=$listname?>&token=<?=$_SESSION['token']?>">
-									<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-										<p><?=sprintf(_('DELETE_IPSET_CONFIRMATION'), $key)?></p>
-									</div>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center compact-5"><b>
-						<?php if ($data[$key]['AUTOUPDATE'] == 'no') { ?>
-							<i class="fas fa-times-circle status-icon red"></i>
-						<?php } else { ?>
-							<i class="fas fa-check-circle status-icon green"></i>
-						<?php } ?>
-					</b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-4"><?=_($data[$key]['IP_VERSION'])?></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-4"><?=_($data[$key]['DATE'])?></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-4"><?=$data[$key]['TIME']?></div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin firewall IP address list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      $listname = $key;
+    ?>
+    <div class="l-unit animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="setname[]" value="<?=$listname ?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=$listname?></b></div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left compact-4">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                <a id="delete_link_<?=$i?>" class="data-controls do_delete">
+                  <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                  <input type="hidden" name="delete_url" value="/delete/firewall/ipset/?listname=<?=$listname?>&token=<?=$_SESSION['token']?>">
+                  <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                    <p><?=sprintf(_('DELETE_IPSET_CONFIRMATION'), $key)?></p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center compact-5"><b>
+            <?php if ($data[$key]['AUTOUPDATE'] == 'no') { ?>
+              <i class="fas fa-times-circle status-icon red"></i>
+            <?php } else { ?>
+              <i class="fas fa-check-circle status-icon green"></i>
+            <?php } ?>
+          </b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-4"><?=_($data[$key]['IP_VERSION'])?></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-4"><?=_($data[$key]['DATE'])?></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-4"><?=$data[$key]['TIME']?></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php
-					if ( $i == 0) {
-						echo _('There are currently no IP lists defined.');
-					} else {
-						printf(ngettext('%d Ipset list', '%d Ipset lists', $i),$i);
-					}
-				?>
-			</div>
-			<div class="data-count l-unit__col l-unit__col--right back clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php
+          if ( $i == 0) {
+            echo _('There are currently no IP lists defined.');
+          } else {
+            printf(ngettext('%d Ipset list', '%d Ipset lists', $i),$i);
+          }
+        ?>
+      </div>
+      <div class="data-count l-unit__col l-unit__col--right back clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_ip.html
+++ b/web/templates/pages/list_ip.html
@@ -1,115 +1,115 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/add/ip/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add IP');?></a>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-ip"><span class="name"><?=_('ip');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-netmask"><span class="name"><?=_('Netmask');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-interface"><span class="name"><?=_('Interface');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-domains" sort_as_int="1"><span class="name"><?=_('Domains');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-owner"><span class="name"><?=_('Owner');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span><b><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></b></span>
-					</td>
-					<td>
-						<form action="/bulk/ip/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select name="action" id="">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="reread IP"><?=_('reread IP');?></option>
-									<option value="delete"><?=_('delete');?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/add/ip/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add IP');?></a>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-ip"><span class="name"><?=_('ip');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-netmask"><span class="name"><?=_('Netmask');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-interface"><span class="name"><?=_('Interface');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-domains" sort_as_int="1"><span class="name"><?=_('Domains');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-owner"><span class="name"><?=_('Owner');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span><b><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></b></span>
+          </td>
+          <td>
+            <form action="/bulk/ip/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select name="action" id="">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="reread IP"><?=_('reread IP');?></option>
+                  <option value="delete"><?=_('delete');?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('IP Address');?></b></div>
-				<div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Netmask');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Interface');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Status');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Domains');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Owner');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('IP Address');?></b></div>
+        <div class="clearfix l-unit__stat-col--left compact text-right"><b>&nbsp;</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-5"><b><?=_('Netmask');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Interface');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Status');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Domains');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Owner');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<!-- Begin IP address list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-		?>
-		<div class="l-unit animated fadeIn" v_unit_id="<?=$key?>"
-			v_section="ip" sort-ip="<?=str_replace('.', '', $key)?>" sort-date="<?=strtotime($data[$key]['DATE'] .' '. $data[$key]['TIME'] )?>"
-			sort-netmask="<?=str_replace('.', '', $data[$key]['NETMASK'])?>" sort-interface="<?=$data[$key]['INTERFACE']?>" sort-domains="<?=$data[$key]['U_WEB_DOMAINS']?>"
-			sort-owner="<?=$data[$key]['OWNER']?>">
+  <!-- Begin IP address list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+    ?>
+    <div class="l-unit animated fadeIn" v_unit_id="<?=$key?>"
+      v_section="ip" sort-ip="<?=str_replace('.', '', $key)?>" sort-date="<?=strtotime($data[$key]['DATE'] .' '. $data[$key]['TIME'] )?>"
+      sort-netmask="<?=str_replace('.', '', $data[$key]['NETMASK'])?>" sort-interface="<?=$data[$key]['INTERFACE']?>" sort-domains="<?=$data[$key]['U_WEB_DOMAINS']?>"
+      sort-owner="<?=$data[$key]['OWNER']?>">
 
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="ip[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><a href="/edit/ip/?ip=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing IP Address');?>"><?=$key?> <?php if (!empty($data[$key]['NAT'])) echo ' → ' . $data[$key]['NAT'] . ''; ?></a></b>
-				</div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left compact text-right">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/ip/?ip=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing IP Address');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-							<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-								<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-									<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-									<input type="hidden" name="delete_url" value="/delete/ip/?ip=<?=$key?>&token=<?=$_SESSION['token']?>">
-									<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-										<p><?=sprintf(_('DELETE_IP_CONFIRMATION'),$key)?></p>
-									</div>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center compact-5"><?=$data[$key]['NETMASK']?></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['INTERFACE']?></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_($data[$key]['STATUS'])?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['U_WEB_DOMAINS']?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['OWNER']?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="ip[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><a href="/edit/ip/?ip=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing IP Address');?>"><?=$key?> <?php if (!empty($data[$key]['NAT'])) echo ' → ' . $data[$key]['NAT'] . ''; ?></a></b>
+        </div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left compact text-right">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/ip/?ip=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing IP Address');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+              <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                  <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                  <input type="hidden" name="delete_url" value="/delete/ip/?ip=<?=$key?>&token=<?=$_SESSION['token']?>">
+                  <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                    <p><?=sprintf(_('DELETE_IP_CONFIRMATION'),$key)?></p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center compact-5"><?=$data[$key]['NETMASK']?></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><?=$data[$key]['INTERFACE']?></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_($data[$key]['STATUS'])?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['U_WEB_DOMAINS']?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['OWNER']?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d IP address', '%d IP addresses', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d IP address', '%d IP addresses', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_key.html
+++ b/web/templates/pages/list_key.html
@@ -1,72 +1,72 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/user/?token=<?=$_SESSION['token']?>"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/user/?token=<?=$_SESSION['token']?>"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
             <?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && ($_GET['user'] !== 'admin')) { ?>
             <a href="/add/key/?user=<?=htmlentities($_GET['user']);?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add SSH Key');?></a>
             <?php } else { ?>
-			<a href="/add/key/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add SSH Key');?></a>
+      <a href="/add/key/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add SSH Key');?></a>
             <?php } ?>
-		</div>
-	</div>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('SSH_ID');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-2">
-				&nbsp;
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-7"><b><?=_('SSH KEY');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('SSH_ID');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-2">
+        &nbsp;
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-7"><b><?=_('SSH KEY');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin SSH key list item loop -->
-	<?php
-		$i = 0;
-			foreach ($data as $key => $value) {
-			++$i;
-		?>
-		<div class="l-unit header animated fadeIn" style="<?php if ($data[$key]['ID'] === 'filemanager.ssh.key'){ echo 'display: none;'; }?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=htmlspecialchars($data[$key]['ID']);?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-left compact-2">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-								<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-									<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-									<?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && ($_GET['user'] !== 'admin')) { ?>
-										<input type="hidden" name="delete_url" value="/delete/key/?user=<?=htmlentities($_GET['user']);?>&key=<?=$key?>&token=<?=$_SESSION['token']?>">
-									<?php } else { ?>
-										<input type="hidden" name="delete_url" value="/delete/key/?key=<?=$key?>&token=<?=$_SESSION['token']?>">
-									<?php } ?>
-									<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-										<p><?=sprintf(_('DELETE_KEY_CONFIRM'),$key)?></p>
-									</div>
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-7"><b><?=htmlspecialchars($data[$key]['KEY'], ENT_QUOTES);?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin SSH key list item loop -->
+  <?php
+    $i = 0;
+      foreach ($data as $key => $value) {
+      ++$i;
+    ?>
+    <div class="l-unit header animated fadeIn" style="<?php if ($data[$key]['ID'] === 'filemanager.ssh.key'){ echo 'display: none;'; }?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=htmlspecialchars($data[$key]['ID']);?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-left compact-2">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                  <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                  <?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && ($_GET['user'] !== 'admin')) { ?>
+                    <input type="hidden" name="delete_url" value="/delete/key/?user=<?=htmlentities($_GET['user']);?>&key=<?=$key?>&token=<?=$_SESSION['token']?>">
+                  <?php } else { ?>
+                    <input type="hidden" name="delete_url" value="/delete/key/?key=<?=$key?>&token=<?=$_SESSION['token']?>">
+                  <?php } ?>
+                  <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                    <p><?=sprintf(_('DELETE_KEY_CONFIRM'),$key)?></p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-7"><b><?=htmlspecialchars($data[$key]['KEY'], ENT_QUOTES);?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d SSH Key', '%d SSH Keys', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d SSH Key', '%d SSH Keys', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_log.html
+++ b/web/templates/pages/list_log.html
@@ -1,56 +1,56 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin')) {?>
-				<a href="/list/user/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php } else if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) === 'system')) { ?>
-				<a href="/list/server/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php } else { ?>
-				<?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && ($_GET['user'] !== 'admin')) { ?>
-					<a href="/edit/user/?user=<?=htmlentities($_GET['user']); ?>&token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-				<?php } else { ?>
-					<a href="/edit/user/?token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-				<?php } ?>
-			<?php } ?>
-			<?php if ($_SESSION['DEMO_MODE'] != "yes"){
-			if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) !== 'admin')) { ?>
-				<?php if (($_SESSION['userContext'] === 'admin') && ($_GET['user'] != '') && (htmlentities($_GET['user']) !== 'admin')) { ?>
-					<?php if (htmlentities($_GET['user']) !== 'system') {?>
-						<a href="/list/log/auth/?user=<?=htmlentities($_GET['user']); ?>&token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr" title="<?=_('Login history');?>"><i class="fas fa-binoculars status-icon green"></i><?=_('Login history');?></a>
-					<?php } ?>
-				<?php } else { ?>
-					<a href="/list/log/auth/" id="btn-back" class="ui-button cancel" dir="ltr" title="<?=_('Login history');?>"><i class="fas fa-binoculars status-icon green"></i><?=_('Login history');?></a>
-				<?php } ?>
-			<?php } ?>
-			<?php if ($_SESSION['userContext'] === 'user') {?>
-				<a href="/list/log/auth/" id="btn-back" class="ui-button cancel" dir="ltr" title="<?=_('Login history');?>"><i class="fas fa-binoculars status-icon green"></i><?=_('Login history');?></a>
-			<?php }
-			} ?>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-			<a href="javascript:location.reload();" class="ui-button cancel" dir="ltr"><i class="fas fa-redo status-icon green"></i><?=_('Refresh');?></a>
-			<?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {?>
-				<!-- Hide delete buttons-->
-			<?php } else { ?>
-				<?php if (($_SESSION['userContext'] === 'admin') || (($_SESSION['userContext'] === 'user') && ($_SESSION['POLICY_USER_DELETE_LOGS'] !== 'no'))) {?>
-					<div class="actions-panel display-inline-block" key-action="js">
-						<a class="data-controls do_delete ui-button danger cancel">
-							<i class="do_delete fas fa-times-circle status-icon red"></i><?=_('Delete');?>
-							<?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user']))) {?>
-								<input type="hidden" name="delete_url" value="/delete/log/?user=<?=htmlentities($_GET['user']);?>&token=<?=$_SESSION['token']?>">
-							<?php } else { ?>
-								<input type="hidden" name="delete_url" value="/delete/log/?token=<?=$_SESSION['token']?>">
-							<?php } ?>
-							<div class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-								<p><?=_('DELETE_LOGS_CONFIRMATION');?></p>
-							</div>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin')) {?>
+        <a href="/list/user/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php } else if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) === 'system')) { ?>
+        <a href="/list/server/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php } else { ?>
+        <?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && ($_GET['user'] !== 'admin')) { ?>
+          <a href="/edit/user/?user=<?=htmlentities($_GET['user']); ?>&token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+        <?php } else { ?>
+          <a href="/edit/user/?token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+        <?php } ?>
+      <?php } ?>
+      <?php if ($_SESSION['DEMO_MODE'] != "yes"){
+      if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) !== 'admin')) { ?>
+        <?php if (($_SESSION['userContext'] === 'admin') && ($_GET['user'] != '') && (htmlentities($_GET['user']) !== 'admin')) { ?>
+          <?php if (htmlentities($_GET['user']) !== 'system') {?>
+            <a href="/list/log/auth/?user=<?=htmlentities($_GET['user']); ?>&token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr" title="<?=_('Login history');?>"><i class="fas fa-binoculars status-icon green"></i><?=_('Login history');?></a>
+          <?php } ?>
+        <?php } else { ?>
+          <a href="/list/log/auth/" id="btn-back" class="ui-button cancel" dir="ltr" title="<?=_('Login history');?>"><i class="fas fa-binoculars status-icon green"></i><?=_('Login history');?></a>
+        <?php } ?>
+      <?php } ?>
+      <?php if ($_SESSION['userContext'] === 'user') {?>
+        <a href="/list/log/auth/" id="btn-back" class="ui-button cancel" dir="ltr" title="<?=_('Login history');?>"><i class="fas fa-binoculars status-icon green"></i><?=_('Login history');?></a>
+      <?php }
+      } ?>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+      <a href="javascript:location.reload();" class="ui-button cancel" dir="ltr"><i class="fas fa-redo status-icon green"></i><?=_('Refresh');?></a>
+      <?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {?>
+        <!-- Hide delete buttons-->
+      <?php } else { ?>
+        <?php if (($_SESSION['userContext'] === 'admin') || (($_SESSION['userContext'] === 'user') && ($_SESSION['POLICY_USER_DELETE_LOGS'] !== 'no'))) {?>
+          <div class="actions-panel display-inline-block" key-action="js">
+            <a class="data-controls do_delete ui-button danger cancel">
+              <i class="do_delete fas fa-times-circle status-icon red"></i><?=_('Delete');?>
+              <?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user']))) {?>
+                <input type="hidden" name="delete_url" value="/delete/log/?user=<?=htmlentities($_GET['user']);?>&token=<?=$_SESSION['token']?>">
+              <?php } else { ?>
+                <input type="hidden" name="delete_url" value="/delete/log/?token=<?=$_SESSION['token']?>">
+              <?php } ?>
+              <div class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                <p><?=_('DELETE_LOGS_CONFIRMATION');?></p>
+              </div>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -58,52 +58,52 @@
 
 <div class="l-center units">
 
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact text-center">&nbsp;</div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('Date');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-2"><b><?=_('Time');?></b></div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('Category');?></b></div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('Message');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact text-center">&nbsp;</div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('Date');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-2"><b><?=_('Time');?></b></div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('Category');?></b></div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('Message');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin log history entry loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
+  <!-- Begin log history entry loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
 
-			if ($data[$key]['LEVEL'] === 'Info') {
-				$level_icon = 'fa-info-circle status-icon blue';
-			}
-			if ($data[$key]['LEVEL'] === 'Warning') {
-				$level_icon = 'fa-exclamation-triangle status-icon orange';
-			}
-			if ($data[$key]['LEVEL'] === 'Error') {
-				$level_icon = 'fa-times-circle status-icon red';
-			}
-		?>
-		<div class="l-unit header animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact text-center">
-					<i class="fas <?=$level_icon;?>"></i>
-				</div>
-				<div class="clearfix l-unit__stat-col--left"><b><?=translate_date($data[$key]['DATE'])?></b></div>
-				<div class="clearfix l-unit__stat-col--left compact-2"><b><?=htmlspecialchars($data[$key]['TIME']);?></b></div>
-				<div class="clearfix l-unit__stat-col--left"><b><?=htmlspecialchars($data[$key]['CATEGORY']);?></b></div>
-				<div class="clearfix l-unit__stat-col--left wide-7"><?=htmlspecialchars($data[$key]['MESSAGE'], ENT_QUOTES);?></div>
-			</div>
-		</div>
-	<?php } ?>
+      if ($data[$key]['LEVEL'] === 'Info') {
+        $level_icon = 'fa-info-circle status-icon blue';
+      }
+      if ($data[$key]['LEVEL'] === 'Warning') {
+        $level_icon = 'fa-exclamation-triangle status-icon orange';
+      }
+      if ($data[$key]['LEVEL'] === 'Error') {
+        $level_icon = 'fa-times-circle status-icon red';
+      }
+    ?>
+    <div class="l-unit header animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact text-center">
+          <i class="fas <?=$level_icon;?>"></i>
+        </div>
+        <div class="clearfix l-unit__stat-col--left"><b><?=translate_date($data[$key]['DATE'])?></b></div>
+        <div class="clearfix l-unit__stat-col--left compact-2"><b><?=htmlspecialchars($data[$key]['TIME']);?></b></div>
+        <div class="clearfix l-unit__stat-col--left"><b><?=htmlspecialchars($data[$key]['CATEGORY']);?></b></div>
+        <div class="clearfix l-unit__stat-col--left wide-7"><?=htmlspecialchars($data[$key]['MESSAGE'], ENT_QUOTES);?></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d log record', '%d log records', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d log record', '%d log records', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_log_auth.html
+++ b/web/templates/pages/list_log_auth.html
@@ -1,96 +1,96 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && (htmlentities($_GET['user']) !== 'admin')) { ?>
-				<a href="/list/log/?user=<?=htmlentities($_GET['user']); ?>&token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php } else { ?>
-				<a href="/list/log/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php } ?>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-			<a href="javascript:location.reload();" class="ui-button cancel" dir="ltr"><i class="fas fa-redo status-icon green"></i><?=_('Refresh');?></a>
-			<?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {?>
-				<!-- Hide delete buttons-->
-			<?php } else { ?>
-				<?php if (($_SESSION['userContext'] === 'admin') || (($_SESSION['userContext'] === 'user') && ($_SESSION['POLICY_USER_DELETE_LOGS'] !== 'no'))) {?>
-					<div class="actions-panel display-inline-block" key-action="js">
-						<a class="data-controls do_delete ui-button danger cancel">
-							<i class="do_delete fas fa-times-circle status-icon red"></i><?=_('Delete');?>
-							<?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user']))) {?>
-								<input type="hidden" name="delete_url" value="/delete/log/auth/?user=<?=htmlentities($_GET['user']);?>&token=<?=$_SESSION['token']?>">
-							<?php } else { ?>
-								<input type="hidden" name="delete_url" value="/delete/log/auth/?token=<?=$_SESSION['token']?>">
-							<?php } ?>
-							<div class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-								<p><?=_('DELETE_LOGS_CONFIRMATION');?></p>
-							</div>
-						</a>
-					</div>
-				<?php } ?>
-			<?php } ?>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user'])) && (htmlentities($_GET['user']) !== 'admin')) { ?>
+        <a href="/list/log/?user=<?=htmlentities($_GET['user']); ?>&token=<?=$_SESSION['token']?>" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php } else { ?>
+        <a href="/list/log/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php } ?>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+      <a href="javascript:location.reload();" class="ui-button cancel" dir="ltr"><i class="fas fa-redo status-icon green"></i><?=_('Refresh');?></a>
+      <?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['look'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {?>
+        <!-- Hide delete buttons-->
+      <?php } else { ?>
+        <?php if (($_SESSION['userContext'] === 'admin') || (($_SESSION['userContext'] === 'user') && ($_SESSION['POLICY_USER_DELETE_LOGS'] !== 'no'))) {?>
+          <div class="actions-panel display-inline-block" key-action="js">
+            <a class="data-controls do_delete ui-button danger cancel">
+              <i class="do_delete fas fa-times-circle status-icon red"></i><?=_('Delete');?>
+              <?php if (($_SESSION['userContext'] === 'admin') && (isset($_GET['user']))) {?>
+                <input type="hidden" name="delete_url" value="/delete/log/auth/?user=<?=htmlentities($_GET['user']);?>&token=<?=$_SESSION['token']?>">
+              <?php } else { ?>
+                <input type="hidden" name="delete_url" value="/delete/log/auth/?token=<?=$_SESSION['token']?>">
+              <?php } ?>
+              <div class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                <p><?=_('DELETE_LOGS_CONFIRMATION');?></p>
+              </div>
+            </a>
+          </div>
+        <?php } ?>
+      <?php } ?>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left text-center">
-				<b><?=_('Status');?></b>
-			</div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('Date');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-2"><b><?=_('Time');?></b></div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('IP address');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-7"><b><?=_('Browser');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left text-center">
+        <b><?=_('Status');?></b>
+      </div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('Date');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-2"><b><?=_('Time');?></b></div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('IP address');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-7"><b><?=_('Browser');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin log history entry loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
+  <!-- Begin log history entry loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
 
-			if ($data[$key]['ACTION'] == 'login') {
-				if ($data[$key]['ACTIVE'] === 'yes') {
-					$action_icon = 'fa-sign-in-alt status-icon maroon';
-				} else {
-					$action_icon = ' fa-sign-in-alt status-icon dim';
-				}
-			}
-			if ($data[$key]['STATUS'] == 'success')  {
-					$status_icon = 'fa-check-circle status-icon green';
-					$status_title = 'Success';
-			} else {
-					$status_icon = 'fa-minus-circle status-icon red';
-					$status_title = 'Failed';
-			}
-		?>
-		<div class="l-unit header animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left text-center">
-					<i class="fas <?=$status_icon;?> icon-pad-right" title="<?=$status_title;?>"></i>
-				</div>
-				<div class="clearfix l-unit__stat-col--left"><b><?=translate_date($data[$key]['DATE'])?></b></div>
-				<div class="clearfix l-unit__stat-col--left compact-2"><b><?=htmlspecialchars($data[$key]['TIME']);?></b></div>
-				<div class="clearfix l-unit__stat-col--left"><?=htmlspecialchars($data[$key]['IP']);?></div>
-				<div class="clearfix l-unit__stat-col--left wide-7"><?=htmlspecialchars($data[$key]['USER_AGENT']);?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+      if ($data[$key]['ACTION'] == 'login') {
+        if ($data[$key]['ACTIVE'] === 'yes') {
+          $action_icon = 'fa-sign-in-alt status-icon maroon';
+        } else {
+          $action_icon = ' fa-sign-in-alt status-icon dim';
+        }
+      }
+      if ($data[$key]['STATUS'] == 'success')  {
+          $status_icon = 'fa-check-circle status-icon green';
+          $status_title = 'Success';
+      } else {
+          $status_icon = 'fa-minus-circle status-icon red';
+          $status_title = 'Failed';
+      }
+    ?>
+    <div class="l-unit header animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left text-center">
+          <i class="fas <?=$status_icon;?> icon-pad-right" title="<?=$status_title;?>"></i>
+        </div>
+        <div class="clearfix l-unit__stat-col--left"><b><?=translate_date($data[$key]['DATE'])?></b></div>
+        <div class="clearfix l-unit__stat-col--left compact-2"><b><?=htmlspecialchars($data[$key]['TIME']);?></b></div>
+        <div class="clearfix l-unit__stat-col--left"><?=htmlspecialchars($data[$key]['IP']);?></div>
+        <div class="clearfix l-unit__stat-col--left wide-7"><?=htmlspecialchars($data[$key]['USER_AGENT']);?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit_col l-unit_col--right clearfix">
-				<?php printf(ngettext('%d log record', '%d log records', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit_col l-unit_col--right clearfix">
+        <?php printf(ngettext('%d log record', '%d log records', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_mail.html
+++ b/web/templates/pages/list_mail.html
@@ -1,235 +1,235 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/mail/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Mail Domain');?></a>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-accounts" sort_as_int="1"><span class="name"><?=_('Accounts');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') {?>
-						<td>
-							<form action="/bulk/mail/" method="post" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select name="action" id="">
-										<option value=""><?=_('apply to selected');?></option>
-										<?php if ($_SESSION['userContext'] === 'admin') {?>
-											<option value="rebuild"><?=_('rebuild');?></option>
-										<?php } ?>
-										<option value="suspend"><?=_('suspend');?></option>
-										<option value="unsuspend"><?=_('unsuspend');?></option>
-										<option value="delete"><?=_('delete');?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/mail/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Mail Domain');?></a>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-accounts" sort_as_int="1"><span class="name"><?=_('Accounts');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') {?>
+            <td>
+              <form action="/bulk/mail/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <?php if ($_SESSION['userContext'] === 'admin') {?>
+                      <option value="rebuild"><?=_('rebuild');?></option>
+                    <?php } ?>
+                    <option value="suspend"><?=_('suspend');?></option>
+                    <option value="unsuspend"><?=_('unsuspend');?></option>
+                    <option value="delete"><?=_('delete');?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-right compact-5"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-2"><b><?=_('Accounts');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-2"><b><?=_('Disk');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('Antivirus');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('AntiSpam');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('DKIM');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('SSL');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-right compact-5"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-2"><b><?=_('Accounts');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-2"><b><?=_('Disk');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('Antivirus');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('AntiSpam');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('DKIM');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-3"><b><?=_('SSL');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin mail domain list item loop -->
-	<?php
-		list($http_host, $port) = explode(':', $_SERVER["HTTP_HOST"].":");
-		$webmail = "webmail";
-		if (!empty($_SESSION['WEBMAIL_ALIAS'])) $webmail = $_SESSION['WEBMAIL_ALIAS'];
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
-				if ($data[$key]['ANTIVIRUS'] == 'no') {
-					$antivirus_icon = 'fa-times-circle';
-				} else {
-					$antivirus_icon = 'fa-check-circle';
-				}
-				if ($data[$key]['ANTISPAM'] == 'no') {
-					$antispam_icon = 'fa-times-circle';
-				} else {
-					$antispam_icon = 'fa-check-circle';
-				}
-				if ($data[$key]['DKIM'] == 'no') {
-					$dkim_icon = 'fa-times-circle';
-				} else {
-					$dkim_icon = 'fa-check-circle';
-				}
-				if ($data[$key]['SSL'] == 'no') {
-					$ssl_icon = 'fa-times-circle';
-				} else {
-					$ssl_icon = 'fa-check-circle';
-				}
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
-				if ($data[$key]['ANTIVIRUS'] == 'no') {
-					$antivirus_icon = 'fa-times-circle status-icon red';
-				} else {
-					$antivirus_icon = 'fa-check-circle status-icon green';
-				}
-				if ($data[$key]['ANTISPAM'] == 'no') {
-					$antispam_icon = 'fa-times-circle status-icon red';
-				} else {
-					$antispam_icon = 'fa-check-circle status-icon green';
-				}
-				if ($data[$key]['DKIM'] == 'no') {
-					$dkim_icon = 'fa-times-circle status-icon red';
-				} else {
-					$dkim_icon = 'fa-check-circle status-icon green';
-				}
-				if ($data[$key]['SSL'] == 'no') {
-					$ssl_icon = 'fa-times-circle status-icon red';
-				} else {
-					$ssl_icon = 'fa-check-circle status-icon green';
-				}
-			}
-			if (empty($data[$key]['CATCHALL'])) {
-				$data[$key]['CATCHALL'] = '/dev/null';
-			}
-		?>
-		<div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=$key?>" v_section="mail"
-			sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>" sort-disk="<?=$data[$key]['U_DISK']?>"
-			sort-accounts="<?=$data[$key]['ACCOUNTS']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div>
-					<div class="clearfix l-unit__stat-col--left super-compact">
-						<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="domain[]" value="<?=$key?>" <?=$display_mode;?>>
-					</div>
-					<div class="clearfix l-unit__stat-col--left wide-3 truncate"><b><a href="?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('mail accounts');?>: <?=$key?>"><?=$key?></a></b></div>
-					<!-- START QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left text-right compact-5">
-						<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-							<div class="actions-panel clearfix">
-								<?php if ($read_only === 'true') {?>
-									<!-- Restrict ability to edit, delete, or suspend domain items when impersonating 'admin' account -->
-									<div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('mail accounts');?>"><i class="fas fa-users status-icon blue status-icon dim"></i></a></div>
-									<div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="?domain=<?=$key?>&dns=1&token=<?=$_SESSION['token']?>" title="<?=_('DNS records mail');?>"><i class="fas fa-atlas status-icon blue status-icon dim"></i></a></div>
-									<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-										<div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$webmail;?>.<?=$key?>/" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-paper-plane status-icon lightblue status-icon dim"></i></a></div>
-									<?php } ?>
-								<?php } else { ?>
-									<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-										<div class="actions-panel__col actions-panel__logs shortcut-n" key-action="href"><a href="/add/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Add Mail Account');?>"><i class="fas fa-plus-circle status-icon green status-icon dim"></i></a></div>
-										<?php if($_SESSION['WEBMAIL_SYSTEM']){?>
-											<?php if (!empty($data[$key]['WEBMAIL'])) {?>
-												<div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$webmail;?>.<?=$key?>/" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-paper-plane status-icon lightblue status-icon dim"></i></a></div>
-											<?php } ?>
-										<?php } ?>
-										<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Mail Domain');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-									<?php } ?>
-									<div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="?domain=<?=$key?>&dns=1&token=<?=$_SESSION['token']?>" title="<?=_('DNS records');?>"><i class="fas fa-atlas status-icon blue status-icon dim"></i></a></div>
-									<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-										<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-											<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-											<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
-											<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-												<p><?=sprintf($spnd_confirmation,$key)?></p>
-											</div>
-										</a>
-									</div>
-									<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-										<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-											<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-											<input type="hidden" name="delete_url" value="/delete/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
-											<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-												<p><?=sprintf(_('DELETE_DOMAIN_CONFIRMATION'),$key)?></p>
-											</div>
-										</a>
-									</div>
-								<?php } ?>
-							</div>
-						</div>
-					</div>
-					<!-- END QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left text-center compact-2"><b>
-							<?php
-								if ($data[$key]['ACCOUNTS']) {
-									$mail_accounts = htmlentities($data[$key]['ACCOUNTS']);
-								} else {
-									$mail_accounts = '0';
-								}
-							?>
-							<span><?=$mail_accounts;?></span>
-						</b>
-					</div>
-					<div class="clearfix l-unit__stat-col--left text-center compact-2"><b>
-							<?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span>
-					</div>
-					<div class="clearfix l-unit__stat-col--left text-center compact-3">
-						<i class="fas <?=$antivirus_icon;?>"></i>
-					</div>
-					<div class="clearfix l-unit__stat-col--left text-center compact-3">
-						<i class="fas <?=$antispam_icon;?>"></i>
-					</div>
-					<div class="clearfix l-unit__stat-col--left text-center compact-3">
-						<i class="fas <?=$dkim_icon;?>"></i>
-					</div>
-					<div class="clearfix l-unit__stat-col--left text-center compact-3">
-						<i class="fas <?=$ssl_icon;?>"></i>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin mail domain list item loop -->
+  <?php
+    list($http_host, $port) = explode(':', $_SERVER["HTTP_HOST"].":");
+    $webmail = "webmail";
+    if (!empty($_SESSION['WEBMAIL_ALIAS'])) $webmail = $_SESSION['WEBMAIL_ALIAS'];
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
+        if ($data[$key]['ANTIVIRUS'] == 'no') {
+          $antivirus_icon = 'fa-times-circle';
+        } else {
+          $antivirus_icon = 'fa-check-circle';
+        }
+        if ($data[$key]['ANTISPAM'] == 'no') {
+          $antispam_icon = 'fa-times-circle';
+        } else {
+          $antispam_icon = 'fa-check-circle';
+        }
+        if ($data[$key]['DKIM'] == 'no') {
+          $dkim_icon = 'fa-times-circle';
+        } else {
+          $dkim_icon = 'fa-check-circle';
+        }
+        if ($data[$key]['SSL'] == 'no') {
+          $ssl_icon = 'fa-times-circle';
+        } else {
+          $ssl_icon = 'fa-check-circle';
+        }
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
+        if ($data[$key]['ANTIVIRUS'] == 'no') {
+          $antivirus_icon = 'fa-times-circle status-icon red';
+        } else {
+          $antivirus_icon = 'fa-check-circle status-icon green';
+        }
+        if ($data[$key]['ANTISPAM'] == 'no') {
+          $antispam_icon = 'fa-times-circle status-icon red';
+        } else {
+          $antispam_icon = 'fa-check-circle status-icon green';
+        }
+        if ($data[$key]['DKIM'] == 'no') {
+          $dkim_icon = 'fa-times-circle status-icon red';
+        } else {
+          $dkim_icon = 'fa-check-circle status-icon green';
+        }
+        if ($data[$key]['SSL'] == 'no') {
+          $ssl_icon = 'fa-times-circle status-icon red';
+        } else {
+          $ssl_icon = 'fa-check-circle status-icon green';
+        }
+      }
+      if (empty($data[$key]['CATCHALL'])) {
+        $data[$key]['CATCHALL'] = '/dev/null';
+      }
+    ?>
+    <div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended'; ?> animated fadeIn" v_unit_id="<?=$key?>" v_section="mail"
+      sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>" sort-disk="<?=$data[$key]['U_DISK']?>"
+      sort-accounts="<?=$data[$key]['ACCOUNTS']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div>
+          <div class="clearfix l-unit__stat-col--left super-compact">
+            <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="domain[]" value="<?=$key?>" <?=$display_mode;?>>
+          </div>
+          <div class="clearfix l-unit__stat-col--left wide-3 truncate"><b><a href="?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('mail accounts');?>: <?=$key?>"><?=$key?></a></b></div>
+          <!-- START QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left text-right compact-5">
+            <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+              <div class="actions-panel clearfix">
+                <?php if ($read_only === 'true') {?>
+                  <!-- Restrict ability to edit, delete, or suspend domain items when impersonating 'admin' account -->
+                  <div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('mail accounts');?>"><i class="fas fa-users status-icon blue status-icon dim"></i></a></div>
+                  <div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="?domain=<?=$key?>&dns=1&token=<?=$_SESSION['token']?>" title="<?=_('DNS records mail');?>"><i class="fas fa-atlas status-icon blue status-icon dim"></i></a></div>
+                  <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                    <div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$webmail;?>.<?=$key?>/" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-paper-plane status-icon lightblue status-icon dim"></i></a></div>
+                  <?php } ?>
+                <?php } else { ?>
+                  <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                    <div class="actions-panel__col actions-panel__logs shortcut-n" key-action="href"><a href="/add/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Add Mail Account');?>"><i class="fas fa-plus-circle status-icon green status-icon dim"></i></a></div>
+                    <?php if($_SESSION['WEBMAIL_SYSTEM']){?>
+                      <?php if (!empty($data[$key]['WEBMAIL'])) {?>
+                        <div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$webmail;?>.<?=$key?>/" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-paper-plane status-icon lightblue status-icon dim"></i></a></div>
+                      <?php } ?>
+                    <?php } ?>
+                    <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Mail Domain');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                  <?php } ?>
+                  <div class="actions-panel__col actions-panel__edit shortcut-l" key-action="href"><a href="?domain=<?=$key?>&dns=1&token=<?=$_SESSION['token']?>" title="<?=_('DNS records');?>"><i class="fas fa-atlas status-icon blue status-icon dim"></i></a></div>
+                  <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                    <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                      <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                      <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
+                      <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                        <p><?=sprintf($spnd_confirmation,$key)?></p>
+                      </div>
+                    </a>
+                  </div>
+                  <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                    <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                      <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                      <input type="hidden" name="delete_url" value="/delete/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
+                      <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                        <p><?=sprintf(_('DELETE_DOMAIN_CONFIRMATION'),$key)?></p>
+                      </div>
+                    </a>
+                  </div>
+                <?php } ?>
+              </div>
+            </div>
+          </div>
+          <!-- END QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left text-center compact-2"><b>
+              <?php
+                if ($data[$key]['ACCOUNTS']) {
+                  $mail_accounts = htmlentities($data[$key]['ACCOUNTS']);
+                } else {
+                  $mail_accounts = '0';
+                }
+              ?>
+              <span><?=$mail_accounts;?></span>
+            </b>
+          </div>
+          <div class="clearfix l-unit__stat-col--left text-center compact-2"><b>
+              <?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span>
+          </div>
+          <div class="clearfix l-unit__stat-col--left text-center compact-3">
+            <i class="fas <?=$antivirus_icon;?>"></i>
+          </div>
+          <div class="clearfix l-unit__stat-col--left text-center compact-3">
+            <i class="fas <?=$antispam_icon;?>"></i>
+          </div>
+          <div class="clearfix l-unit__stat-col--left text-center compact-3">
+            <i class="fas <?=$dkim_icon;?>"></i>
+          </div>
+          <div class="clearfix l-unit__stat-col--left text-center compact-3">
+            <i class="fas <?=$ssl_icon;?>"></i>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d mail domain', '%d mail domains', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d mail domain', '%d mail domains', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_mail_acc.html
+++ b/web/templates/pages/list_mail_acc.html
@@ -1,214 +1,214 @@
 <?php
-	$v_webmail_alias = "webmail";
-	if (!empty($_SESSION['WEBMAIL_ALIAS'])) $v_webmail_alias = $_SESSION['WEBMAIL_ALIAS'];
+  $v_webmail_alias = "webmail";
+  if (!empty($_SESSION['WEBMAIL_ALIAS'])) $v_webmail_alias = $_SESSION['WEBMAIL_ALIAS'];
 ?>
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/mail/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php if ($read_only !== 'true') { ?>
-				<a href="/add/mail/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Mail Account');?></a>
-				<a href="/edit/mail/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-pencil-alt status-icon blue"></i><?=_('Editing Mail Domain');?></a>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-quota" sort_as_int="1"><span class="name"><?=_('Quota');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') { ?>
-						<td>
-							<form action="/bulk/mail/" method="post" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<input type="hidden" value="<?=htmlspecialchars($_GET['domain']); ?>" name="domain">
-								<div class="l-select">
-									<select name="action" id="">
-										<option value=""><?=_('apply to selected');?></option>
-										<option value="suspend"><?=_('suspend');?></option>
-										<option value="unsuspend"><?=_('unsuspend');?></option>
-										<option value="delete"><?=_('delete');?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/mail/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php if ($read_only !== 'true') { ?>
+        <a href="/add/mail/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Mail Account');?></a>
+        <a href="/edit/mail/?domain=<?=htmlentities($_GET['domain'])?>" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-pencil-alt status-icon blue"></i><?=_('Editing Mail Domain');?></a>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-quota" sort_as_int="1"><span class="name"><?=_('Quota');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') { ?>
+            <td>
+              <form action="/bulk/mail/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <input type="hidden" value="<?=htmlspecialchars($_GET['domain']); ?>" name="domain">
+                <div class="l-select">
+                  <select name="action" id="">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <option value="suspend"><?=_('suspend');?></option>
+                    <option value="unsuspend"><?=_('unsuspend');?></option>
+                    <option value="delete"><?=_('delete');?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-right compact-4"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Disk');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Quota');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Aliases');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Forwarding');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Autoreply');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-right compact-4"><b>&nbsp;</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Disk');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Quota');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Aliases');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Forwarding');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Autoreply');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<!-- Begin mail account list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_MAIL_ACCOUNT_CONFIRMATION');
-				if ($data[$key]['ALIAS'] == '') {
-					$alias_icon = 'fa-minus-circle';
-				} else {
-					$alias_icon = 'fa-check-circle';
-				}
-				if ($data[$key]['FWD'] == '') {
-					$fwd_icon = 'fa-minus-circle';
-				} else {
-					$fwd_icon = 'fa-check-circle';
-				}
-				if ($data[$key]['AUTOREPLY'] == 'no') {
-					$autoreply_icon = 'fa-minus-circle';
-				} else {
-					$autoreply_icon = 'fa-check-circle';
-				}
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_MAIL_ACCOUNT_CONFIRMATION');
-				if ($data[$key]['ALIAS'] == '') {
-					$alias_icon = 'fa-minus-circle';
-				} else {
-					$alias_icon = 'fa-check-circle status-icon green';
-				}
-				if ($data[$key]['FWD'] == '') {
-					$fwd_icon = 'fa-minus-circle';
-				} else {
-					$fwd_icon = 'fa-check-circle status-icon green';
-				}
-				if ($data[$key]['AUTOREPLY'] == 'no') {
-					$autoreply_icon = 'fa-minus-circle';
-				} else {
-					$autoreply_icon = 'fa-check-circle status-icon green';
-				}
-			}
-		?>
-		<div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended';?> animated fadeIn"
-			v_unit_id="<?=$key."@".htmlentities($_GET['domain']);?>" v_section="mail_acc" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>" sort-disk="<?=$data[$key]['U_DISK']?>"
-			sort-quota="<?=$data[$key]['QUOTA']?>" >
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="account[]" value="<?=$key?>" <?=$display_mode;?>>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3 truncate">
-					<?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) { ?>
-						<b><?=$key."@".htmlentities($_GET['domain']);?></b>
-					<?php } else { ?>
-						<b><a href="/edit/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Mail Account');?>: <?=$key?>@<?=htmlspecialchars($_GET['domain'])?>"><?=$key."@".htmlentities($_GET['domain']);?></a></b>
-					<?php } ?>
-				</div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-right compact-4">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<?php if ($read_only === 'true') { ?>
-								<!-- Restrict the ability to edit, delete, or suspend domain items when impersonating 'admin' account -->
-								<?php if ($data[$key]['SUSPENDED'] == 'yes') { ?>
-									&nbsp;
-								<?php } else { ?>
-									<div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain'])?>/?_user=<?=$key?>@<?=htmlspecialchars($_GET['domain'])?>" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-envelope-open-text status-icon maroon status-icon dim"></i></a></div>
-								<?php } ?>
-							<?php } else { ?>
-								<?php if ($data[$key]['SUSPENDED'] == 'no') { ?>
-									<?php if($_SESSION['WEBMAIL_SYSTEM']){?>
-										<?php if (!empty($data[$key]['WEBMAIL'])) { ?>
-											<div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain'])?>/?_user=<?=$key?>@<?=htmlspecialchars($_GET['domain'])?>" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-envelope-open-text status-icon maroon status-icon dim"></i></a></div>
-										<?php } ?>
-									<?php } ?>
-								<div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Mail Account');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-								<?php } ?>
-								<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-									<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-										<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-										<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-											<p><?=sprintf($spnd_confirmation,$key)?></p>
-										</div>
-									</a>
-								</div>
-								<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-									<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-										<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-										<input type="hidden" name="delete_url" value="/delete/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-											<p><?=sprintf(_('DELETE_MAIL_ACCOUNT_CONFIRMATION'),$key)?></p>
-										</div>
-									</a>
-								</div>
-							<?php } ?>
-						</div>
-					</div>
-					<!-- END QUICK ACTION TOOLBAR AREA -->
-				</div>
+  <!-- Begin mail account list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_MAIL_ACCOUNT_CONFIRMATION');
+        if ($data[$key]['ALIAS'] == '') {
+          $alias_icon = 'fa-minus-circle';
+        } else {
+          $alias_icon = 'fa-check-circle';
+        }
+        if ($data[$key]['FWD'] == '') {
+          $fwd_icon = 'fa-minus-circle';
+        } else {
+          $fwd_icon = 'fa-check-circle';
+        }
+        if ($data[$key]['AUTOREPLY'] == 'no') {
+          $autoreply_icon = 'fa-minus-circle';
+        } else {
+          $autoreply_icon = 'fa-check-circle';
+        }
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_MAIL_ACCOUNT_CONFIRMATION');
+        if ($data[$key]['ALIAS'] == '') {
+          $alias_icon = 'fa-minus-circle';
+        } else {
+          $alias_icon = 'fa-check-circle status-icon green';
+        }
+        if ($data[$key]['FWD'] == '') {
+          $fwd_icon = 'fa-minus-circle';
+        } else {
+          $fwd_icon = 'fa-check-circle status-icon green';
+        }
+        if ($data[$key]['AUTOREPLY'] == 'no') {
+          $autoreply_icon = 'fa-minus-circle';
+        } else {
+          $autoreply_icon = 'fa-check-circle status-icon green';
+        }
+      }
+    ?>
+    <div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended';?> animated fadeIn"
+      v_unit_id="<?=$key."@".htmlentities($_GET['domain']);?>" v_section="mail_acc" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>" sort-disk="<?=$data[$key]['U_DISK']?>"
+      sort-quota="<?=$data[$key]['QUOTA']?>" >
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="account[]" value="<?=$key?>" <?=$display_mode;?>>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3 truncate">
+          <?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) { ?>
+            <b><?=$key."@".htmlentities($_GET['domain']);?></b>
+          <?php } else { ?>
+            <b><a href="/edit/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Mail Account');?>: <?=$key?>@<?=htmlspecialchars($_GET['domain'])?>"><?=$key."@".htmlentities($_GET['domain']);?></a></b>
+          <?php } ?>
+        </div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-right compact-4">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <?php if ($read_only === 'true') { ?>
+                <!-- Restrict the ability to edit, delete, or suspend domain items when impersonating 'admin' account -->
+                <?php if ($data[$key]['SUSPENDED'] == 'yes') { ?>
+                  &nbsp;
+                <?php } else { ?>
+                  <div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain'])?>/?_user=<?=$key?>@<?=htmlspecialchars($_GET['domain'])?>" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-envelope-open-text status-icon maroon status-icon dim"></i></a></div>
+                <?php } ?>
+              <?php } else { ?>
+                <?php if ($data[$key]['SUSPENDED'] == 'no') { ?>
+                  <?php if($_SESSION['WEBMAIL_SYSTEM']){?>
+                    <?php if (!empty($data[$key]['WEBMAIL'])) { ?>
+                      <div class="actions-panel__col actions-panel__edit" key-action="href"><a href="http://<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain'])?>/?_user=<?=$key?>@<?=htmlspecialchars($_GET['domain'])?>" target="_blank" title="<?=_('open webmail');?>"><i class="fas fa-envelope-open-text status-icon maroon status-icon dim"></i></a></div>
+                    <?php } ?>
+                  <?php } ?>
+                <div class="actions-panel__col actions-panel__logs shortcut-enter" key-action="href"><a href="/edit/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Mail Account');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                <?php } ?>
+                <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                  <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                    <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                    <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf($spnd_confirmation,$key)?></p>
+                    </div>
+                  </a>
+                </div>
+                <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                  <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                    <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                    <input type="hidden" name="delete_url" value="/delete/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf(_('DELETE_MAIL_ACCOUNT_CONFIRMATION'),$key)?></p>
+                    </div>
+                  </a>
+                </div>
+              <?php } ?>
+            </div>
+          </div>
+          <!-- END QUICK ACTION TOOLBAR AREA -->
+        </div>
 
-				<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_(humanize_usage_size($data[$key]['QUOTA'])) ?></b> <span class="text-small"><?=_(humanize_usage_measure($data[$key]['QUOTA'])) ?></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center">
-					<i class="fas <?=$alias_icon;?>"></i>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center">
-					<i class="fas <?=$fwd_icon;?>"></i>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center">
-					<i class="fas <?=$autoreply_icon;?>"></i>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+        <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_(humanize_usage_size($data[$key]['QUOTA'])) ?></b> <span class="text-small"><?=_(humanize_usage_measure($data[$key]['QUOTA'])) ?></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center">
+          <i class="fas <?=$alias_icon;?>"></i>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center">
+          <i class="fas <?=$fwd_icon;?>"></i>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center">
+          <i class="fas <?=$autoreply_icon;?>"></i>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d mail account', '%d mail accounts', $i),$i); ?>
-			</div>
-			<div class="data-count l-unit__col l-unit__col--right back clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d mail account', '%d mail accounts', $i),$i); ?>
+      </div>
+      <div class="data-count l-unit__col l-unit__col--right back clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_mail_dns.html
+++ b/web/templates/pages/list_mail_dns.html
@@ -1,130 +1,130 @@
 <?php
-	$v_webmail_alias = "webmail";
-	if (!empty($_SESSION['WEBMAIL_ALIAS'])) $v_webmail_alias = $_SESSION['WEBMAIL_ALIAS'];
+  $v_webmail_alias = "webmail";
+  if (!empty($_SESSION['WEBMAIL_ALIAS'])) $v_webmail_alias = $_SESSION['WEBMAIL_ALIAS'];
 ?>
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/mail/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td></td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/mail/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td></td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Record');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Type');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Priority');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('TTL');?></b></div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('IP or Value');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Record');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Type');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Priority');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('TTL');?></b></div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('IP or Value');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<div class="l-unit animated fadeIn">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control" style="width:260px;" value="mail.<?=htmlspecialchars($_GET['domain']);?>"></b>
-			</div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>A</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control u-input-width" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ? array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>"></b>
-			</div>
-		</div>
-	</div>
-	<?php if($_SESSION['WEBMAIL_SYSTEM']){?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left wide-3">
-					<b><input type="text" class="form-control" style="width:260px;" value="<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain']);?>"></b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>A</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
-				<div class="clearfix l-unit__stat-col--left wide-3">
-					<b><input type="text" class="form-control u-input-width" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ? array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>"></b>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
-	<div class="l-unit animated fadeIn">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control" style="width:260px;" value="<?=htmlspecialchars($_GET['domain']);?>"></b>
-			</div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>MX</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>10</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control u-input-width" value="mail.<?=htmlspecialchars($_GET['domain']);?>."></b>
-			</div>
-		</div>
-	</div>
-	<div class="l-unit animated fadeIn">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control" style="width:260px;" value="<?=htmlspecialchars($_GET['domain']);?>"></b>
-			</div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>TXT</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
-			<?php $ip = (empty($ips[array_key_first($ips)]['NAT'])) ? array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control u-input-width" value="<?=htmlspecialchars('v=spf1 a mx ip4:'.$ip.' -all');?>"></b>
-			</div>
-		</div>
-	</div>
-	<div class="l-unit animated fadeIn">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control" style="width:260px;" value="_dmarc"></b>
-			</div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>TXT</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
-			<div class="clearfix l-unit__stat-col--left wide-3">
-				<b><input type="text" class="form-control u-input-width" value="<?=htmlspecialchars('v=DMARC1; p=quarantine; pct=100');?>"></b>
-			</div>
-		</div>
-	</div>
-	<?php foreach($dkim as $key => $value){ ?>
-		<div class="l-unit animated fadeIn">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left wide-3">
-					<b><input type="text" class="form-control" style="width:260px;" value="<?=htmlspecialchars($key);?>"></b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>TXT</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>3600</b></div>
-				<div class="clearfix l-unit__stat-col--left wide-3">
-					<b><input type="text" class="form-control u-input-width" value="<?=htmlspecialchars(str_replace(array('"',"'"),'',$dkim[$key]['TXT']));?>"></b>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <div class="l-unit animated fadeIn">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control" style="width:260px;" value="mail.<?=htmlspecialchars($_GET['domain']);?>"></b>
+      </div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>A</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control u-input-width" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ? array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>"></b>
+      </div>
+    </div>
+  </div>
+  <?php if($_SESSION['WEBMAIL_SYSTEM']){?>
+    <div class="l-unit animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left wide-3">
+          <b><input type="text" class="form-control" style="width:260px;" value="<?=$v_webmail_alias;?>.<?=htmlspecialchars($_GET['domain']);?>"></b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>A</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
+        <div class="clearfix l-unit__stat-col--left wide-3">
+          <b><input type="text" class="form-control u-input-width" value="<?=(empty($ips[array_key_first($ips)]['NAT'])) ? array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>"></b>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
+  <div class="l-unit animated fadeIn">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control" style="width:260px;" value="<?=htmlspecialchars($_GET['domain']);?>"></b>
+      </div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>MX</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>10</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control u-input-width" value="mail.<?=htmlspecialchars($_GET['domain']);?>."></b>
+      </div>
+    </div>
+  </div>
+  <div class="l-unit animated fadeIn">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control" style="width:260px;" value="<?=htmlspecialchars($_GET['domain']);?>"></b>
+      </div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>TXT</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
+      <?php $ip = (empty($ips[array_key_first($ips)]['NAT'])) ? array_key_first($ips) : $ips[array_key_first($ips)]['NAT'];?>
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control u-input-width" value="<?=htmlspecialchars('v=spf1 a mx ip4:'.$ip.' -all');?>"></b>
+      </div>
+    </div>
+  </div>
+  <div class="l-unit animated fadeIn">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control" style="width:260px;" value="_dmarc"></b>
+      </div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>TXT</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>14400</b></div>
+      <div class="clearfix l-unit__stat-col--left wide-3">
+        <b><input type="text" class="form-control u-input-width" value="<?=htmlspecialchars('v=DMARC1; p=quarantine; pct=100');?>"></b>
+      </div>
+    </div>
+  </div>
+  <?php foreach($dkim as $key => $value){ ?>
+    <div class="l-unit animated fadeIn">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left wide-3">
+          <b><input type="text" class="form-control" style="width:260px;" value="<?=htmlspecialchars($key);?>"></b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>TXT</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>&nbsp;</b></div>
+        <div class="clearfix l-unit__stat-col--left text-center u-pt10"><b>3600</b></div>
+        <div class="clearfix l-unit__stat-col--left wide-3">
+          <b><input type="text" class="form-control u-input-width" value="<?=htmlspecialchars(str_replace(array('"',"'"),'',$dkim[$key]['TXT']));?>"></b>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-			</div>
-			<div class="data-count l-unit__col l-unit__col--right back clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+      </div>
+      <div class="data-count l-unit__col l-unit__col--right back clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_packages.html
+++ b/web/templates/pages/list_packages.html
@@ -1,231 +1,231 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/user/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/add/package/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Package');?></a>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td>
-						<form action="/bulk/package/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select class="" name="action">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="delete"><?=_('delete');?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/user/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/add/package/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Package');?></a>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td>
+            <form action="/bulk/package/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select class="" name="action">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="delete"><?=_('delete');?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-2"><b><?=_('Package');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3 text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-terminal" title="<?=_('Shell');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-hdd" title="<?=_('Quota');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-exchange-alt" title="<?=_('Bandwidth');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-globe-americas" title="<?=_('Web Domains');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-link" title="<?=_('Web Aliases');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-atlas" title="<?=_('DNS Domains');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-globe" title="<?=_('DNS Records');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-mail-bulk" title="<?=_('Mail Domains');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-inbox" title="<?=_('Mail Accounts');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-database" title="<?=_('Databases');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-clock" title="<?=_('Cron Jobs');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-file-archive" title="<?=_('Backups');?>"></i></b></div>
-		</div>
-	</div>
+  <div class="table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-2"><b><?=_('Package');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3 text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-terminal" title="<?=_('Shell');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-hdd" title="<?=_('Quota');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-exchange-alt" title="<?=_('Bandwidth');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-globe-americas" title="<?=_('Web Domains');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-link" title="<?=_('Web Aliases');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-atlas" title="<?=_('DNS Domains');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-globe" title="<?=_('DNS Records');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-mail-bulk" title="<?=_('Mail Domains');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-inbox" title="<?=_('Mail Accounts');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-database" title="<?=_('Databases');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-clock" title="<?=_('Cron Jobs');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-file-archive" title="<?=_('Backups');?>"></i></b></div>
+    </div>
+  </div>
 
-	<!-- Begin package list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-		?>
-		<div class="l-unit animated fadeIn" v_section="user"
-			v_unit_id="<?=$key?>" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>"
-			sort-bandwidth="<?=$data[$key]['BANDWIDTH']?>" sort-disk="<?=$data[$key]['DISK_QUOTA']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="user[]" value="<?=$key?>">
-				</div>
-				<?php if ($key == 'system'){ ?>
-					<div class="clearfix l-unit__stat-col--left wide-2 truncate"><b><?=$key?></b></div>
-				<?php } else {?>
-					<div class="clearfix l-unit__stat-col--left wide-2 truncate"><b><a href="/edit/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Package');?>: <?=$key?>"><?=$key?></a></b></div>
-				<?php } ?>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-right compact-3">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<?php if (($key == 'system')) { ?>
-								<!-- Restrict editing system package -->
-							<?php } else {?>
-								<div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href"><a href="/edit/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Package');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-							<?php } ?>
-							<div class="actions-panel__col actions-panel__edit" key-action="href"><a href="/copy/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Copy');?>"><i class="fas fa-clone status-icon teal status-icon dim"></i></a></div>
-							<?php if ($key == 'system') { ?>
-								<!-- Restrict deleting system package -->
-							<?php } else {?>
-								<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-									<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('Delete');?>">
-										<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-										<input type="hidden" name="delete_url" value="/delete/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-											<p><?=sprintf(_('DELETE_PACKAGE_CONFIRMATION'),$key)?></p>
-										</div>
-									</a>
-								</div>
-							<?php } ?>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center compact">
-					<?php if ($data[$key]['SHELL'] == 'nologin'){ ?>
-						<i class="fas fa-minus-circle status-icon large" title="<?=_('SSH Access');?>: <?=$data[$key]['SHELL']?>"> </i>
-					<?php } else {?>
-						<i class="fas fa-check-circle status-icon green large"></i>
-					<?php } ?>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center compact">
-					<span title="<?=_('Quota');?>: <?=humanize_usage_size($data[$key]['DISK_QUOTA'])?> <?=humanize_usage_measure($data[$key]['DISK_QUOTA'])?>">
-						<?php if (preg_match('/[a-z]/i', $data[$key]['DISK_QUOTA'])): ?>
-							<b>&infin;</b>
-						<?php else: ?>
-							<b><?=humanize_usage_size($data[$key]['DISK_QUOTA'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['DISK_QUOTA'])?></span>
-						<?php endif; ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center compact">
-					<span title="<?=_('Bandwidth');?>: <?=humanize_usage_size($data[$key]['BANDWIDTH'])?> <?=humanize_usage_measure($data[$key]['BANDWIDTH'])?>">
-						<?php if ($data[$key]['BANDWIDTH'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=humanize_usage_size($data[$key]['BANDWIDTH'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['BANDWIDTH'])?></span>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Web Domains');?>: <?=$data[$key]['WEB_DOMAINS']?>">
-						<?php if ($data[$key]['WEB_DOMAINS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['WEB_DOMAINS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Web Aliases');?>: <?=$data[$key]['WEB_ALIASES']?>">
-						<?php if ($data[$key]['WEB_ALIASES'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['WEB_ALIASES']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('DNS Domains');?>: <?=$data[$key]['DNS_DOMAINS']?>">
-						<?php if ($data[$key]['DNS_DOMAINS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['DNS_DOMAINS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('DNS Records');?>: <?=$data[$key]['DNS_RECORDS']?>">
-						<?php if ($data[$key]['DNS_RECORDS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['DNS_RECORDS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Mail Domains');?>: <?=$data[$key]['MAIL_DOMAINS']?>">
-						<?php if ($data[$key]['MAIL_DOMAINS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['MAIL_DOMAINS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Mail Accounts');?>: <?=$data[$key]['MAIL_ACCOUNTS']?>">
-						<?php if ($data[$key]['MAIL_ACCOUNTS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['MAIL_ACCOUNTS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Databases');?>: <?=$data[$key]['DATABASES']?>">
-						<?php if ($data[$key]['DATABASES'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['DATABASES']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Cron Jobs');?>: <?=$data[$key]['CRON_JOBS']?>">
-						<?php if ($data[$key]['CRON_JOBS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['CRON_JOBS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact">
-					<span class="jump-top badge gray raised" title="<?=_('Backups');?>: <?=$data[$key]['BACKUPS']?>">
-						<?php if ($data[$key]['BACKUPS'] == 'unlimited'){ ?>
-							<b>&infin;</b>
-						<?php } else {?>
-							<b><?=$data[$key]['BACKUPS']?></b>
-						<?php } ?>
-					</span>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin package list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+    ?>
+    <div class="l-unit animated fadeIn" v_section="user"
+      v_unit_id="<?=$key?>" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=$key?>"
+      sort-bandwidth="<?=$data[$key]['BANDWIDTH']?>" sort-disk="<?=$data[$key]['DISK_QUOTA']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="user[]" value="<?=$key?>">
+        </div>
+        <?php if ($key == 'system'){ ?>
+          <div class="clearfix l-unit__stat-col--left wide-2 truncate"><b><?=$key?></b></div>
+        <?php } else {?>
+          <div class="clearfix l-unit__stat-col--left wide-2 truncate"><b><a href="/edit/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Package');?>: <?=$key?>"><?=$key?></a></b></div>
+        <?php } ?>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-right compact-3">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <?php if (($key == 'system')) { ?>
+                <!-- Restrict editing system package -->
+              <?php } else {?>
+                <div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href"><a href="/edit/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Package');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+              <?php } ?>
+              <div class="actions-panel__col actions-panel__edit" key-action="href"><a href="/copy/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Copy');?>"><i class="fas fa-clone status-icon teal status-icon dim"></i></a></div>
+              <?php if ($key == 'system') { ?>
+                <!-- Restrict deleting system package -->
+              <?php } else {?>
+                <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                  <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('Delete');?>">
+                    <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                    <input type="hidden" name="delete_url" value="/delete/package/?package=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf(_('DELETE_PACKAGE_CONFIRMATION'),$key)?></p>
+                    </div>
+                  </a>
+                </div>
+              <?php } ?>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center compact">
+          <?php if ($data[$key]['SHELL'] == 'nologin'){ ?>
+            <i class="fas fa-minus-circle status-icon large" title="<?=_('SSH Access');?>: <?=$data[$key]['SHELL']?>"> </i>
+          <?php } else {?>
+            <i class="fas fa-check-circle status-icon green large"></i>
+          <?php } ?>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center compact">
+          <span title="<?=_('Quota');?>: <?=humanize_usage_size($data[$key]['DISK_QUOTA'])?> <?=humanize_usage_measure($data[$key]['DISK_QUOTA'])?>">
+            <?php if (preg_match('/[a-z]/i', $data[$key]['DISK_QUOTA'])): ?>
+              <b>&infin;</b>
+            <?php else: ?>
+              <b><?=humanize_usage_size($data[$key]['DISK_QUOTA'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['DISK_QUOTA'])?></span>
+            <?php endif; ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center compact">
+          <span title="<?=_('Bandwidth');?>: <?=humanize_usage_size($data[$key]['BANDWIDTH'])?> <?=humanize_usage_measure($data[$key]['BANDWIDTH'])?>">
+            <?php if ($data[$key]['BANDWIDTH'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=humanize_usage_size($data[$key]['BANDWIDTH'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['BANDWIDTH'])?></span>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Web Domains');?>: <?=$data[$key]['WEB_DOMAINS']?>">
+            <?php if ($data[$key]['WEB_DOMAINS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['WEB_DOMAINS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Web Aliases');?>: <?=$data[$key]['WEB_ALIASES']?>">
+            <?php if ($data[$key]['WEB_ALIASES'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['WEB_ALIASES']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('DNS Domains');?>: <?=$data[$key]['DNS_DOMAINS']?>">
+            <?php if ($data[$key]['DNS_DOMAINS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['DNS_DOMAINS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('DNS Records');?>: <?=$data[$key]['DNS_RECORDS']?>">
+            <?php if ($data[$key]['DNS_RECORDS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['DNS_RECORDS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Mail Domains');?>: <?=$data[$key]['MAIL_DOMAINS']?>">
+            <?php if ($data[$key]['MAIL_DOMAINS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['MAIL_DOMAINS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Mail Accounts');?>: <?=$data[$key]['MAIL_ACCOUNTS']?>">
+            <?php if ($data[$key]['MAIL_ACCOUNTS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['MAIL_ACCOUNTS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Databases');?>: <?=$data[$key]['DATABASES']?>">
+            <?php if ($data[$key]['DATABASES'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['DATABASES']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Cron Jobs');?>: <?=$data[$key]['CRON_JOBS']?>">
+            <?php if ($data[$key]['CRON_JOBS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['CRON_JOBS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact">
+          <span class="jump-top badge gray raised" title="<?=_('Backups');?>: <?=$data[$key]['BACKUPS']?>">
+            <?php if ($data[$key]['BACKUPS'] == 'unlimited'){ ?>
+              <b>&infin;</b>
+            <?php } else {?>
+              <b><?=$data[$key]['BACKUPS']?></b>
+            <?php } ?>
+          </span>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator visible"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d package', '%d packages', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator visible"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d package', '%d packages', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_rrd.html
+++ b/web/templates/pages/list_rrd.html
@@ -1,58 +1,58 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="/list/server/?cpu" class="ui-button cancel" dir="ltr"><i class="fas fa-chart-pie status-icon green"></i><?=_('show: CPU / MEM / NET / DISK');?></a>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td>
-						<a class="vst<?php if ((empty($period)) || ($period == 'daily')) echo " selected" ?>" href="?period=daily"><?=_('Daily');?></a>
-						<a class="vst<?php if ((!empty($period)) && ($period == 'weekly')) echo " selected" ?>" href="?period=weekly"><?=_('Weekly');?></a>
-						<a class="vst<?php if ((!empty($period)) && ($period == 'monthly')) echo " selected" ?>" href="?period=monthly"><?=_('Monthly');?></a>
-						<a class="vst<?php if ((!empty($period)) && ($period == 'yearly')) echo " selected" ?>" href="?period=yearly"><?=_('Yearly');?></a>
-					</td>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="/list/server/?cpu" class="ui-button cancel" dir="ltr"><i class="fas fa-chart-pie status-icon green"></i><?=_('show: CPU / MEM / NET / DISK');?></a>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td>
+            <a class="vst<?php if ((empty($period)) || ($period == 'daily')) echo " selected" ?>" href="?period=daily"><?=_('Daily');?></a>
+            <a class="vst<?php if ((!empty($period)) && ($period == 'weekly')) echo " selected" ?>" href="?period=weekly"><?=_('Weekly');?></a>
+            <a class="vst<?php if ((!empty($period)) && ($period == 'monthly')) echo " selected" ?>" href="?period=monthly"><?=_('Monthly');?></a>
+            <a class="vst<?php if ((!empty($period)) && ($period == 'yearly')) echo " selected" ?>" href="?period=yearly"><?=_('Yearly');?></a>
+          </td>
 
-					<td>
-						<div class="timer-container" style="float:right;">
-							<span class="timer-button pause-stop" onclick="stopTimer()"><i class="fas fa-pause"></i></span>
-							<div class="timer-button spinner">
-								<div class="spinner-inner"></div>
-								<div class="spinner-mask"></div>
-								<div class="spinner-mask-two"></div>
-							</div>
-						</div>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+          <td>
+            <div class="timer-container" style="float:right;">
+              <span class="timer-button pause-stop" onclick="stopTimer()"><i class="fas fa-pause"></i></span>
+              <div class="timer-button spinner">
+                <div class="spinner-inner"></div>
+                <div class="spinner-mask"></div>
+                <div class="spinner-mask-two"></div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units animated fadeIn">
-	<!-- Begin graph list item loop -->
-	<?php foreach ($data as $key => $value) { ?>
-		<div class="l-unit l-unit__stats">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="l-unit__name separate">
-					<?= _($data[$key]['TITLE'])?>
-				</div>
-				<div>
-					<a href="/list/rrd/image.php?/rrd/<?=$data[$key]['TYPE']."/".$period."-".$data[$key]['RRD'].".png"?>" class="u-block" target="_blank">
-						<img class="graph-rounded" src="/list/rrd/image.php?/rrd/<?=$data[$key]['TYPE']."/".$period."-".$data[$key]['RRD'].".png"?>" alt="">
-					</a>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin graph list item loop -->
+  <?php foreach ($data as $key => $value) { ?>
+    <div class="l-unit l-unit__stats">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="l-unit__name separate">
+          <?= _($data[$key]['TITLE'])?>
+        </div>
+        <div>
+          <a href="/list/rrd/image.php?/rrd/<?=$data[$key]['TYPE']."/".$period."-".$data[$key]['RRD'].".png"?>" class="u-block" target="_blank">
+            <img class="graph-rounded" src="/list/rrd/image.php?/rrd/<?=$data[$key]['TYPE']."/".$period."-".$data[$key]['RRD'].".png"?>" alt="">
+          </a>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center"></div>
+  <div class="l-separator"></div>
+  <div class="l-center"></div>
 </div>

--- a/web/templates/pages/list_search.html
+++ b/web/templates/pages/list_search.html
@@ -1,171 +1,171 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a href="javascript:window.history.back();" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<a href="javascript:location.reload();" class="ui-button cancel" dir="ltr"><i class="fas fa-sync status-icon green"></i> <?=_('Refresh');?></a>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span><b><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></b></span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_GET['q']) ? htmlspecialchars($_GET['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a href="javascript:window.history.back();" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <a href="javascript:location.reload();" class="ui-button cancel" dir="ltr"><i class="fas fa-sync status-icon green"></i> <?=_('Refresh');?></a>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span><b><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></b></span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_GET['q']) ? htmlspecialchars($_GET['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				&nbsp;
-			</div>
-			<div class="clearfix l-unit__stat-col--left text-center compact-2"><b><?=_('Status');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-5"><b><?=_('Search Results');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Date');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Owner');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Type');?></b></div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        &nbsp;
+      </div>
+      <div class="clearfix l-unit__stat-col--left text-center compact-2"><b><?=_('Status');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-5"><b><?=_('Search Results');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Date');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Owner');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Type');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin search result item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
+  <!-- Begin search result item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
 
-			if ($value['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-			}
+      if ($value['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+      }
 
-			if ($value['TYPE'] == 'db') {
-				$object = 'database';
-			} else {
-				$object = strtolower($value['TYPE'] . ' ' . $value['KEY']);
-			}
+      if ($value['TYPE'] == 'db') {
+        $object = 'database';
+      } else {
+        $object = strtolower($value['TYPE'] . ' ' . $value['KEY']);
+      }
 
-			$uniq_id = $value['TYPE'] . '-';
-			if ($value['KEY'] == 'ACCOUNT'){
-				$uniq_id .= 'acc-';
-			}
-			$uniq_id .= sha1($value['RESULT']);
-		?>
-		<div class="l-unit <?php if($status == 'suspended') echo 'l-unit--suspended'; if($_COOKIE[$uniq_id] == 1) echo ' l-unit--starred'; ?> animated fadeIn" id="web-unit-<?=$i?>" uniq-id="<?=$uniq_id?>" sort-date="<?=strtotime($value['DATE'].' '.$value['TIME'])?>" sort-name="<?=$value['RESULT']?>" sort-type="<?=_($object)?>" sort-owner="<?=$value['USER']?>" sort-status="<?=$status?>"
-			style="<?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value['USER']) === 'admin') { echo 'display: none;';}?>">
+      $uniq_id = $value['TYPE'] . '-';
+      if ($value['KEY'] == 'ACCOUNT'){
+        $uniq_id .= 'acc-';
+      }
+      $uniq_id .= sha1($value['RESULT']);
+    ?>
+    <div class="l-unit <?php if($status == 'suspended') echo 'l-unit--suspended'; if($_COOKIE[$uniq_id] == 1) echo ' l-unit--starred'; ?> animated fadeIn" id="web-unit-<?=$i?>" uniq-id="<?=$uniq_id?>" sort-date="<?=strtotime($value['DATE'].' '.$value['TIME'])?>" sort-name="<?=$value['RESULT']?>" sort-type="<?=_($object)?>" sort-owner="<?=$value['USER']?>" sort-status="<?=$status?>"
+      style="<?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value['USER']) === 'admin') { echo 'display: none;';}?>">
 
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact text-center">
-					<?php
-						if ($object === 'web domain') {
-								$icon = 'fa-globe-americas';
-						}
-						if ($object === 'mail domain') {
-								$icon = 'fa-mail-bulk';
-						}
-						if ($object === 'dns domain') {
-								$icon = 'fa-atlas';
-						}
-						if ($object === 'dns record') {
-								$icon = 'fa-atlas';
-						}
-						if ($object === 'database') {
-								$icon = 'fa-database';
-						}
-						if ($object === 'cron job') {
-								$icon = 'fa-clock';
-						}
-					?>
-					<i class="fa <?=$icon;?> status-icon dim"></i>
-				</div>
-				<div class="clearfix l-unit__stat-col--left compact-2 text-center">
-					<b>
-						<?php if ($status === 'active') {?>
-							<i class="fas fa-check-circle status-icon green"></i>
-						<?php  } ?>
-						<?php if ($status === 'suspended') {?>
-							<i class="fas fa-exclamation-triangle status-icon orange"></i>
-						<?php  } ?>
-					</b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-5 truncate">
-					<?php
-						if ($value['KEY'] == 'RECORD') {
-							$edit_lnk = '/edit/'.$value['TYPE'].'/?domain='.$value['PARENT'].'&record_id='.$value['LINK'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
-						}
-						if ($value['KEY'] == 'ACCOUNT') {
-							$edit_lnk = '/edit/'.$value['TYPE'].'/?domain='.$value['PARENT'].'&account='.$value['LINK'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
-						}
-						if ($value['KEY'] == 'JOB') {
-							$edit_lnk = '/edit/'.$value['TYPE'].'/?job='.$value['LINK'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
-						}
-						if ($value['KEY'] == 'DATABASE') {
-							$edit_lnk = '/edit/'.$value['TYPE'].'/?database='.$value['RESULT'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
-						}
-						if (($value['KEY'] != 'RECORD') && ($value['KEY'] != 'ACCOUNT') && ($value['KEY'] != 'JOB') && ($value['KEY'] != 'DATABASE') ) {
-							$edit_lnk = '/edit/'.$value['TYPE'].'/?'.strtolower($value['KEY']).'='.$value['RESULT'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
-						}
-					?>
-					<b>
-						<?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['user'] !== 'admin') && ($value['USER'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {?>
-							<?=$value['RESULT']?>
-						<?} else {?>
-							<a href="<?=$edit_lnk; ?>"><?=$value['RESULT']?></a>
-						<?php } ?>
-					</b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-right compact-3">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							&nbsp;
-						</div>
-					</div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center"><?=translate_date($value['DATE'])?></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b>
-						<a href="/search/?q=<?=htmlentities($_GET['q']); ?>&u=<?=$value['USER']; ?>&token=<?=$_SESSION['token']?>"><?=$value['USER']; ?></a>
-						<?php if (!($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes' && $value['USER'] !== 'admin')){
-						if ($_SESSION['userContext'] === 'admin'){
-						?>
-							<a href="/login/?loginas=<?=$value['USER']?>&token=<?=$_SESSION['token']?>" title="<?=_('login as');?> <?=$value['USER']?>"><i class="fas fa-sign-in-alt status-icon green status-icon dim icon-large"></i></a>
-						<?php
-						}
-						}
-						?>
-						</b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><?=_($object)?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact text-center">
+          <?php
+            if ($object === 'web domain') {
+                $icon = 'fa-globe-americas';
+            }
+            if ($object === 'mail domain') {
+                $icon = 'fa-mail-bulk';
+            }
+            if ($object === 'dns domain') {
+                $icon = 'fa-atlas';
+            }
+            if ($object === 'dns record') {
+                $icon = 'fa-atlas';
+            }
+            if ($object === 'database') {
+                $icon = 'fa-database';
+            }
+            if ($object === 'cron job') {
+                $icon = 'fa-clock';
+            }
+          ?>
+          <i class="fa <?=$icon;?> status-icon dim"></i>
+        </div>
+        <div class="clearfix l-unit__stat-col--left compact-2 text-center">
+          <b>
+            <?php if ($status === 'active') {?>
+              <i class="fas fa-check-circle status-icon green"></i>
+            <?php  } ?>
+            <?php if ($status === 'suspended') {?>
+              <i class="fas fa-exclamation-triangle status-icon orange"></i>
+            <?php  } ?>
+          </b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-5 truncate">
+          <?php
+            if ($value['KEY'] == 'RECORD') {
+              $edit_lnk = '/edit/'.$value['TYPE'].'/?domain='.$value['PARENT'].'&record_id='.$value['LINK'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
+            }
+            if ($value['KEY'] == 'ACCOUNT') {
+              $edit_lnk = '/edit/'.$value['TYPE'].'/?domain='.$value['PARENT'].'&account='.$value['LINK'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
+            }
+            if ($value['KEY'] == 'JOB') {
+              $edit_lnk = '/edit/'.$value['TYPE'].'/?job='.$value['LINK'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
+            }
+            if ($value['KEY'] == 'DATABASE') {
+              $edit_lnk = '/edit/'.$value['TYPE'].'/?database='.$value['RESULT'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
+            }
+            if (($value['KEY'] != 'RECORD') && ($value['KEY'] != 'ACCOUNT') && ($value['KEY'] != 'JOB') && ($value['KEY'] != 'DATABASE') ) {
+              $edit_lnk = '/edit/'.$value['TYPE'].'/?'.strtolower($value['KEY']).'='.$value['RESULT'].'&user='.$value['USER'].'&token='.$_SESSION['token'].'';
+            }
+          ?>
+          <b>
+            <?php if (($_SESSION['userContext'] === 'admin') && ($_SESSION['user'] !== 'admin') && ($value['USER'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {?>
+              <?=$value['RESULT']?>
+            <?} else {?>
+              <a href="<?=$edit_lnk; ?>"><?=$value['RESULT']?></a>
+            <?php } ?>
+          </b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-right compact-3">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              &nbsp;
+            </div>
+          </div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center"><?=translate_date($value['DATE'])?></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b>
+            <a href="/search/?q=<?=htmlentities($_GET['q']); ?>&u=<?=$value['USER']; ?>&token=<?=$_SESSION['token']?>"><?=$value['USER']; ?></a>
+            <?php if (!($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes' && $value['USER'] !== 'admin')){
+            if ($_SESSION['userContext'] === 'admin'){
+            ?>
+              <a href="/login/?loginas=<?=$value['USER']?>&token=<?=$_SESSION['token']?>" title="<?=_('login as');?> <?=$value['USER']?>"><i class="fas fa-sign-in-alt status-icon green status-icon dim icon-large"></i></a>
+            <?php
+            }
+            }
+            ?>
+            </b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><?=_($object)?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d object', '%d objects', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d object', '%d objects', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_server_info.html
+++ b/web/templates/pages/list_server_info.html
@@ -2,53 +2,53 @@
 <html lang="en">
 
 <head>
-	<!-- Load necessary CSS and JavaScript from source -->
-	<?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/title.html'; ?>
-	<?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/css.html'; ?>
-	<?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/top_js.html'; ?>
-	<script src="/js/jquery/jquery.cookie.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/jquery/jquery-ui.min.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/jquery/jquery.finder.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/hotkeys.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/events.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/app.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/init.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/i18n.js.php?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/templates.js?<?=JS_LATEST_UPDATE?>"></script>
-	<?php foreach(new DirectoryIterator($_SERVER['HESTIA'].'/web/js/custom_scripts') as $customScript){
-		if($customScript->getExtension() === 'js'){
-			echo '<script src="/js/custom_scripts/'.rawurlencode($customScript->getBasename()).'"></script>';
-		} elseif($customScript->getExtension() === "php"){
-			require_once($customScript->getPathname());
-		}
-	 } ?>
+  <!-- Load necessary CSS and JavaScript from source -->
+  <?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/title.html'; ?>
+  <?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/css.html'; ?>
+  <?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/top_js.html'; ?>
+  <script src="/js/jquery/jquery.cookie.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/jquery/jquery-ui.min.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/jquery/jquery.finder.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/hotkeys.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/events.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/app.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/init.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/i18n.js.php?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/templates.js?<?=JS_LATEST_UPDATE?>"></script>
+  <?php foreach(new DirectoryIterator($_SERVER['HESTIA'].'/web/js/custom_scripts') as $customScript){
+    if($customScript->getExtension() === 'js'){
+      echo '<script src="/js/custom_scripts/'.rawurlencode($customScript->getBasename()).'"></script>';
+    } elseif($customScript->getExtension() === "php"){
+      require_once($customScript->getPathname());
+    }
+   } ?>
 </head>
 
 <body>
-	<a href="#" class="to-top" title="<?=_('Top');?>">
-		<i class="fas fa-arrow-up"></i>
-	</a>
-	<div class="l-header">
-		<div class="l-center">
-			<a href="/list/web/" class="l-logo"></a>
-			<div class="l-menu clearfix">
-				<div class="l-menu__item"><a href="/list/rrd/" title="<?=_('Back');?>" class="no-hide"><i class="fas fa-arrow-alt-circle-left"></i></a></div>
-				<div class="l-menu__item <?php if(isset($_GET['cpu'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?cpu"><i class="fas fa-microchip panel-icon"></i><?=_('CPU');?></a></div>
-				<div class="l-menu__item <?php if(isset($_GET['mem'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?mem"><i class="fas fa-memory panel-icon"></i><?=_('RAM');?></a></div>
-				<div class="l-menu__item <?php if(isset($_GET['disk'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?disk"><i class="fas fa-hdd panel-icon"></i><?=_('Disk');?></a></div>
-				<div class="l-menu__item <?php if(isset($_GET['net'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?net"><i class="fas fa-ethernet panel-icon"></i><?=_('Network');?></a></div>
-				<?php if ((isset($_SESSION['WEB_SYSTEM'])) && (!empty($_SESSION['WEB_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['web'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?web"><i class="fas fa-globe-europe panel-icon"></i><?=_('Web');?></a></div><?php }?>
-				<?php if ((isset($_SESSION['DNS_SYSTEM'])) && (!empty($_SESSION['DNS_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['dns'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?dns"><i class="fas fa-atlas panel-icon"></i><?=_('DNS');?></a></div><?php }?>
-				<?php if ((isset($_SESSION['MAIL_SYSTEM'])) && (!empty($_SESSION['MAIL_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['mail'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?mail"><i class="fas fa-mail-bulk panel-icon"></i><?=_('Mail');?></a></div><?php }?>
-				<?php if ((isset($_SESSION['DB_SYSTEM'])) && (!empty($_SESSION['DB_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['db'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?db"><i class="fas fa-database panel-icon"></i><?=_('DB');?></a></div><?php }?>
-			</div>
-			<div class="l-profile noselect">
-				<div class="l-menu__item"><a href="javascript:location.reload();" title="<?=_('Refresh');?>"><i class="fas fa-redo"></i></a></div>
-				<div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?>" class="l-profile__logout"><i class="fas fa-sign-out-alt"></i></a></div>
-			</div>
-		</div>
-	</div>
+  <a href="#" class="to-top" title="<?=_('Top');?>">
+    <i class="fas fa-arrow-up"></i>
+  </a>
+  <div class="l-header">
+    <div class="l-center">
+      <a href="/list/web/" class="l-logo"></a>
+      <div class="l-menu clearfix">
+        <div class="l-menu__item"><a href="/list/rrd/" title="<?=_('Back');?>" class="no-hide"><i class="fas fa-arrow-alt-circle-left"></i></a></div>
+        <div class="l-menu__item <?php if(isset($_GET['cpu'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?cpu"><i class="fas fa-microchip panel-icon"></i><?=_('CPU');?></a></div>
+        <div class="l-menu__item <?php if(isset($_GET['mem'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?mem"><i class="fas fa-memory panel-icon"></i><?=_('RAM');?></a></div>
+        <div class="l-menu__item <?php if(isset($_GET['disk'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?disk"><i class="fas fa-hdd panel-icon"></i><?=_('Disk');?></a></div>
+        <div class="l-menu__item <?php if(isset($_GET['net'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?net"><i class="fas fa-ethernet panel-icon"></i><?=_('Network');?></a></div>
+        <?php if ((isset($_SESSION['WEB_SYSTEM'])) && (!empty($_SESSION['WEB_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['web'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?web"><i class="fas fa-globe-europe panel-icon"></i><?=_('Web');?></a></div><?php }?>
+        <?php if ((isset($_SESSION['DNS_SYSTEM'])) && (!empty($_SESSION['DNS_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['dns'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?dns"><i class="fas fa-atlas panel-icon"></i><?=_('DNS');?></a></div><?php }?>
+        <?php if ((isset($_SESSION['MAIL_SYSTEM'])) && (!empty($_SESSION['MAIL_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['mail'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?mail"><i class="fas fa-mail-bulk panel-icon"></i><?=_('Mail');?></a></div><?php }?>
+        <?php if ((isset($_SESSION['DB_SYSTEM'])) && (!empty($_SESSION['DB_SYSTEM']))) {?><div class="l-menu__item <?php if(isset($_GET['db'])) echo 'l-menu__item--active' ?>"><a href="/list/server/?db"><i class="fas fa-database panel-icon"></i><?=_('DB');?></a></div><?php }?>
+      </div>
+      <div class="l-profile noselect">
+        <div class="l-menu__item"><a href="javascript:location.reload();" title="<?=_('Refresh');?>"><i class="fas fa-redo"></i></a></div>
+        <div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?>" class="l-profile__logout"><i class="fas fa-sign-out-alt"></i></a></div>
+      </div>
+    </div>
+  </div>
 
-	<div class="server-info-output">.</div>
-	<div class="l-center">
-		<pre class="console-output animated fadeIn">
+  <div class="server-info-output">.</div>
+  <div class="l-center">
+    <pre class="console-output animated fadeIn">

--- a/web/templates/pages/list_server_preview.html
+++ b/web/templates/pages/list_server_preview.html
@@ -1,12 +1,12 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a href="/edit/server/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a href="/edit/server/" id="btn-back" class="ui-button cancel" dir="ltr"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -14,35 +14,35 @@
 
 <div class="l-center units">
 
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact text-center">&nbsp;</div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('Category');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-2"><b><?=_('Status');?></b></div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact text-center">&nbsp;</div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('Category');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-2"><b><?=_('Status');?></b></div>
 
-		</div>
-	</div>
-	<!-- Start of item element-->
-	<div class="l-unit header animated fadeIn">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact text-center">
-				<i class="fas fa-cog status-icon blue"></i>
-			</div>
-			<div class="clearfix l-unit__stat-col--left"><b><?=_('System');?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('Policy'); ?>: <?=_('Allow suspended users to log in with read-only access'); ?></b></div>
-			<div class="clearfix l-unit__stat-col--left wide-2">Partially implemented.</div>
-		</div>
-	</div>
-	<!-- End of item element-->
+    </div>
+  </div>
+  <!-- Start of item element-->
+  <div class="l-unit header animated fadeIn">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact text-center">
+        <i class="fas fa-cog status-icon blue"></i>
+      </div>
+      <div class="clearfix l-unit__stat-col--left"><b><?=_('System');?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-6"><b><?=_('Policy'); ?>: <?=_('Allow suspended users to log in with read-only access'); ?></b></div>
+      <div class="clearfix l-unit__stat-col--left wide-2">Partially implemented.</div>
+    </div>
+  </div>
+  <!-- End of item element-->
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_services.html
+++ b/web/templates/pages/list_services.html
@@ -1,45 +1,45 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a href="/edit/server/" class="ui-button cancel" dir="ltr"><i class="fas fa-cog status-icon maroon"></i><?=_('Configure');?></a>
-			<a href="/list/rrd/" class="ui-button cancel" dir="ltr"><i class="fas fa-chart-area status-icon blue"></i><?=_('Graphs');?></a>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a href="/edit/server/" class="ui-button cancel" dir="ltr"><i class="fas fa-cog status-icon maroon"></i><?=_('Configure');?></a>
+      <a href="/list/rrd/" class="ui-button cancel" dir="ltr"><i class="fas fa-chart-area status-icon blue"></i><?=_('Graphs');?></a>
             <a href="/list/updates/" class="ui-button cancel" dir="ltr"><i class="fas fa-sync status-icon green"></i><?=_('Updates');?></a>
-			<?php if (!empty($_SESSION['FIREWALL_SYSTEM']) && $_SESSION['FIREWALL_SYSTEM'] == "iptables" ) {?>
-			<a href="/list/firewall/" class="ui-button cancel" dir="ltr"><i class="fas fa-shield-alt status-icon red"></i><?=_('Firewall');?></a>
-			<?php }?>
-			<a href="/list/log/?user=system&token=<?=$_SESSION['token']?>" class="ui-button cancel" dir="ltr"><i class="fas fa-binoculars status-icon orange"></i><?=_('Logs');?></a>
-			<div class="actions-panel display-inline-block" key-action="js">
-				<a class="data-controls do_servicerestart ui-button danger cancel">
-					<i class="do_servicerestart fas fa-undo status-icon red"></i><?=_('Restart');?>
-					<input type="hidden" name="servicerestart_url" value="/restart/system/?hostname=<?=$sys['sysinfo']['HOSTNAME'] ?>&token=<?=$_SESSION['token']?>&system_reset_token=<?=time(); ?>">
-					<div class="dialog js-confirm-dialog-servicerestart" title="<?=_('Confirmation');?>">
-						<p><?=sprintf(_('RESTART_CONFIRMATION'), 'Server');?></p>
-					</div>
-				</a>
-			</div>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td>
-						<form action="/bulk/service/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select" style="width:160px !important;">
-								<select class="" name="action">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="stop"><?=_('stop');?></option>
-									<option value="start"><?=_('start');?></option>
-									<option value="restart"><?=_('restart');?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+      <?php if (!empty($_SESSION['FIREWALL_SYSTEM']) && $_SESSION['FIREWALL_SYSTEM'] == "iptables" ) {?>
+      <a href="/list/firewall/" class="ui-button cancel" dir="ltr"><i class="fas fa-shield-alt status-icon red"></i><?=_('Firewall');?></a>
+      <?php }?>
+      <a href="/list/log/?user=system&token=<?=$_SESSION['token']?>" class="ui-button cancel" dir="ltr"><i class="fas fa-binoculars status-icon orange"></i><?=_('Logs');?></a>
+      <div class="actions-panel display-inline-block" key-action="js">
+        <a class="data-controls do_servicerestart ui-button danger cancel">
+          <i class="do_servicerestart fas fa-undo status-icon red"></i><?=_('Restart');?>
+          <input type="hidden" name="servicerestart_url" value="/restart/system/?hostname=<?=$sys['sysinfo']['HOSTNAME'] ?>&token=<?=$_SESSION['token']?>&system_reset_token=<?=time(); ?>">
+          <div class="dialog js-confirm-dialog-servicerestart" title="<?=_('Confirmation');?>">
+            <p><?=sprintf(_('RESTART_CONFIRMATION'), 'Server');?></p>
+          </div>
+        </a>
+      </div>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td>
+            <form action="/bulk/service/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select" style="width:160px !important;">
+                <select class="" name="action">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="stop"><?=_('stop');?></option>
+                  <option value="start"><?=_('start');?></option>
+                  <option value="restart"><?=_('restart');?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -47,140 +47,140 @@
 
 <div class="l-center units">
 
-	<div class="">
-		<div class="l-unit__col l-unit__col--right server-info">
-			<div class="icon-server-info"><i class="fas fa-server"></i></div>
-			<div class="l-unit__servername separate server-info-name"><?=$sys['sysinfo']['HOSTNAME']?></div>
-			<div class="server-info-data">
-				<table class="text-small">
-					<tr>
-						<td>
-							<div class="l-unit__stat-cols clearfix">
-								<div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Hestia Control Panel');?>:</b></div>
-								<div class="l-unit__stat-col l-unit__stat-col--right">
-									<?php if ($sys['sysinfo']['RELEASE'] != 'release') { ?>
-										<i class="fas fa-flask icon-large status-icon red" title="<?=$sys['sysinfo']['RELEASE'];?>"></i>
-									<?php } ?>
-									<?php if ($sys['sysinfo']['RELEASE'] == 'release') { ?>
-										<i class="fas fa-cube icon-large status-icon" title="<?=_('Production release');?>"></i>
-									<?php } ?>
-									&nbsp;v<?=$sys['sysinfo']['HESTIA']?></div>
-							</div>
-						</td>
-						<td>
-							<div class="l-unit__stat-cols clearfix">
-								<div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Operating System');?>:</b></div>
-								<div class="l-unit__stat-col l-unit__stat-col--right"><?=$sys['sysinfo']['OS']?> <?=$sys['sysinfo']['VERSION']?> (<?=$sys['sysinfo']['ARCH']?>)</div>
-							</div>
-						</td>
-						<td>
-							<div class="l-unit__stat-cols clearfix">
-								<div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Load Average');?>:</b></div>
-								<div class="l-unit__stat-col l-unit__stat-col--right"><?=$sys['sysinfo']['LOADAVERAGE']?></div>
-							</div>
-						</td>
-						<td>
-							<div class="l-unit__stat-cols clearfix last">
-								<div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Uptime');?>:</b></div>
-								<div class="l-unit__stat-col l-unit__stat-col--right"><?=humanize_time($sys['sysinfo']['UPTIME'])?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</div>
-		</div>
-	</div>
+  <div class="">
+    <div class="l-unit__col l-unit__col--right server-info">
+      <div class="icon-server-info"><i class="fas fa-server"></i></div>
+      <div class="l-unit__servername separate server-info-name"><?=$sys['sysinfo']['HOSTNAME']?></div>
+      <div class="server-info-data">
+        <table class="text-small">
+          <tr>
+            <td>
+              <div class="l-unit__stat-cols clearfix">
+                <div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Hestia Control Panel');?>:</b></div>
+                <div class="l-unit__stat-col l-unit__stat-col--right">
+                  <?php if ($sys['sysinfo']['RELEASE'] != 'release') { ?>
+                    <i class="fas fa-flask icon-large status-icon red" title="<?=$sys['sysinfo']['RELEASE'];?>"></i>
+                  <?php } ?>
+                  <?php if ($sys['sysinfo']['RELEASE'] == 'release') { ?>
+                    <i class="fas fa-cube icon-large status-icon" title="<?=_('Production release');?>"></i>
+                  <?php } ?>
+                  &nbsp;v<?=$sys['sysinfo']['HESTIA']?></div>
+              </div>
+            </td>
+            <td>
+              <div class="l-unit__stat-cols clearfix">
+                <div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Operating System');?>:</b></div>
+                <div class="l-unit__stat-col l-unit__stat-col--right"><?=$sys['sysinfo']['OS']?> <?=$sys['sysinfo']['VERSION']?> (<?=$sys['sysinfo']['ARCH']?>)</div>
+              </div>
+            </td>
+            <td>
+              <div class="l-unit__stat-cols clearfix">
+                <div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Load Average');?>:</b></div>
+                <div class="l-unit__stat-col l-unit__stat-col--right"><?=$sys['sysinfo']['LOADAVERAGE']?></div>
+              </div>
+            </td>
+            <td>
+              <div class="l-unit__stat-cols clearfix last">
+                <div class="l-unit__stat-col l-unit__stat-col--left wide"><b><?=_('Uptime');?>:</b></div>
+                <div class="l-unit__stat-col l-unit__stat-col--right"><?=humanize_time($sys['sysinfo']['UPTIME'])?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
 
-	<div class="table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-			</div>
+  <div class="table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+      </div>
 
-			<div class="clearfix l-unit__stat-col--left wide-2"><b><?=_('Service');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-right compact-2">&nbsp;</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Description');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Uptime');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('CPU');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Memory');?></b></div>
-		</div>
-	</div>
+      <div class="clearfix l-unit__stat-col--left wide-2"><b><?=_('Service');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-right compact-2">&nbsp;</div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Description');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Uptime');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('CPU');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Memory');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin services status list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-		++$i;
-			if ($data[$key]['STATE'] == 'running') {
-				$status = 'active';
-				$action = 'stop';
-				$spnd_icon = 'fa-stop';
-				$state_icon = 'fa-check-circle status-icon green';
-			} else {
-				$status = 'suspended';
-				$action = 'start';
-				$spnd_icon = 'fa-play';
-				$state_icon = 'fa-minus-circle status-icon red';
-			}
-			if(in_array($key, $phpfpm)){
-				$edit_url="php";
-			} else {
-				$edit_url=$key;
-			}
+  <!-- Begin services status list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+    ++$i;
+      if ($data[$key]['STATE'] == 'running') {
+        $status = 'active';
+        $action = 'stop';
+        $spnd_icon = 'fa-stop';
+        $state_icon = 'fa-check-circle status-icon green';
+      } else {
+        $status = 'suspended';
+        $action = 'start';
+        $spnd_icon = 'fa-play';
+        $state_icon = 'fa-minus-circle status-icon red';
+      }
+      if(in_array($key, $phpfpm)){
+        $edit_url="php";
+      } else {
+        $edit_url=$key;
+      }
 
-			$cpu = $data[$key]['CPU'] / 10;
-			$cpu = number_format($cpu, 1);
-			if ($cpu == '0.0')  $cpu = 0;
-		?>
-		<div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended';?> animated fadeIn" sort-name="<?=strtolower($key)?>"
-			sort-memory="<?=$data[$key]['MEM']?>" sort-cpu="<?=$cpu;?>" sort-uptime="<?=$data[$key]['RTIME']?>">
-			<div class="l-unit__col l-unit__col--right">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="service[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-2">
-					<i class="fas <?=$state_icon;?> icon-pad-right"></i>
-					<b><a href="/edit/server/<? echo $edit_url ?>/" title="<?=_('edit');?>: <?=$key?>"><?=$key?></a></b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center compact-2">
-					<div class="actions-panel clearfix">
-						<div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href">
-							<a href="/edit/server/<? echo $edit_url ?>/" title="<?=_('edit');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim icon-large"></i></a>
-						</div>
-						<div class="actions-panel__col actions-panel__stop shortcut-s" key-action="js">
-							<a id="restart_link_<?=$i?>" class="data-controls do_servicerestart" title="<?=_('restart');?>">
-								<i class="do_servicerestart data-controls fas fa-undo status-icon highlight status-icon dim icon-large"></i>
-								<input type="hidden" name="servicerestart_url" value="/restart/service/?srv=<?=$key?>&token=<?=$_SESSION['token']?>">
-								<div id="restart_link_dialog_<?=$i?>" class="dialog js-confirm-dialog-servicerestart" title="<?=_('Confirmation');?>">
-									<p><?=sprintf(_('RESTART_CONFIRMATION'),$key); ?></p>
-								</div>
-							</a>
-						</div>
-						<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-							<a id="delete_link_<?=$i?>" class="data-controls do_servicestop" title="<?=_($action)?>">
-								<i class="do_servicestop fas <?=$spnd_icon?> status-icon red status-icon dim icon-large"></i>
-								<input type="hidden" name="servicestop_url" value="/<?=$action ?>/service/?srv=<?=$key?>&token=<?=$_SESSION['token']?>">
-								<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-servicestop" title="<?=_('Confirmation');?>">
-									<p><?php if($action == 'stop'){ echo sprintf(_('Are you sure you want to stop service'),$key); }else{ echo sprintf(_('Are you sure you want to start service'),$key); }?></p>
-								</div>
-							</a>
-						</div>
-					</div>
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3"><?=_($data[$key]['SYSTEM'])?></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_time($data[$key]['RTIME'])?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$cpu?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['MEM']?> <?=_('mb');?></b></div>
-			</div>
-		</div>
-	<?php } ?>
+      $cpu = $data[$key]['CPU'] / 10;
+      $cpu = number_format($cpu, 1);
+      if ($cpu == '0.0')  $cpu = 0;
+    ?>
+    <div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended';?> animated fadeIn" sort-name="<?=strtolower($key)?>"
+      sort-memory="<?=$data[$key]['MEM']?>" sort-cpu="<?=$cpu;?>" sort-uptime="<?=$data[$key]['RTIME']?>">
+      <div class="l-unit__col l-unit__col--right">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="service[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-2">
+          <i class="fas <?=$state_icon;?> icon-pad-right"></i>
+          <b><a href="/edit/server/<? echo $edit_url ?>/" title="<?=_('edit');?>: <?=$key?>"><?=$key?></a></b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center compact-2">
+          <div class="actions-panel clearfix">
+            <div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href">
+              <a href="/edit/server/<? echo $edit_url ?>/" title="<?=_('edit');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim icon-large"></i></a>
+            </div>
+            <div class="actions-panel__col actions-panel__stop shortcut-s" key-action="js">
+              <a id="restart_link_<?=$i?>" class="data-controls do_servicerestart" title="<?=_('restart');?>">
+                <i class="do_servicerestart data-controls fas fa-undo status-icon highlight status-icon dim icon-large"></i>
+                <input type="hidden" name="servicerestart_url" value="/restart/service/?srv=<?=$key?>&token=<?=$_SESSION['token']?>">
+                <div id="restart_link_dialog_<?=$i?>" class="dialog js-confirm-dialog-servicerestart" title="<?=_('Confirmation');?>">
+                  <p><?=sprintf(_('RESTART_CONFIRMATION'),$key); ?></p>
+                </div>
+              </a>
+            </div>
+            <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+              <a id="delete_link_<?=$i?>" class="data-controls do_servicestop" title="<?=_($action)?>">
+                <i class="do_servicestop fas <?=$spnd_icon?> status-icon red status-icon dim icon-large"></i>
+                <input type="hidden" name="servicestop_url" value="/<?=$action ?>/service/?srv=<?=$key?>&token=<?=$_SESSION['token']?>">
+                <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-servicestop" title="<?=_('Confirmation');?>">
+                  <p><?php if($action == 'stop'){ echo sprintf(_('Are you sure you want to stop service'),$key); }else{ echo sprintf(_('Are you sure you want to start service'),$key); }?></p>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3"><?=_($data[$key]['SYSTEM'])?></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_time($data[$key]['RTIME'])?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$cpu?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=$data[$key]['MEM']?> <?=_('mb');?></b></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator visible"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="l-unit__col l-unit__col--left clearfix"></div>
-			<div class="data-count l-unit__col l-unit__col--right clearfix"></div>
-		</div>
-	</div>
+  <div class="l-separator visible"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="l-unit__col l-unit__col--left clearfix"></div>
+      <div class="data-count l-unit__col l-unit__col--right clearfix"></div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_stats.html
+++ b/web/templates/pages/list_stats.html
@@ -1,55 +1,55 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if (($_SESSION['userContext'] === 'admin') && (!isset($_SESSION['look']))) { ?>
-				<a class="ui-button cancel" dir="ltr" href='/list/stats/'><i class="fas fa-binoculars status-icon lightblue"></i><?=_('Overall Statistics');?></a>
-			<?php } ?>
-		</div>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-			<?php if (($_SESSION['userContext'] === 'admin') && (!isset($_SESSION['look']))) { ?>
-				<table>
-					<tr>
-						<td>
-							<form action="/list/stats/" method="get" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select class="" name="user">
-										<option value=""><?=_('show per user');?></option>
-										<?php
-											foreach ($users as $key => $value) {
-												if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value === 'admin')) {
-													// Hide admin user from statistics list
-												} else {
-												echo "\t\t\t\t<option value=\"".$value."\"";
-												if ((!empty($v_user)) && ( $value == $_GET['user'])){
-													echo ' selected';
-												}
-													echo ">".$value."</option>\n";
-												}
-											}
-										?>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					</tr>
-				</table>
-			<?php } ?>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if (($_SESSION['userContext'] === 'admin') && (!isset($_SESSION['look']))) { ?>
+        <a class="ui-button cancel" dir="ltr" href='/list/stats/'><i class="fas fa-binoculars status-icon lightblue"></i><?=_('Overall Statistics');?></a>
+      <?php } ?>
+    </div>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+      <?php if (($_SESSION['userContext'] === 'admin') && (!isset($_SESSION['look']))) { ?>
+        <table>
+          <tr>
+            <td>
+              <form action="/list/stats/" method="get" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select class="" name="user">
+                    <option value=""><?=_('show per user');?></option>
+                    <?php
+                      foreach ($users as $key => $value) {
+                        if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value === 'admin')) {
+                          // Hide admin user from statistics list
+                        } else {
+                        echo "\t\t\t\t<option value=\"".$value."\"";
+                        if ((!empty($v_user)) && ( $value == $_GET['user'])){
+                          echo ' selected';
+                        }
+                          echo ">".$value."</option>\n";
+                        }
+                      }
+                    ?>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          </tr>
+        </table>
+      <?php } ?>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -57,190 +57,190 @@
 
 <div class="l-center units">
 
-	<!-- Begin statistics list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-		++$i;
-		?>
-		<div class="header animated fadeIn">
-			<div class="l-unit">
-				<div class="l-unit-toolbar clearfix">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--left">
-					</div>
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right">
-						<div class="actions-panel clearfix">
-						</div>
-					</div>
-				</div>
-				<div class="l-unit__col l-unit__col--left clearfix">
-					<i class="fas fa-chart-bar status-icon dim" style="font-size: 3em;margin-left: 20px;margin-top: 10px;"></i>
-				</div>
-				<div class="l-unit__col l-unit__col--right">
-					<div class="l-unit__name separate">
-						<?php $date = new DateTime($key);
-						echo _($date -> format('M')) .' '.$date -> format('Y');?>
-					</div>
-					<div class="l-unit__stats">
-						<table>
-							<tr>
-								<td>
-									<div class="l-unit__stat-cols clearfix">
-										<div class="l-unit__stat-cols clearfix graph">
-											<div class="l-unit__stat-col l-unit__stat-col--left">
-												<i class="fas fa-exchange-alt status-icon dim large icon-pad-right" title="<?=_('Bandwidth');?>"></i><b><?=_('Bandwidth');?></b>
-											</div>
-											<div class="l-unit__stat-col l-unit__stat-col--right text-right volume">
-												<b><?=humanize_usage_size($data[$key]['U_BANDWIDTH'])?></b> <?=humanize_usage_measure($data[$key]['U_BANDWIDTH'])?>
-											</div>
-										</div>
-										<div class="l-percent">
-											<div class="l-percent__fill" style="width: <?=get_percentage($data[$key]['U_BANDWIDTH'],$data[$key]['BANDWIDTH'])?>%"></div>
-										</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Web Domains');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_WEB_DOMAINS']?></b>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix last">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Mail Domains');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_MAIL_DOMAINS']?></b>
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<div class="l-unit__stat-cols clearfix tiny">
-										<div class="text-right">
-											<?php if (($_SESSION['userContext'] === 'admin') || ($_SESSION['userContext'] === 'user') && ($data[$key]['IP_OWNED'] != "0")) {?>
-												<span style="float: left;font-weight:500;"><?=_('IP Addresses');?>:</span><b><?=$data[$key]['IP_OWNED']?></b> <?=_('IPs');?></span>
-											<?php } ?>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('SSL Domains');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_WEB_SSL']?></b>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix last">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Mail Accounts');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_MAIL_ACCOUNTS']?></b>
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<div class="l-unit__stat-cols clearfix graph">
-										<div class="l-unit__stat-col l-unit__stat-col--left"><i class="fas fa-hdd status-icon dim large icon-pad-right" title="<?=_('Disk');?>"></i><b><?=_('Disk');?></b></div>
-										<div class="l-unit__stat-col l-unit__stat-col--right text-right volume">
-											<b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK'])?>
-										</div>
-									</div>
-									<div class="l-percent">
-										<div class="l-percent__fill" style="width: <?=get_percentage($data[$key]['U_DISK'],$data[$key]['DISK_QUOTA'])?>%"></div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Web Aliases');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_WEB_ALIASES']?></b>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix last">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Databases');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_DATABASES']?></b>
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<div class="l-unit__stat-cols clearfix tiny">
-										<div class="text-right">
-											<span style="float: left;font-weight:500;"><?=_('Web');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_WEB'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_WEB'])?>
-										</div>
-										<div class="text-right">
-											<span style="float: left;font-weight:500;"><?=_('Databases');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_DB'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_DB'])?>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('DNS domains');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_DNS_DOMAINS']?></b>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix last">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Cron Jobs');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_CRON_JOBS']?></b>
-										</div>
-									</div>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<div class="l-unit__stat-cols clearfix tiny">
-										<div class="text-right">
-											<span style="float: left;font-weight:500;"><?=_('Mail');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_MAIL'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_MAIL'])?>
-										</div>
-										<div class="text-right">
-											<span style="float: left;font-weight:500;"><?=_('User Directories');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_DIRS'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_DIRS'])?>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('DNS records');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_DNS_RECORDS']?></b>
-										</div>
-									</div>
-								</td>
-								<td>
-									<div class="l-unit__stat-cols clearfix last">
-										<div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Backups');?>:</div>
-										<div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
-											<b><?=$data[$key]['U_BACKUPS']?></b>
-										</div>
-									</div>
-								</td>
-							</tr>
-						</table>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin statistics list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+    ++$i;
+    ?>
+    <div class="header animated fadeIn">
+      <div class="l-unit">
+        <div class="l-unit-toolbar clearfix">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--left">
+          </div>
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right">
+            <div class="actions-panel clearfix">
+            </div>
+          </div>
+        </div>
+        <div class="l-unit__col l-unit__col--left clearfix">
+          <i class="fas fa-chart-bar status-icon dim" style="font-size: 3em;margin-left: 20px;margin-top: 10px;"></i>
+        </div>
+        <div class="l-unit__col l-unit__col--right">
+          <div class="l-unit__name separate">
+            <?php $date = new DateTime($key);
+            echo _($date -> format('M')) .' '.$date -> format('Y');?>
+          </div>
+          <div class="l-unit__stats">
+            <table>
+              <tr>
+                <td>
+                  <div class="l-unit__stat-cols clearfix">
+                    <div class="l-unit__stat-cols clearfix graph">
+                      <div class="l-unit__stat-col l-unit__stat-col--left">
+                        <i class="fas fa-exchange-alt status-icon dim large icon-pad-right" title="<?=_('Bandwidth');?>"></i><b><?=_('Bandwidth');?></b>
+                      </div>
+                      <div class="l-unit__stat-col l-unit__stat-col--right text-right volume">
+                        <b><?=humanize_usage_size($data[$key]['U_BANDWIDTH'])?></b> <?=humanize_usage_measure($data[$key]['U_BANDWIDTH'])?>
+                      </div>
+                    </div>
+                    <div class="l-percent">
+                      <div class="l-percent__fill" style="width: <?=get_percentage($data[$key]['U_BANDWIDTH'],$data[$key]['BANDWIDTH'])?>%"></div>
+                    </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Web Domains');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_WEB_DOMAINS']?></b>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix last">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Mail Domains');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_MAIL_DOMAINS']?></b>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="l-unit__stat-cols clearfix tiny">
+                    <div class="text-right">
+                      <?php if (($_SESSION['userContext'] === 'admin') || ($_SESSION['userContext'] === 'user') && ($data[$key]['IP_OWNED'] != "0")) {?>
+                        <span style="float: left;font-weight:500;"><?=_('IP Addresses');?>:</span><b><?=$data[$key]['IP_OWNED']?></b> <?=_('IPs');?></span>
+                      <?php } ?>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('SSL Domains');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_WEB_SSL']?></b>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix last">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Mail Accounts');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_MAIL_ACCOUNTS']?></b>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="l-unit__stat-cols clearfix graph">
+                    <div class="l-unit__stat-col l-unit__stat-col--left"><i class="fas fa-hdd status-icon dim large icon-pad-right" title="<?=_('Disk');?>"></i><b><?=_('Disk');?></b></div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right text-right volume">
+                      <b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK'])?>
+                    </div>
+                  </div>
+                  <div class="l-percent">
+                    <div class="l-percent__fill" style="width: <?=get_percentage($data[$key]['U_DISK'],$data[$key]['DISK_QUOTA'])?>%"></div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Web Aliases');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_WEB_ALIASES']?></b>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix last">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Databases');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_DATABASES']?></b>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="l-unit__stat-cols clearfix tiny">
+                    <div class="text-right">
+                      <span style="float: left;font-weight:500;"><?=_('Web');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_WEB'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_WEB'])?>
+                    </div>
+                    <div class="text-right">
+                      <span style="float: left;font-weight:500;"><?=_('Databases');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_DB'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_DB'])?>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('DNS domains');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_DNS_DOMAINS']?></b>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix last">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Cron Jobs');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_CRON_JOBS']?></b>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="l-unit__stat-cols clearfix tiny">
+                    <div class="text-right">
+                      <span style="float: left;font-weight:500;"><?=_('Mail');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_MAIL'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_MAIL'])?>
+                    </div>
+                    <div class="text-right">
+                      <span style="float: left;font-weight:500;"><?=_('User Directories');?>:</span> <b><?=humanize_usage_size($data[$key]['U_DISK_DIRS'])?></b> <?=humanize_usage_measure($data[$key]['U_DISK_DIRS'])?>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('DNS records');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_DNS_RECORDS']?></b>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="l-unit__stat-cols clearfix last">
+                    <div class="l-unit__stat-col l-unit__stat-col--left text-right icon-pad-right text-italic"><?=_('Backups');?>:</div>
+                    <div class="l-unit__stat-col l-unit__stat-col--right statistics-count">
+                      <b><?=$data[$key]['U_BACKUPS']?></b>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d month', '%d months', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d month', '%d months', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_updates.html
+++ b/web/templates/pages/list_updates.html
@@ -1,80 +1,80 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-			<?php
-				if($autoupdate == 'Enabled') {
-					$btn_url = '/delete/cron/autoupdate/?token='.$_SESSION['token'].'';
-					$btn_icon = 'fa-toggle-on status-icon green';
-					$btn_label = _('Disable automatic updates');
-				} else {
-					$btn_url = '/add/cron/autoupdate/?token='.$_SESSION['token'].'';
-					$btn_icon = 'fa-toggle-off status-icon red';
-					$btn_label = _('Enable automatic updates');
-				}
-			?>
-			<a class="ui-button cancel" dir="ltr" href="<?=$btn_url;?>"><i class="fas <?=$btn_icon;?>"></i><?=$btn_label;?></a>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/list/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+      <?php
+        if($autoupdate == 'Enabled') {
+          $btn_url = '/delete/cron/autoupdate/?token='.$_SESSION['token'].'';
+          $btn_icon = 'fa-toggle-on status-icon green';
+          $btn_label = _('Disable automatic updates');
+        } else {
+          $btn_url = '/add/cron/autoupdate/?token='.$_SESSION['token'].'';
+          $btn_icon = 'fa-toggle-off status-icon red';
+          $btn_label = _('Enable automatic updates');
+        }
+      ?>
+      <a class="ui-button cancel" dir="ltr" href="<?=$btn_url;?>"><i class="fas <?=$btn_icon;?>"></i><?=$btn_label;?></a>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
 <div class="l-separator"></div>
 
 <div class="l-center units">
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div>
-				<div class="clearfix l-unit__stat-col--left super-compact center">
-					<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide"><b><?=_('Package');?></b></div>
-				<div class="clearfix l-unit__stat-col--left wide-5"><b><?=_('Description');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center wide"><b><?=_('Version');?></b></div>
-				<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Status');?></b></div>
-			</div>
-		</div>
-	</div>
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div>
+        <div class="clearfix l-unit__stat-col--left super-compact center">
+          <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide"><b><?=_('Package');?></b></div>
+        <div class="clearfix l-unit__stat-col--left wide-5"><b><?=_('Description');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center wide"><b><?=_('Version');?></b></div>
+        <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Status');?></b></div>
+      </div>
+    </div>
+  </div>
 
-	<!-- Begin update list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
+  <!-- Begin update list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
 
-			if ($data[$key]['UPDATED'] == 'yes') {
-				$status = 'active';
-				$upd_status = 'updated';
-			} else {
-				$status = 'suspended';
-				$upd_status = 'outdated';
-			}
-		?>
-		<div class="l-unit<?php if ($status == 'suspended') echo ' l-unit--outdated';?> animated fadeIn">
-			<div class="l-unit-toolbar clearfix">
-				<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-				</div>
-			</div>
+      if ($data[$key]['UPDATED'] == 'yes') {
+        $status = 'active';
+        $upd_status = 'updated';
+      } else {
+        $status = 'suspended';
+        $upd_status = 'outdated';
+      }
+    ?>
+    <div class="l-unit<?php if ($status == 'suspended') echo ' l-unit--outdated';?> animated fadeIn">
+      <div class="l-unit-toolbar clearfix">
+        <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+        </div>
+      </div>
 
-			<div class="l-unit__col l-unit__col--right">
-				<div>
-					<div class="clearfix l-unit__stat-col--left super-compact center">
-						<input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="pkg[]" value="<?=$key?>">
-					</div>
-					<div class="clearfix l-unit__stat-col--left wide"><b><?=$key?></b></div>
-					<div class="clearfix l-unit__stat-col--left wide-5"><?=_($data[$key]['DESCR'])?></div>
-					<div class="clearfix l-unit__stat-col--left text-center wide"><?=$data[$key]['VERSION'] ?> (<?=$data[$key]['ARCH']?>)</div>
-					<div class="clearfix l-unit__stat-col--left text-center">
-						<?php if ($data[$key]['UPDATED'] == 'no') { echo '<i class="fas fa-exclamation-triangle" style="color: orange;"></i>'; } ?>
-						<?php if ($data[$key]['UPDATED'] == 'yes') { echo '<i class="fas fa-check-circle status-icon green"></i>'; } ?>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php } ?>
+      <div class="l-unit__col l-unit__col--right">
+        <div>
+          <div class="clearfix l-unit__stat-col--left super-compact center">
+            <input id="check<?=$i ?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="pkg[]" value="<?=$key?>">
+          </div>
+          <div class="clearfix l-unit__stat-col--left wide"><b><?=$key?></b></div>
+          <div class="clearfix l-unit__stat-col--left wide-5"><?=_($data[$key]['DESCR'])?></div>
+          <div class="clearfix l-unit__stat-col--left text-center wide"><?=$data[$key]['VERSION'] ?> (<?=$data[$key]['ARCH']?>)</div>
+          <div class="clearfix l-unit__stat-col--left text-center">
+            <?php if ($data[$key]['UPDATED'] == 'no') { echo '<i class="fas fa-exclamation-triangle" style="color: orange;"></i>'; } ?>
+            <?php if ($data[$key]['UPDATED'] == 'yes') { echo '<i class="fas fa-check-circle status-icon green"></i>'; } ?>
+          </div>
+        </div>
+      </div>
+    </div>
+  <?php } ?>
 
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
+  <div class="l-separator"></div>
 </div>

--- a/web/templates/pages/list_user.html
+++ b/web/templates/pages/list_user.html
@@ -1,60 +1,60 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a href="/add/user/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add User');?></a>
-			<a href="/list/package/" class="ui-button cancel" dir="ltr"><i class="fas fa-box-open status-icon orange"></i><?=_('Packages');?></a>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-bandwidth" sort_as_int="1"><span class="name"><?=_('Bandwidth');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
-								<?=$label;?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<td>
-						<form action="/bulk/user/" method="post" id="objects">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<div class="l-select">
-								<select class="" name="action">
-									<option value=""><?=_('apply to selected');?></option>
-									<option value="rebuild"><?=_('rebuild');?></option>
-									<option value="rebuild user"><?=_('rebuild user');?></option>
-									<option value="rebuild web"><?=_('rebuild web');?></option>
-									<option value="rebuild dns"><?=_('rebuild dns');?></option>
-									<option value="rebuild mail"><?=_('rebuild mail');?></option>
-									<option value="rebuild db"><?=_('rebuild db');?></option>
-									<option value="rebuild cron"><?=_('rebuild cron');?></option>
-									<option value="update counters"><?=_('update counters');?></option>
-									<option value="suspend"><?= _('suspend');?></option>
-									<option value="unsuspend"><?=_('unsuspend');?></option>
-									<option value="delete"><?=_('delete');?></option>
-								</select>
-							</div>
-							<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-						</form>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a href="/add/user/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add User');?></a>
+      <a href="/list/package/" class="ui-button cancel" dir="ltr"><i class="fas fa-box-open status-icon orange"></i><?=_('Packages');?></a>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-bandwidth" sort_as_int="1"><span class="name"><?=_('Bandwidth');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = _('Name'); } else { $label = _('Date'); } ?>
+                <?=$label;?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <td>
+            <form action="/bulk/user/" method="post" id="objects">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <div class="l-select">
+                <select class="" name="action">
+                  <option value=""><?=_('apply to selected');?></option>
+                  <option value="rebuild"><?=_('rebuild');?></option>
+                  <option value="rebuild user"><?=_('rebuild user');?></option>
+                  <option value="rebuild web"><?=_('rebuild web');?></option>
+                  <option value="rebuild dns"><?=_('rebuild dns');?></option>
+                  <option value="rebuild mail"><?=_('rebuild mail');?></option>
+                  <option value="rebuild db"><?=_('rebuild db');?></option>
+                  <option value="rebuild cron"><?=_('rebuild cron');?></option>
+                  <option value="update counters"><?=_('update counters');?></option>
+                  <option value="suspend"><?= _('suspend');?></option>
+                  <option value="unsuspend"><?=_('unsuspend');?></option>
+                  <option value="delete"><?=_('delete');?></option>
+                </select>
+              </div>
+              <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+            </form>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -62,134 +62,134 @@
 
 <div class="l-center units">
 
-	<!-- Table header -->
-	<div class="table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-3"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Package');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><?=_('IPs');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-hdd" title="<?=_('Disk');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-exchange-alt" title="<?=_('Bandwidth');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-globe-americas" title="<?=_('Web Domains');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-atlas" title="<?=_('DNS Domains');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-mail-bulk" title="<?=_('Mail Domains');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-database" title="<?=_('Databases');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-clock" title="<?=_('Cron Jobs');?>"></i></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-file-archive" title="<?=_('Backups');?>"></i></b></div>
-		</div>
-	</div>
+  <!-- Table header -->
+  <div class="table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');">
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-3"><b><?=_('Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-3"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Package');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><?=_('IPs');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-hdd" title="<?=_('Disk');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><i class="fas fa-exchange-alt" title="<?=_('Bandwidth');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-globe-americas" title="<?=_('Web Domains');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-atlas" title="<?=_('DNS Domains');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-mail-bulk" title="<?=_('Mail Domains');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-database" title="<?=_('Databases');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-clock" title="<?=_('Cron Jobs');?>"></i></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><i class="fas fa-file-archive" title="<?=_('Backups');?>"></i></b></div>
+    </div>
+  </div>
 
-	<!-- Begin user list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-			++$i;
-			if ($data[$key]['SUSPENDED'] == 'yes') {
-				$status = 'suspended';
-				$spnd_action = 'unsuspend';
-				$spnd_icon = 'fa-play';
-				$spnd_confirmation = _('UNSUSPEND_USER_CONFIRMATION');
-			} else {
-				$status = 'active';
-				$spnd_action = 'suspend';
-				$spnd_icon = 'fa-pause';
-				$spnd_confirmation = _('SUSPEND_USER_CONFIRMATION');
-			}
-		?>
-		<div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended';?> animated fadeIn" v_section="user"
-			v_unit_id="<?=$key?>" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=strtolower($key)?>"
-			sort-bandwidth="<?=$data[$key]['U_BANDWIDTH']?>" sort-disk="<?=$data[$key]['U_DISK']?>">
-			<div class="l-unit__col l-unit__col--right" style="<?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($_SESSION['user'] !== 'admin') && ($key === 'admin')) { echo 'display: none';} else {echo 'display: table-cell';}?>">
-				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="user[]" value="<?=$key?>">
-				</div>
-				<div class="clearfix l-unit__stat-col--left wide-3 userlist-username">
-					<?php if ($key == $user_plain) { ?>
-						<b><a href="/edit/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing User');?>"><?=$key?> <span style="font-weight: normal !important;">(<?=$data[$key]['NAME'];?>)</span></a></b>
-					<?php } else { ?>
-						<b><a href="/login/?loginas=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('login as');?> <?=$key?>"><?=$key?> <span style="font-weight: normal !important;">(<?=$data[$key]['NAME'];?>)</span></a></b>
-					<?php } ?>
-					<br>
-					<div class="userlist-email"><b><?=_('Email');?>:</b> <?=$data[$key]['CONTACT']?></div>
-				</div>
-				<!-- START QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-right compact-3">
-					<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-						<div class="actions-panel clearfix">
-							<?php if ($key == $user_plain) { ?>
-								<i class="fas fa-user-check status-icon status-icon dim icon-large" title="<?=$key?> (<?=$data[$key]['NAME']?>)"></i>
-							<?php } else { ?>
-								<a href="/login/?loginas=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('login as');?> <?=$key?>"><i class="fas fa-sign-in-alt status-icon green status-icon dim icon-large"></i></a>
-							<?php } ?>
-							<?php if (($_SESSION['userContext'] === 'admin') && ($key == 'admin') && ($_SESSION['user'] != 'admin')) { ?>
-								<!-- Hide edit button from admin user when logged in with another admin user -->
-								&nbsp;
-							<?php } else { ?>
-								<div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href"><a href="/edit/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing User');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-							<?php } ?>
-							<?php if ($key == 'admin') { ?>
-								<!-- Hide suspend and delete buttons in the user list for primary 'admin' account -->
-							<?php } else { ?>
-								<?php if ($key == $user_plain) { ?>
-									<!-- Hide suspend and delete buttons in the user list for current user -->
-								<?php } else { ?>
-								<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-									<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-										<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-										<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-											<p><?=sprintf($spnd_confirmation,$key)?></p>
-										</div>
-									</a>
-								</div>
-								<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-									<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-										<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-										<input type="hidden" name="delete_url" value="/delete/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>">
-										<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-											<p><?=sprintf(_('DELETE_USER_CONFIRMATION'),$key)?></p>
-										</div>
-									</a>
-								</div>
-								<?php } ?>
-							<?php } ?>
-						</div>
-					</div>
-				</div>
-				<!-- END QUICK ACTION TOOLBAR AREA -->
-				<div class="clearfix l-unit__stat-col--left text-center">
-					<b>
-						<?php if ($data[$key]['PACKAGE'] === 'default' ){?>
-							<?=$data[$key]['PACKAGE']?>
-						<?php } else { ?>
-							<a href="/edit/package/?package=<?=$data[$key]['PACKAGE']?>&token=<?=$_SESSION['token']?>" title="<?=_('Edit Package');?>"><?=$data[$key]['PACKAGE']?></a>
-						<?php } ?>
-					</b>
-				</div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact"><?=$data[$key]['IP_OWNED']?></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=humanize_usage_size($data[$key]['U_BANDWIDTH'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_BANDWIDTH'])?></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_WEB_DOMAINS']?> <?=_('Web Domains');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_WEB_DOMAINS']?></b></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_DNS_DOMAINS']?> <?=_('DNS Domains');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_DNS_DOMAINS']?></b></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_MAIL_DOMAINS']?> <?=_('Mail Domains');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_MAIL_DOMAINS']?></b></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_DATABASES']?> <?=_('Databases');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_DATABASES']?></b></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_CRON_JOBS']?> <?=_('Cron Jobs');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_CRON_JOBS']?></b></span></div>
-				<div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_BACKUPS']?> <?=_('Backups');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_BACKUPS']?></b></span></div>
-			</div>
-		</div>
-	<?php } ?>
+  <!-- Begin user list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+      ++$i;
+      if ($data[$key]['SUSPENDED'] == 'yes') {
+        $status = 'suspended';
+        $spnd_action = 'unsuspend';
+        $spnd_icon = 'fa-play';
+        $spnd_confirmation = _('UNSUSPEND_USER_CONFIRMATION');
+      } else {
+        $status = 'active';
+        $spnd_action = 'suspend';
+        $spnd_icon = 'fa-pause';
+        $spnd_confirmation = _('SUSPEND_USER_CONFIRMATION');
+      }
+    ?>
+    <div class="l-unit <?php if ($status == 'suspended') echo 'l-unit--suspended';?> animated fadeIn" v_section="user"
+      v_unit_id="<?=$key?>" sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>" sort-name="<?=strtolower($key)?>"
+      sort-bandwidth="<?=$data[$key]['U_BANDWIDTH']?>" sort-disk="<?=$data[$key]['U_DISK']?>">
+      <div class="l-unit__col l-unit__col--right" style="<?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($_SESSION['user'] !== 'admin') && ($key === 'admin')) { echo 'display: none';} else {echo 'display: table-cell';}?>">
+        <div class="clearfix l-unit__stat-col--left super-compact">
+          <input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="user[]" value="<?=$key?>">
+        </div>
+        <div class="clearfix l-unit__stat-col--left wide-3 userlist-username">
+          <?php if ($key == $user_plain) { ?>
+            <b><a href="/edit/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing User');?>"><?=$key?> <span style="font-weight: normal !important;">(<?=$data[$key]['NAME'];?>)</span></a></b>
+          <?php } else { ?>
+            <b><a href="/login/?loginas=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('login as');?> <?=$key?>"><?=$key?> <span style="font-weight: normal !important;">(<?=$data[$key]['NAME'];?>)</span></a></b>
+          <?php } ?>
+          <br>
+          <div class="userlist-email"><b><?=_('Email');?>:</b> <?=$data[$key]['CONTACT']?></div>
+        </div>
+        <!-- START QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-right compact-3">
+          <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+            <div class="actions-panel clearfix">
+              <?php if ($key == $user_plain) { ?>
+                <i class="fas fa-user-check status-icon status-icon dim icon-large" title="<?=$key?> (<?=$data[$key]['NAME']?>)"></i>
+              <?php } else { ?>
+                <a href="/login/?loginas=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('login as');?> <?=$key?>"><i class="fas fa-sign-in-alt status-icon green status-icon dim icon-large"></i></a>
+              <?php } ?>
+              <?php if (($_SESSION['userContext'] === 'admin') && ($key == 'admin') && ($_SESSION['user'] != 'admin')) { ?>
+                <!-- Hide edit button from admin user when logged in with another admin user -->
+                &nbsp;
+              <?php } else { ?>
+                <div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href"><a href="/edit/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing User');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+              <?php } ?>
+              <?php if ($key == 'admin') { ?>
+                <!-- Hide suspend and delete buttons in the user list for primary 'admin' account -->
+              <?php } else { ?>
+                <?php if ($key == $user_plain) { ?>
+                  <!-- Hide suspend and delete buttons in the user list for current user -->
+                <?php } else { ?>
+                <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                  <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                    <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                    <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf($spnd_confirmation,$key)?></p>
+                    </div>
+                  </a>
+                </div>
+                <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                  <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                    <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                    <input type="hidden" name="delete_url" value="/delete/user/?user=<?=$key?>&token=<?=$_SESSION['token']?>">
+                    <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                      <p><?=sprintf(_('DELETE_USER_CONFIRMATION'),$key)?></p>
+                    </div>
+                  </a>
+                </div>
+                <?php } ?>
+              <?php } ?>
+            </div>
+          </div>
+        </div>
+        <!-- END QUICK ACTION TOOLBAR AREA -->
+        <div class="clearfix l-unit__stat-col--left text-center">
+          <b>
+            <?php if ($data[$key]['PACKAGE'] === 'default' ){?>
+              <?=$data[$key]['PACKAGE']?>
+            <?php } else { ?>
+              <a href="/edit/package/?package=<?=$data[$key]['PACKAGE']?>&token=<?=$_SESSION['token']?>" title="<?=_('Edit Package');?>"><?=$data[$key]['PACKAGE']?></a>
+            <?php } ?>
+          </b>
+        </div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact"><?=$data[$key]['IP_OWNED']?></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=humanize_usage_size($data[$key]['U_BANDWIDTH'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_BANDWIDTH'])?></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_WEB_DOMAINS']?> <?=_('Web Domains');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_WEB_DOMAINS']?></b></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_DNS_DOMAINS']?> <?=_('DNS Domains');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_DNS_DOMAINS']?></b></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_MAIL_DOMAINS']?> <?=_('Mail Domains');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_MAIL_DOMAINS']?></b></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_DATABASES']?> <?=_('Databases');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_DATABASES']?></b></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_CRON_JOBS']?> <?=_('Cron Jobs');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_CRON_JOBS']?></b></span></div>
+        <div class="clearfix l-unit__stat-col--left text-center super-compact" title="<?=$data[$key]['U_BACKUPS']?> <?=_('Backups');?>"><span class="jump-top badge gray raised"><b><?=$data[$key]['U_BACKUPS']?></b></span></div>
+      </div>
+    </div>
+  <?php } ?>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator visible"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d user account', '%d user accounts', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator visible"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d user account', '%d user accounts', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_web.html
+++ b/web/templates/pages/list_web.html
@@ -1,59 +1,59 @@
 <!-- Begin toolbar -->
 <div class="l-center">
-	<div class="l-sort clearfix noselect">
-		<div class="l-unit-toolbar__buttonstrip">
-			<?php if ($read_only !== 'true') {?>
-				<a href="/add/web/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Web Domain');?></a>
-			<?php } ?>
-		</div>
-		<ul class="context-menu sort-order animated fadeIn" style="display:none;">
-			<li entity="sort-bandwidth" sort_as_int="1"><span class="name"><?=_('Bandwidth');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-			<li entity="sort-ip" sort_as_int="1"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
-		</ul>
-		<div class="l-sort-toolbar clearfix">
-			<table>
-				<tr>
-					<td class="sort-by" title="<?=_('Sort items');?>">
-						<?=_('sort by');?>: <span>
-							<b>
-								<?php if ($_SESSION['userSortOrder'] === 'name') { $label = ('Name'); } else { $label = _('Date'); } ?>
-								<?=$label?> <i class="fas fa-sort-alpha-down"></i>
-							</b>
-						</span>
-					</td>
-					<td class="l-sort-toolbar__search-box">
-						<form action="/search/" method="get">
-							<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-							<input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
-							<button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
-						</form>
-					</td>
-					<?php if ($read_only !== 'true') {?>
-						<td>
-							<form action="/bulk/web/" method="post" id="objects">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-								<div class="l-select">
-									<select name="action">
-										<option value=""><?=_('apply to selected');?></option>
-										<?php if ($_SESSION['userContext'] === 'admin') {?>
-											<option value="rebuild"><?=_('rebuild');?></option>
-										<?php } ?>
-										<option value="suspend"><?=_('suspend');?></option>
-										<option value="unsuspend"><?=_('unsuspend');?></option>
-										<option value="delete"><?=_('delete');?></option>
-									</select>
-								</div>
-								<button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
-							</form>
-						</td>
-					<?php } ?>
-				</tr>
-			</table>
-		</div>
-	</div>
+  <div class="l-sort clearfix noselect">
+    <div class="l-unit-toolbar__buttonstrip">
+      <?php if ($read_only !== 'true') {?>
+        <a href="/add/web/" id="btn-create" class="ui-button cancel" dir="ltr"><i class="fas fa-plus-circle status-icon green"></i><?=_('Add Web Domain');?></a>
+      <?php } ?>
+    </div>
+    <ul class="context-menu sort-order animated fadeIn" style="display:none;">
+      <li entity="sort-bandwidth" sort_as_int="1"><span class="name"><?=_('Bandwidth');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?=_('Date');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-disk" sort_as_int="1"><span class="name"><?=_('Disk');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?=_('Name');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+      <li entity="sort-ip" sort_as_int="1"><span class="name"><?=_('IP address');?> <i class="fas fa-sort-alpha-down"></i></span><span class="up"><i class="fas fa-sort-alpha-up"></i></span></li>
+    </ul>
+    <div class="l-sort-toolbar clearfix">
+      <table>
+        <tr>
+          <td class="sort-by" title="<?=_('Sort items');?>">
+            <?=_('sort by');?>: <span>
+              <b>
+                <?php if ($_SESSION['userSortOrder'] === 'name') { $label = ('Name'); } else { $label = _('Date'); } ?>
+                <?=$label?> <i class="fas fa-sort-alpha-down"></i>
+              </b>
+            </span>
+          </td>
+          <td class="l-sort-toolbar__search-box">
+            <form action="/search/" method="get">
+              <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+              <input type="text" class="search-input" name="q" value="<? echo isset($_POST['q']) ? htmlspecialchars($_POST['q']) : '' ?>" title="<?=_('Search');?>">
+              <button type="submit" class="l-sort-toolbar__filter-apply" onclick="return doSearch('/search/')" value="" title="<?=_('Search');?>"><i class="fas fa-search"></i></button>
+            </form>
+          </td>
+          <?php if ($read_only !== 'true') {?>
+            <td>
+              <form action="/bulk/web/" method="post" id="objects">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+                <div class="l-select">
+                  <select name="action">
+                    <option value=""><?=_('apply to selected');?></option>
+                    <?php if ($_SESSION['userContext'] === 'admin') {?>
+                      <option value="rebuild"><?=_('rebuild');?></option>
+                    <?php } ?>
+                    <option value="suspend"><?=_('suspend');?></option>
+                    <option value="unsuspend"><?=_('unsuspend');?></option>
+                    <option value="delete"><?=_('delete');?></option>
+                  </select>
+                </div>
+                <button type="submit" class="l-sort-toolbar__filter-apply" value="" title="<?=_('apply to selected');?>"><i class="fas fa-arrow-right"></i></button>
+              </form>
+            </td>
+          <?php } ?>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -61,196 +61,196 @@
 
 <div class="l-center units narrow">
 
-	<!-- Table header -->
-	<div class="header table-header">
-		<div class="l-unit__col l-unit__col--right">
-			<div class="clearfix l-unit__stat-col--left super-compact">
-				<input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
-			</div>
-			<div class="clearfix l-unit__stat-col--left wide-4"><b><?=_('Name');?></b></div>
-			<div class="clearfix l-unit__stat-col--left compact-4 text-right"><b>&nbsp;</b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('IP address');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Disk');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Bandwidth');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center"><b><?=_('SSL');?></b></div>
-			<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Statistics');?></b></div>
-		</div>
-	</div>
+  <!-- Table header -->
+  <div class="header table-header">
+    <div class="l-unit__col l-unit__col--right">
+      <div class="clearfix l-unit__stat-col--left super-compact">
+        <input id="toggle-all" type="checkbox" name="toggle-all" value="toggle-all" title="<?=_('Select all');?>" onchange="checkedAll('objects');" <?=$display_mode;?>>
+      </div>
+      <div class="clearfix l-unit__stat-col--left wide-4"><b><?=_('Name');?></b></div>
+      <div class="clearfix l-unit__stat-col--left compact-4 text-right"><b>&nbsp;</b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('IP address');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('Disk');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Bandwidth');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center"><b><?=_('SSL');?></b></div>
+      <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=_('Statistics');?></b></div>
+    </div>
+  </div>
 
-	<!-- Begin web domain list item loop -->
-	<?php
-		foreach ($data as $key => $value) {
-				++$i;
-				if ($data[$key]['SUSPENDED'] == 'yes') {
-						$status = 'suspended';
-						$spnd_action = 'unsuspend';
-						$spnd_icon = 'fa-play';
-						$spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
-				} else {
-						$status = 'active';
-						$spnd_action = 'suspend';
-						$spnd_icon = 'fa-pause';
-						$spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
-				}
-				if (!empty($data[$key]['SSL_HOME'])) {
-						if ($data[$key]['SSL_HOME'] == 'same') {
-								$ssl_home = 'public_html';
-						} else {
-								$ssl_home = 'public_shtml';
-						}
-				} else {
-						$ssl_home = '';
-				}
-				$web_stats='no';
-				if (!empty($data[$key]['STATS'])) {
-						$web_stats=$data[$key]['STATS'];
-				}
-				$ftp_user='no';
-				if (!empty($data[$key]['FTP_USER'])) {
-						$ftp_user=$data[$key]['FTP_USER'];
+  <!-- Begin web domain list item loop -->
+  <?php
+    foreach ($data as $key => $value) {
+        ++$i;
+        if ($data[$key]['SUSPENDED'] == 'yes') {
+            $status = 'suspended';
+            $spnd_action = 'unsuspend';
+            $spnd_icon = 'fa-play';
+            $spnd_confirmation = _('UNSUSPEND_DOMAIN_CONFIRMATION');
+        } else {
+            $status = 'active';
+            $spnd_action = 'suspend';
+            $spnd_icon = 'fa-pause';
+            $spnd_confirmation = _('SUSPEND_DOMAIN_CONFIRMATION');
+        }
+        if (!empty($data[$key]['SSL_HOME'])) {
+            if ($data[$key]['SSL_HOME'] == 'same') {
+                $ssl_home = 'public_html';
+            } else {
+                $ssl_home = 'public_shtml';
+            }
+        } else {
+            $ssl_home = '';
+        }
+        $web_stats='no';
+        if (!empty($data[$key]['STATS'])) {
+            $web_stats=$data[$key]['STATS'];
+        }
+        $ftp_user='no';
+        if (!empty($data[$key]['FTP_USER'])) {
+            $ftp_user=$data[$key]['FTP_USER'];
 
-				}
-				if (strlen($ftp_user) > 24 ) {
-						$ftp_user = str_replace(':', ', ', $ftp_user);
-						$ftp_user = substr($ftp_user, 0, 24);
-						$ftp_user = trim($ftp_user, ":");
-						$ftp_user = str_replace(':', ', ', $ftp_user);
-						$ftp_user = $ftp_user.", ...";
-				} else {
-						$ftp_user = str_replace(':', ', ', $ftp_user);
-				}
+        }
+        if (strlen($ftp_user) > 24 ) {
+            $ftp_user = str_replace(':', ', ', $ftp_user);
+            $ftp_user = substr($ftp_user, 0, 24);
+            $ftp_user = trim($ftp_user, ":");
+            $ftp_user = str_replace(':', ', ', $ftp_user);
+            $ftp_user = $ftp_user.", ...";
+        } else {
+            $ftp_user = str_replace(':', ', ', $ftp_user);
+        }
 
-				$backend_support='no';
-				if (!empty($data[$key]['BACKEND'])) {
-						$backend_support='yes';
-				}
+        $backend_support='no';
+        if (!empty($data[$key]['BACKEND'])) {
+            $backend_support='yes';
+        }
 
-				$proxy_support='no';
-				if (!empty($data[$key]['PROXY'])) {
-						$proxy_support='yes';
-				}
-				if (strlen($data[$key]['PROXY_EXT']) > 24 ) {
-						$proxy_ext_title = str_replace(',', ', ', $data[$key]['PROXY_EXT']);
-						$proxy_ext = substr($data[$key]['PROXY_EXT'], 0, 24);
-						$proxy_ext = trim($proxy_ext, ",");
-						$proxy_ext = str_replace(',', ', ', $proxy_ext);
-						$proxy_ext = $proxy_ext.", ...";
-				} else {
-						$proxy_ext_title = '';
-						$proxy_ext = str_replace(',', ', ', $data[$key]['PROXY_EXT']);
-				}
-				if ($data[$key]['SUSPENDED'] === 'yes') {
-					if ($data[$key]['SSL'] == 'no') {
-						$icon_ssl = 'fas fa-times-circle';
-					}
-					if ($data[$key]['SSL'] == 'yes') {
-						$icon_ssl = 'fas fa-check-circle';
-					}
-					if ($web_stats == 'no') {
-						$icon_webstats = 'fas fa-times-circle';
-					} else {
-						$icon_webstats = 'fas fa-check-circle';
-					}
-				} else {
-					if ($data[$key]['SSL'] == 'no') {
-						$icon_ssl = 'fas fa-times-circle status-icon red';
-					}
-					if ($data[$key]['SSL'] == 'yes') {
-						$icon_ssl = 'fas fa-check-circle status-icon green';
-					}
-					if ($web_stats == 'no') {
-						$icon_webstats = 'fas fa-times-circle status-icon red';
-					} else {
-						$icon_webstats = 'fas fa-check-circle status-icon green';
-					}
-				}
-			?>
-			<div class="l-unit <?php if ($data[$key]['SUSPENDED'] == 'yes') echo 'l-unit--suspended';?> animated fadeIn" v_section="web" v_unit_id="<?=$key?>"
-				id="web-unit-<?=$i?>" sort-ip="<?=str_replace('.', '', $data[$key]['IP'])?>"
-				sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>"
-				sort-name="<?=$key?>" sort-bandwidth="<?=$data[$key]['U_BANDWIDTH']?>" sort-disk="<?=$data[$key]['U_DISK']?>">
-				<div class="l-unit__col l-unit__col--right">
-					<div class="clearfix l-unit__stat-col--left super-compact">
-						<input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="domain[]" value="<?=$key?>" <?=$display_mode;?>>
-					</div>
-					<div class="clearfix l-unit__stat-col--left wide-4 truncate">
-						<b>
-							<?php if ($read_only === 'true') {?>
-								<?=$key?>
-							<?php } else {
-								$aliases = explode(',', $data[$key]['ALIAS']);
-								$alias_new = array();
-								foreach($aliases as $alias){
-									if($alias != 'www.'.$key){
-										$alias_new[] = trim($alias);
-									}
-								}
-								?>
-								<a href="/edit/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Domain');?>: <?=$key?>"><?=$key?><?php if( !empty($alias_new) && !empty($data[$key]['ALIAS']) ){ echo " <span class=\"hint\">(".implode(',',$alias_new).")"; } ?></a>
-							<?php } ?>
-						</b>
-					</div>
-					<!-- START QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left compact-4 text-right">
-						<div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
-							<div class="actions-panel clearfix">
-								<?php if (!empty($data[$key]['STATS'])) { ?>
-									<div class="actions-panel__col actions-panel__logs shortcut-w" key-action="href"><a href="http://<?=$key?>/vstats/" rel="noopener" target="_blank" rel="noopener" title="<?=_('Statistics');?>"><i class="fas fa-chart-bar status-icon maroon status-icon dim"></i></a></div>
-								<?php } ?>
-									<div class="actions-panel__col actions-panel__view" key-action="href"><a href="http://<?=$key?>/" rel="noopener" target="_blank"><i class="fas fa-external-link-square-alt status-icon lightblue status-icon dim"></i></a></div>
-								<?php if ($read_only === 'true') {?>
-									<!-- Restrict ability to edit, delete, or suspend web domains when impersonating the 'admin' account -->
-									&nbsp;
-								<?php } else { ?>
-									<?php if ($data[$key]['SUSPENDED'] == 'no') {?>
-										<div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href"><a href="/edit/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Domain');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
-									<?php } ?>
-									<div class="actions-panel__col actions-panel__logs shortcut-l" key-action="href"><a href="/list/web-log/?domain=<?=$key?>&type=access#" title="<?=_('AccessLog');?>"><i class="fas fa-binoculars status-icon purple status-icon dim"></i></a></div>
-									<div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
-										<a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
-											<i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
-											<input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
-											<div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
-												<p><?=sprintf($spnd_confirmation,$key)?></p>
-											</div>
-										</a>
-									</div>
-									<div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
-										<a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
-											<i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
-											<input type="hidden" name="delete_url" value="/delete/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
-											<div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
-												<p><?=sprintf(_('DELETE_DOMAIN_CONFIRMATION'),$key)?></p>
-											</div>
-										</a>
-									</div>
-								<?php } ?>
-							</div>
-						</div>
-					</div>
-					<!-- END QUICK ACTION TOOLBAR AREA -->
-					<div class="clearfix l-unit__stat-col--left text-center"><?=empty($ips[$data[$key]['IP']]['NAT']) ? $data[$key]['IP'] : "{$ips[$data[$key]['IP']]['NAT']}"; ?></div>
-					<div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
-					<div class="clearfix l-unit__stat-col--left text-center compact"><b><?=humanize_usage_size($data[$key]['U_BANDWIDTH'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_BANDWIDTH'])?></span></div>
-					<div class="clearfix l-unit__stat-col--left text-center">
-						<i class="fas <?=$icon_ssl;?>"></i>
-					</div>
-					<div class="clearfix l-unit__stat-col--left text-center compact">
-						<i class="fas <?=$icon_webstats;?>"></i>
-					</div>
-				</div>
-			</div>
-		<?php } ?>
-	</div>
+        $proxy_support='no';
+        if (!empty($data[$key]['PROXY'])) {
+            $proxy_support='yes';
+        }
+        if (strlen($data[$key]['PROXY_EXT']) > 24 ) {
+            $proxy_ext_title = str_replace(',', ', ', $data[$key]['PROXY_EXT']);
+            $proxy_ext = substr($data[$key]['PROXY_EXT'], 0, 24);
+            $proxy_ext = trim($proxy_ext, ",");
+            $proxy_ext = str_replace(',', ', ', $proxy_ext);
+            $proxy_ext = $proxy_ext.", ...";
+        } else {
+            $proxy_ext_title = '';
+            $proxy_ext = str_replace(',', ', ', $data[$key]['PROXY_EXT']);
+        }
+        if ($data[$key]['SUSPENDED'] === 'yes') {
+          if ($data[$key]['SSL'] == 'no') {
+            $icon_ssl = 'fas fa-times-circle';
+          }
+          if ($data[$key]['SSL'] == 'yes') {
+            $icon_ssl = 'fas fa-check-circle';
+          }
+          if ($web_stats == 'no') {
+            $icon_webstats = 'fas fa-times-circle';
+          } else {
+            $icon_webstats = 'fas fa-check-circle';
+          }
+        } else {
+          if ($data[$key]['SSL'] == 'no') {
+            $icon_ssl = 'fas fa-times-circle status-icon red';
+          }
+          if ($data[$key]['SSL'] == 'yes') {
+            $icon_ssl = 'fas fa-check-circle status-icon green';
+          }
+          if ($web_stats == 'no') {
+            $icon_webstats = 'fas fa-times-circle status-icon red';
+          } else {
+            $icon_webstats = 'fas fa-check-circle status-icon green';
+          }
+        }
+      ?>
+      <div class="l-unit <?php if ($data[$key]['SUSPENDED'] == 'yes') echo 'l-unit--suspended';?> animated fadeIn" v_section="web" v_unit_id="<?=$key?>"
+        id="web-unit-<?=$i?>" sort-ip="<?=str_replace('.', '', $data[$key]['IP'])?>"
+        sort-date="<?=strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])?>"
+        sort-name="<?=$key?>" sort-bandwidth="<?=$data[$key]['U_BANDWIDTH']?>" sort-disk="<?=$data[$key]['U_DISK']?>">
+        <div class="l-unit__col l-unit__col--right">
+          <div class="clearfix l-unit__stat-col--left super-compact">
+            <input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?=_('Select');?>" name="domain[]" value="<?=$key?>" <?=$display_mode;?>>
+          </div>
+          <div class="clearfix l-unit__stat-col--left wide-4 truncate">
+            <b>
+              <?php if ($read_only === 'true') {?>
+                <?=$key?>
+              <?php } else {
+                $aliases = explode(',', $data[$key]['ALIAS']);
+                $alias_new = array();
+                foreach($aliases as $alias){
+                  if($alias != 'www.'.$key){
+                    $alias_new[] = trim($alias);
+                  }
+                }
+                ?>
+                <a href="/edit/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Domain');?>: <?=$key?>"><?=$key?><?php if( !empty($alias_new) && !empty($data[$key]['ALIAS']) ){ echo " <span class=\"hint\">(".implode(',',$alias_new).")"; } ?></a>
+              <?php } ?>
+            </b>
+          </div>
+          <!-- START QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left compact-4 text-right">
+            <div class="l-unit-toolbar__col l-unit-toolbar__col--right noselect">
+              <div class="actions-panel clearfix">
+                <?php if (!empty($data[$key]['STATS'])) { ?>
+                  <div class="actions-panel__col actions-panel__logs shortcut-w" key-action="href"><a href="http://<?=$key?>/vstats/" rel="noopener" target="_blank" rel="noopener" title="<?=_('Statistics');?>"><i class="fas fa-chart-bar status-icon maroon status-icon dim"></i></a></div>
+                <?php } ?>
+                  <div class="actions-panel__col actions-panel__view" key-action="href"><a href="http://<?=$key?>/" rel="noopener" target="_blank"><i class="fas fa-external-link-square-alt status-icon lightblue status-icon dim"></i></a></div>
+                <?php if ($read_only === 'true') {?>
+                  <!-- Restrict ability to edit, delete, or suspend web domains when impersonating the 'admin' account -->
+                  &nbsp;
+                <?php } else { ?>
+                  <?php if ($data[$key]['SUSPENDED'] == 'no') {?>
+                    <div class="actions-panel__col actions-panel__edit shortcut-enter" key-action="href"><a href="/edit/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>" title="<?=_('Editing Domain');?>"><i class="fas fa-pencil-alt status-icon orange status-icon dim"></i></a></div>
+                  <?php } ?>
+                  <div class="actions-panel__col actions-panel__logs shortcut-l" key-action="href"><a href="/list/web-log/?domain=<?=$key?>&type=access#" title="<?=_('AccessLog');?>"><i class="fas fa-binoculars status-icon purple status-icon dim"></i></a></div>
+                  <div class="actions-panel__col actions-panel__suspend shortcut-s" key-action="js">
+                    <a id="<?=$spnd_action ?>_link_<?=$i?>" class="data-controls do_<?=$spnd_action?>" title="<?=_($spnd_action)?>">
+                      <i class="fas <?=$spnd_icon?> status-icon highlight status-icon dim do_<?=$spnd_action?>"></i>
+                      <input type="hidden" name="<?=$spnd_action?>_url" value="/<?=$spnd_action?>/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
+                      <div id="<?=$spnd_action?>_dialog_<?=$i?>" class="dialog js-confirm-dialog-suspend" title="<?=_('Confirmation');?>">
+                        <p><?=sprintf($spnd_confirmation,$key)?></p>
+                      </div>
+                    </a>
+                  </div>
+                  <div class="actions-panel__col actions-panel__delete shortcut-delete" key-action="js">
+                    <a id="delete_link_<?=$i?>" class="data-controls do_delete" title="<?=_('delete');?>">
+                      <i class="fas fa-trash status-icon red status-icon dim do_delete"></i>
+                      <input type="hidden" name="delete_url" value="/delete/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>">
+                      <div id="delete_dialog_<?=$i?>" class="dialog js-confirm-dialog-delete" title="<?=_('Confirmation');?>">
+                        <p><?=sprintf(_('DELETE_DOMAIN_CONFIRMATION'),$key)?></p>
+                      </div>
+                    </a>
+                  </div>
+                <?php } ?>
+              </div>
+            </div>
+          </div>
+          <!-- END QUICK ACTION TOOLBAR AREA -->
+          <div class="clearfix l-unit__stat-col--left text-center"><?=empty($ips[$data[$key]['IP']]['NAT']) ? $data[$key]['IP'] : "{$ips[$data[$key]['IP']]['NAT']}"; ?></div>
+          <div class="clearfix l-unit__stat-col--left text-center"><b><?=humanize_usage_size($data[$key]['U_DISK'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_DISK'])?></span></div>
+          <div class="clearfix l-unit__stat-col--left text-center compact"><b><?=humanize_usage_size($data[$key]['U_BANDWIDTH'])?></b> <span class="text-small"><?=humanize_usage_measure($data[$key]['U_BANDWIDTH'])?></span></div>
+          <div class="clearfix l-unit__stat-col--left text-center">
+            <i class="fas <?=$icon_ssl;?>"></i>
+          </div>
+          <div class="clearfix l-unit__stat-col--left text-center compact">
+            <i class="fas <?=$icon_webstats;?>"></i>
+          </div>
+        </div>
+      </div>
+    <?php } ?>
+  </div>
 </div>
 
 <div id="vstobjects">
-	<div class="l-separator"></div>
-	<div class="l-center">
-		<div class="l-unit-ft">
-			<div class="data-count l-unit__col l-unit__col--right clearfix">
-				<?php printf(ngettext('%d web domain', '%d web domains', $i),$i); ?>
-			</div>
-		</div>
-	</div>
+  <div class="l-separator"></div>
+  <div class="l-center">
+    <div class="l-unit-ft">
+      <div class="data-count l-unit__col l-unit__col--right clearfix">
+        <?php printf(ngettext('%d web domain', '%d web domains', $i),$i); ?>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/templates/pages/list_webapps.html
+++ b/web/templates/pages/list_webapps.html
@@ -1,12 +1,12 @@
 <!-- Begin toolbar -->
 <div class="l-center edit">
-	<div class="l-sort clearfix">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/web/?domain=<?=htmlentities($v_domain)?>"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-		</div>
-	</div>
+  <div class="l-sort clearfix">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/edit/web/?domain=<?=htmlentities($v_domain)?>"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -14,42 +14,42 @@
 
 <div class="l-center animated fadeIn" style="padding-top:240px;">
 
-	<div style="margin-left:68px; margin-top: 20px">
-		<h1 class="page-title"><?=_('Quick Install App');?></h1>
-		<div>
-			<span>
-				<?php
-					if (!empty($_SESSION['error_msg'])) {
-						$msg_icon = 'fa-exclamation-circle status-icon red';
-						$msg_text = htmlentities($_SESSION['error_msg']);
-						$msg_id = 'vst-error';
-					} else {
-						if (!empty($_SESSION['ok_msg'])) {
-							$msg_icon = 'fa-check-circle status-icon green';
-							$msg_text = $_SESSION['ok_msg'];
-							$msg_id = 'vst-ok';
-						}
-					}
-					if(!empty($msg_id)){
-				?>
-				<span class="<?=$msg_id;?>"> <i class="fas <?=$msg_icon;?>"></i> <?=$msg_text;?></span>
-				<?php }; ?>
-			</span>
-		</div>
-	</div>
-	<div class="app-list cards u-mb20">
-		<!-- List available web apps -->
-		<?php foreach($v_web_apps as $webapp):?>
-			<div class="card <?=($webapp['enabled'] ? '' : 'disable');?>">
-				<div class="card-thumb">
-					<img src="/src/app/WebApp/Installers/<?=$webapp['name'];?>/<?=$webapp['thumbnail'];?>" alt="<?=$webapp['name'];?>">
-				</div>
-				<div class="card-details">
-					<p class="card-title"><?=$webapp['name'];?></p>
-					<p class="u-mb10"><?=_('version');?>: <?=$webapp['version'];?></p>
-					<a href="/add/webapp/?app=<?=$webapp['name'];?>&domain=<?=htmlentities($v_domain)?>" class="ui-button cancel" dir="ltr"><?=_('Setup');?></a>
-				</div>
-			</div>
-		<?php endforeach; ?>
-	</div>
+  <div style="margin-left:68px; margin-top: 20px">
+    <h1 class="page-title"><?=_('Quick Install App');?></h1>
+    <div>
+      <span>
+        <?php
+          if (!empty($_SESSION['error_msg'])) {
+            $msg_icon = 'fa-exclamation-circle status-icon red';
+            $msg_text = htmlentities($_SESSION['error_msg']);
+            $msg_id = 'vst-error';
+          } else {
+            if (!empty($_SESSION['ok_msg'])) {
+              $msg_icon = 'fa-check-circle status-icon green';
+              $msg_text = $_SESSION['ok_msg'];
+              $msg_id = 'vst-ok';
+            }
+          }
+          if(!empty($msg_id)){
+        ?>
+        <span class="<?=$msg_id;?>"> <i class="fas <?=$msg_icon;?>"></i> <?=$msg_text;?></span>
+        <?php }; ?>
+      </span>
+    </div>
+  </div>
+  <div class="app-list cards u-mb20">
+    <!-- List available web apps -->
+    <?php foreach($v_web_apps as $webapp):?>
+      <div class="card <?=($webapp['enabled'] ? '' : 'disable');?>">
+        <div class="card-thumb">
+          <img src="/src/app/WebApp/Installers/<?=$webapp['name'];?>/<?=$webapp['thumbnail'];?>" alt="<?=$webapp['name'];?>">
+        </div>
+        <div class="card-details">
+          <p class="card-title"><?=$webapp['name'];?></p>
+          <p class="u-mb10"><?=_('version');?>: <?=$webapp['version'];?></p>
+          <a href="/add/webapp/?app=<?=$webapp['name'];?>&domain=<?=htmlentities($v_domain)?>" class="ui-button cancel" dir="ltr"><?=_('Setup');?></a>
+        </div>
+      </div>
+    <?php endforeach; ?>
+  </div>
 </div>

--- a/web/templates/pages/list_weblog.html
+++ b/web/templates/pages/list_weblog.html
@@ -2,47 +2,47 @@
 <html lang="en">
 
 <head>
-	<!-- Load necessary CSS and JavaScript from source -->
-	<?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/title.html'; ?>
-	<?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/css.html'; ?>
-	<?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/top_js.html'; ?>
-	<script src="/js/jquery/jquery.cookie.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/jquery/jquery-ui.min.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/jquery/jquery.finder.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/hotkeys.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/events.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/app.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/init.js?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/i18n.js.php?<?=JS_LATEST_UPDATE?>"></script>
-	<script src="/js/templates.js?<?=JS_LATEST_UPDATE?>"></script>
-	<?php foreach(new DirectoryIterator($_SERVER['HESTIA'].'/web/js/custom_scripts') as $customScript){
-		if($customScript->getExtension() === 'js'){
-			echo '<script src="/js/custom_scripts/'.rawurlencode($customScript->getBasename()).'"></script>';
-		} elseif($customScript->getExtension() === "php"){
-			require_once($customScript->getPathname());
-		}
-	 } ?>
+  <!-- Load necessary CSS and JavaScript from source -->
+  <?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/title.html'; ?>
+  <?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/css.html'; ?>
+  <?php require ''.$_SERVER['HESTIA'].'/web/templates/includes/top_js.html'; ?>
+  <script src="/js/jquery/jquery.cookie.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/jquery/jquery-ui.min.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/jquery/jquery.finder.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/hotkeys.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/events.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/app.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/init.js?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/i18n.js.php?<?=JS_LATEST_UPDATE?>"></script>
+  <script src="/js/templates.js?<?=JS_LATEST_UPDATE?>"></script>
+  <?php foreach(new DirectoryIterator($_SERVER['HESTIA'].'/web/js/custom_scripts') as $customScript){
+    if($customScript->getExtension() === 'js'){
+      echo '<script src="/js/custom_scripts/'.rawurlencode($customScript->getBasename()).'"></script>';
+    } elseif($customScript->getExtension() === "php"){
+      require_once($customScript->getPathname());
+    }
+   } ?>
 </head>
 
 <body>
-	<a href="#" class="to-top" title="<?=_('Top');?>">
-		<i class="fas fa-arrow-up"></i>
-	</a>
-	<div class="l-header">
-		<div class="l-center">
-			<a href="/" class="l-logo"></a>
-			<div class="l-menu clearfix">
-				<div class="l-menu__item"><a href="/list/web/"><i class="fas fa-arrow-alt-circle-left"></i>&nbsp;&nbsp;&nbsp;<?=_('Back');?></a></div>
-				<div class="l-menu__item <?php if($_GET['type'] == 'access') echo 'l-menu__item--active' ?>"><a href="/list/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=access&token=<?=$_SESSION['token']?>"><i class="fas fa-eye"></i>&nbsp;&nbsp;&nbsp;<?=_('Access Log');?></a><a href="/download/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=access&&token=<?=$_SESSION['token']?>" title="<?=_('Download');?>"><i class="fas fa-download"></i></a></div>
-				<div class="l-menu__item <?php if($_GET['type'] == 'error') echo 'l-menu__item--active' ?>"><a href="/list/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=error&token=<?=$_SESSION['token']?>"><i class="fas fa-exclamation-circle"></i>&nbsp;&nbsp;&nbsp;<?=_('Error Log');?></a><a href="/download/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=error&token=<?=$_SESSION['token']?>" title="<?=_('Download');?>"><i class="fas fa-download"></i></a></div>
-			</div>
-			<div class="l-profile">
-				<div class="l-menu__item"><a href="javascript:location.reload();" title="<?=_('Refresh');?>"><i class="fas fa-redo"></i></a></div>
-				<div class="l-menu__item"><a href="/edit/user/" title="<?=htmlentities($user)?>" class="l-profile__username"><i class="fas fa-user-circle"></i></a></div>
-				<div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?>" class="l-profile__logout"><i class="fas fa-sign-out-alt"></i></a></div>
-			</div>
-		</div>
-	</div>
+  <a href="#" class="to-top" title="<?=_('Top');?>">
+    <i class="fas fa-arrow-up"></i>
+  </a>
+  <div class="l-header">
+    <div class="l-center">
+      <a href="/" class="l-logo"></a>
+      <div class="l-menu clearfix">
+        <div class="l-menu__item"><a href="/list/web/"><i class="fas fa-arrow-alt-circle-left"></i>&nbsp;&nbsp;&nbsp;<?=_('Back');?></a></div>
+        <div class="l-menu__item <?php if($_GET['type'] == 'access') echo 'l-menu__item--active' ?>"><a href="/list/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=access&token=<?=$_SESSION['token']?>"><i class="fas fa-eye"></i>&nbsp;&nbsp;&nbsp;<?=_('Access Log');?></a><a href="/download/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=access&&token=<?=$_SESSION['token']?>" title="<?=_('Download');?>"><i class="fas fa-download"></i></a></div>
+        <div class="l-menu__item <?php if($_GET['type'] == 'error') echo 'l-menu__item--active' ?>"><a href="/list/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=error&token=<?=$_SESSION['token']?>"><i class="fas fa-exclamation-circle"></i>&nbsp;&nbsp;&nbsp;<?=_('Error Log');?></a><a href="/download/web-log/?domain=<?=htmlentities($_GET['domain'])?>&type=error&token=<?=$_SESSION['token']?>" title="<?=_('Download');?>"><i class="fas fa-download"></i></a></div>
+      </div>
+      <div class="l-profile">
+        <div class="l-menu__item"><a href="javascript:location.reload();" title="<?=_('Refresh');?>"><i class="fas fa-redo"></i></a></div>
+        <div class="l-menu__item"><a href="/edit/user/" title="<?=htmlentities($user)?>" class="l-profile__username"><i class="fas fa-user-circle"></i></a></div>
+        <div class="l-menu__item"><a href="/logout/?token=<?=$_SESSION['token']?>" title="<?=_('Log out');?>" class="l-profile__logout"><i class="fas fa-sign-out-alt"></i></a></div>
+      </div>
+    </div>
+  </div>
 
-	<div style="margin-left: auto; margin-right: auto; padding-top: 80px; width: 1020px;"><?=sprintf(_('Last 70 lines of %s.%s.log'),htmlentities($_GET['domain']),htmlentities($type)) ;?></div>
-	<pre style="width: 1020px; margin-left: auto; margin-right: auto;" class="console-output">
+  <div style="margin-left: auto; margin-right: auto; padding-top: 80px; width: 1020px;"><?=sprintf(_('Last 70 lines of %s.%s.log'),htmlentities($_GET['domain']),htmlentities($type)) ;?></div>
+  <pre style="width: 1020px; margin-left: auto; margin-right: auto;" class="console-output">

--- a/web/templates/pages/login/login.html
+++ b/web/templates/pages/login/login.html
@@ -1,48 +1,48 @@
 <div class="u-flex-align-center">
-	<table class="login animated zoomIn">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;">
-							<form method="post" action="/login/" id="form_login">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
-								<input type="hidden" name="murmur" value="" id="murmur">
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('Welcome to Hestia Control Panel');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<label for="user" class="form-label"><?=_('Username');?></label>
-											<input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;" autofocus>
-										</td>
-									</tr>
-									<tr>
-										<td class="u-pt18">
-											<button tabindex="3" type="submit" class="button"><?=_('Next');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($error)) echo $error ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login animated zoomIn">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;">
+              <form method="post" action="/login/" id="form_login">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
+                <input type="hidden" name="murmur" value="" id="murmur">
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('Welcome to Hestia Control Panel');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <label for="user" class="form-label"><?=_('Username');?></label>
+                      <input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;" autofocus>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="u-pt18">
+                      <button tabindex="3" type="submit" class="button"><?=_('Next');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($error)) echo $error ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/login_1.html
+++ b/web/templates/pages/login/login_1.html
@@ -1,58 +1,58 @@
 <div class="u-flex-align-center">
-	<table class="login">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
-							<form method="post" action="/login/" id="form_login">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
-								<input type="hidden" name="murmur" value="" id="murmur">
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('Welcome');?> <?=htmlspecialchars($_SESSION['login']['username']); ?>!
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<label for="password" class="form-label" style="display:block;">
-												<?=_('Password');?>
-												<?php if ($_SESSION['POLICY_SYSTEM_PASSWORD_RESET'] !== 'no' ) {?>
-													<div style="padding:0 6px 0px 14px; float:right;">
-														<a tabindex="5" class="vst-advanced" href="/reset/">
-															<?=_('forgot password');?>
-														</a>
-													</div>
-												<?php } ?>
-											</label>
-											<input type="password" class="form-control" name="password" id="password" tabindex="2" style="width:260px;" autofocus>
-										</td>
-									</tr>
-									<tr>
-										<td class="u-pt18">
-											<button tabindex="3" type="submit" class="button"><?=_('Login');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>&nbsp;&nbsp;
-											<input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout=true'">
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;" class="animated fadeIn">
+              <form method="post" action="/login/" id="form_login">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
+                <input type="hidden" name="murmur" value="" id="murmur">
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('Welcome');?> <?=htmlspecialchars($_SESSION['login']['username']); ?>!
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <label for="password" class="form-label" style="display:block;">
+                        <?=_('Password');?>
+                        <?php if ($_SESSION['POLICY_SYSTEM_PASSWORD_RESET'] !== 'no' ) {?>
+                          <div style="padding:0 6px 0px 14px; float:right;">
+                            <a tabindex="5" class="vst-advanced" href="/reset/">
+                              <?=_('forgot password');?>
+                            </a>
+                          </div>
+                        <?php } ?>
+                      </label>
+                      <input type="password" class="form-control" name="password" id="password" tabindex="2" style="width:260px;" autofocus>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="u-pt18">
+                      <button tabindex="3" type="submit" class="button"><?=_('Login');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>&nbsp;&nbsp;
+                      <input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout=true'">
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/login_2.html
+++ b/web/templates/pages/login/login_2.html
@@ -1,56 +1,56 @@
 <div class="u-flex-align-center">
-	<table class="login">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
-							<form method="post" action="/login/" id="form_login">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
-								<input type="hidden" name="murmur" value="" id="murmur">
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('2 Factor Authentication');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding-top: 12px; padding-left:2px;">
-											<label for="twofa" class="form-label" style="display:block;">
-												<?=_('2FA Token');?>
-												<div style="padding:0 6px 0px 14px; float:right;">
-													<a tabindex="5" class="vst-advanced" href="/reset2fa/">
-														<?=_('Forgot token');?>
-													</a>
-												</div>
-											</label>
-											<input type="text" class="form-control" name="twofa" id="twofa" tabindex="2" style="width:260px;" autofocus>
-										</td>
-									</tr>
-									<tr>
-										<td class="u-pt18">
-											<button tabindex="3" type="submit" class="button"><?=_('Login');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>&nbsp;&nbsp;
-											<input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout'">
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;" class="animated fadeIn">
+              <form method="post" action="/login/" id="form_login">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
+                <input type="hidden" name="murmur" value="" id="murmur">
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('2 Factor Authentication');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding-top: 12px; padding-left:2px;">
+                      <label for="twofa" class="form-label" style="display:block;">
+                        <?=_('2FA Token');?>
+                        <div style="padding:0 6px 0px 14px; float:right;">
+                          <a tabindex="5" class="vst-advanced" href="/reset2fa/">
+                            <?=_('Forgot token');?>
+                          </a>
+                        </div>
+                      </label>
+                      <input type="text" class="form-control" name="twofa" id="twofa" tabindex="2" style="width:260px;" autofocus>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="u-pt18">
+                      <button tabindex="3" type="submit" class="button"><?=_('Login');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>&nbsp;&nbsp;
+                      <input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout'">
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/login_a.html
+++ b/web/templates/pages/login/login_a.html
@@ -1,63 +1,63 @@
 <div class="u-flex-align-center">
-	<table class="login animated zoomIn">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;">
-							<form method="post" action="/login/" id="form_login">
-								<input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
-								<input type="hidden" name="murmur" value="" id="murmur">
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('Welcome to Hestia Control Panel');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 5px 2px;">
-											<label for="user" class="form-label"><?=_('Username');?></label>
-											<input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;" autofocus>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<label for="password" class="form-label" style="display:block;">
-												<?=_('Password');?>
-												<?php if ($_SESSION['POLICY_SYSTEM_PASSWORD_RESET'] !== 'no' ) {?>
-													<div style="padding:0 6px 0px 14px; float:right;">
-														<a tabindex="5" class="vst-advanced" href="/reset/">
-															<?=_('forgot password');?>
-														</a>
-													</div>
-												<?php } ?>
-											</label>
-											<input type="password" class="form-control" name="password" id="password" tabindex="2" style="width:260px;" autofocus>
-										</td>
-									</tr>
-									<tr>
-										<td class="u-pt18">
-											<button tabindex="3" type="submit" class="button"><?=_('Next');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($error)) echo $error ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login animated zoomIn">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;">
+              <form method="post" action="/login/" id="form_login">
+                <input type="hidden" name="token" value="<?=$_SESSION['token']; ?>">
+                <input type="hidden" name="murmur" value="" id="murmur">
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('Welcome to Hestia Control Panel');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 5px 2px;">
+                      <label for="user" class="form-label"><?=_('Username');?></label>
+                      <input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;" autofocus>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <label for="password" class="form-label" style="display:block;">
+                        <?=_('Password');?>
+                        <?php if ($_SESSION['POLICY_SYSTEM_PASSWORD_RESET'] !== 'no' ) {?>
+                          <div style="padding:0 6px 0px 14px; float:right;">
+                            <a tabindex="5" class="vst-advanced" href="/reset/">
+                              <?=_('forgot password');?>
+                            </a>
+                          </div>
+                        <?php } ?>
+                      </label>
+                      <input type="password" class="form-control" name="password" id="password" tabindex="2" style="width:260px;" autofocus>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="u-pt18">
+                      <button tabindex="3" type="submit" class="button"><?=_('Next');?>&nbsp;&nbsp;&nbsp;<i class="fas fa-sign-in-alt"></i></button>
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($error)) echo $error ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/reset2fa.html
+++ b/web/templates/pages/login/reset2fa.html
@@ -1,69 +1,69 @@
 <div class="u-flex-align-center">
-	<table class="login">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
-							<?php if ($success) {?>
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<?=_('2FA Reset successfully'); ?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 20px 0 12px 0;">
-											<input type="button" class="button" value="<?=_('Log in');?>" onclick="location.href='/login/'">
-										</td>
-									</tr>
-								</table>
-							<?php } else { ?>
-								<form method="post" action="/reset2fa/">
-									<input type="hidden" name="token" value="<?=$_SESSION['token'];?>"/>
-									<table class="login-box">
-										<tr>
-											<td style="padding: 12px 0 0 2px;" class="login-welcome">
-												<?=_('Reset 2FA');?>
-											</td>
-										</tr>
-										<tr>
-											<td style="padding: 12px 0 0 2px;">
-												<label for="user" class="form-label"><?=_('Username');?></label>
-												<input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;">
-											</td>
-										</tr>
-										<tr>
-											<td style="padding: 12px 0 0 2px;">
-												<label for="twofa" class="form-label"><?=_('2FA Reset Code');?></label>
-												<input type="text" class="form-control" name="twofa" id="twofa" tabindex="1" style="width:260px;">
-											</td>
-										</tr>
-										<tr>
-											<td style="padding: 20px 0 12px 0;">
-												<input tabindex="2" type="submit" value="<?=_('Submit');?>" class="button">&nbsp;&nbsp;
-												<input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout'">
-											</td>
-										</tr>
-									</table>
-								</form>
-							<?php } ?>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;" class="animated fadeIn">
+              <?php if ($success) {?>
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <?=_('2FA Reset successfully'); ?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 20px 0 12px 0;">
+                      <input type="button" class="button" value="<?=_('Log in');?>" onclick="location.href='/login/'">
+                    </td>
+                  </tr>
+                </table>
+              <?php } else { ?>
+                <form method="post" action="/reset2fa/">
+                  <input type="hidden" name="token" value="<?=$_SESSION['token'];?>"/>
+                  <table class="login-box">
+                    <tr>
+                      <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                        <?=_('Reset 2FA');?>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 12px 0 0 2px;">
+                        <label for="user" class="form-label"><?=_('Username');?></label>
+                        <input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;">
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 12px 0 0 2px;">
+                        <label for="twofa" class="form-label"><?=_('2FA Reset Code');?></label>
+                        <input type="text" class="form-control" name="twofa" id="twofa" tabindex="1" style="width:260px;">
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 20px 0 12px 0;">
+                        <input tabindex="2" type="submit" value="<?=_('Submit');?>" class="button">&nbsp;&nbsp;
+                        <input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout'">
+                      </td>
+                    </tr>
+                  </table>
+                </form>
+              <?php } ?>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/reset_1.html
+++ b/web/templates/pages/login/reset_1.html
@@ -1,54 +1,54 @@
 <div class="u-flex-align-center">
-	<table class="login">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
-							<form method="post" action="/reset/">
-								<input type="hidden" name="token" value="<?=$_SESSION['token'];?>"/>
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('Forgot Password');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<label for="user" class="form-label"><?=_('Username');?></label>
-											<input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;">
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<label for="email" class="form-label"><?=_('Email');?></label>
-											<input type="email" class="form-control" name="email" id="email" tabindex="1" style="width:260px;">
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 20px 0 12px 0;">
-											<input tabindex="2" type="submit" value="<?=_('Submit');?>" class="button">&nbsp;&nbsp;
-											<input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout'">
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;" class="animated fadeIn">
+              <form method="post" action="/reset/">
+                <input type="hidden" name="token" value="<?=$_SESSION['token'];?>"/>
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('Forgot Password');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <label for="user" class="form-label"><?=_('Username');?></label>
+                      <input type="text" class="form-control" name="user" id="user" tabindex="1" style="width:260px;">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <label for="email" class="form-label"><?=_('Email');?></label>
+                      <input type="email" class="form-control" name="email" id="email" tabindex="1" style="width:260px;">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 20px 0 12px 0;">
+                      <input tabindex="2" type="submit" value="<?=_('Submit');?>" class="button">&nbsp;&nbsp;
+                      <input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/?logout'">
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/reset_2.html
+++ b/web/templates/pages/login/reset_2.html
@@ -1,55 +1,55 @@
 <div class="u-flex-align-center">
-	<table class="login">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
-							<form method="get" action="/reset/">
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('Forgot Password');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<?=_('RESET_CODE_SENT');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<input type="hidden" name="action" value="confirm">
-											<input type="hidden" name="token" value="<?=htmlentities($_SESSION['token']);?>"/>
-											<input type="hidden" name="user" value="<?=htmlentities($_GET['user'])?>">
-											<label for="code" class="form-label"><?=_('Reset Code');?></label>
-											<input type="text" class="form-control" name="code" id="code" tabindex="1" style="width:260px;">
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 20px 0 12px 0;">
-											<input tabindex="2" type="submit" value="<?=_('Confirm');?>" class="button">&nbsp;&nbsp;
-											<input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/reset/'">
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;" class="animated fadeIn">
+              <form method="get" action="/reset/">
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('Forgot Password');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <?=_('RESET_CODE_SENT');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <input type="hidden" name="action" value="confirm">
+                      <input type="hidden" name="token" value="<?=htmlentities($_SESSION['token']);?>"/>
+                      <input type="hidden" name="user" value="<?=htmlentities($_GET['user'])?>">
+                      <label for="code" class="form-label"><?=_('Reset Code');?></label>
+                      <input type="text" class="form-control" name="code" id="code" tabindex="1" style="width:260px;">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 20px 0 12px 0;">
+                      <input tabindex="2" type="submit" value="<?=_('Confirm');?>" class="button">&nbsp;&nbsp;
+                      <input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/reset/'">
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/login/reset_3.html
+++ b/web/templates/pages/login/reset_3.html
@@ -1,57 +1,57 @@
 <div class="u-flex-align-center">
-	<table class="login">
-		<tr>
-			<td>
-				<table>
-					<tr>
-						<td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
-							<a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
-						</td>
-						<td style="padding: 40px 60px 0 0;" class="animated fadeIn">
-							<form method="post">
-								<table class="login-box">
-									<tr>
-										<td style="padding: 12px 0 0 2px;" class="login-welcome">
-											<?=_('Forgot Password');?>
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<input type="hidden" name="action" value="confirm">
-											<input type="hidden" name="token" value="<?=htmlentities($_SESSION['token']);?>"/>
-											<input type="hidden" name="user" value="<?=htmlentities($_GET['user']);?>">
-											<input type="hidden" name="code" value="<?=htmlentities($_GET['code']);?>">
-											<label for="password" class="form-label"><?=_('New Password');?></label>
-											<input type="password" class="form-control" name="password" id="password" tabindex="1" style="width:260px;">
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 12px 0 0 2px;">
-											<label for="password_confirm" class="form-label"><?=_('Confirm Password');?></label>
-											<input type="password" class="form-control" name="password_confirm" id="password_confirm" tabindex="2" style="width:260px;">
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 20px 0 12px 0;">
-											<input tabindex="3" type="submit" value="<?=_('Reset');?>" class="button">&nbsp;&nbsp;
-											<input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/'">
-										</td>
-									</tr>
-								</table>
-							</form>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<div class="login-bottom">
-								<div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
+  <table class="login">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td style="padding: 22px 30px 0 42px; height: 280px; width: 170px;">
+              <a href="/" class="u-block"><img src="/images/logo.svg" alt="<?=_('Hestia Control Panel');?>" style="margin-top: 70px;"></a>
+            </td>
+            <td style="padding: 40px 60px 0 0;" class="animated fadeIn">
+              <form method="post">
+                <table class="login-box">
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;" class="login-welcome">
+                      <?=_('Forgot Password');?>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <input type="hidden" name="action" value="confirm">
+                      <input type="hidden" name="token" value="<?=htmlentities($_SESSION['token']);?>"/>
+                      <input type="hidden" name="user" value="<?=htmlentities($_GET['user']);?>">
+                      <input type="hidden" name="code" value="<?=htmlentities($_GET['code']);?>">
+                      <label for="password" class="form-label"><?=_('New Password');?></label>
+                      <input type="password" class="form-control" name="password" id="password" tabindex="1" style="width:260px;">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 12px 0 0 2px;">
+                      <label for="password_confirm" class="form-label"><?=_('Confirm Password');?></label>
+                      <input type="password" class="form-control" name="password_confirm" id="password_confirm" tabindex="2" style="width:260px;">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 20px 0 12px 0;">
+                      <input tabindex="3" type="submit" value="<?=_('Reset');?>" class="button">&nbsp;&nbsp;
+                      <input type="button" class="button cancel" value="<?=_('Back');?>" onclick="location.href='/login/'">
+                    </td>
+                  </tr>
+                </table>
+              </form>
+            </td>
+          </tr>
+          <tr>
+            <td colspan=2>
+              <div class="login-bottom">
+                <div style="height:20px"><?php if (isset($ERROR)) echo $ERROR ?></div>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </div>
 
 </body>

--- a/web/templates/pages/setup_webapp.html
+++ b/web/templates/pages/setup_webapp.html
@@ -1,22 +1,22 @@
 <!-- Begin toolbar -->
 <div class="l-center edit">
-	<div class="l-sort clearfix">
-		<div class="l-unit-toolbar__buttonstrip">
-			<a class="ui-button cancel" dir="ltr" id="btn-back" href="/add/webapp/?domain=<?=htmlentities($v_domain);?>"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
-		</div>
-		<div class="l-unit-toolbar__buttonstrip float-right">
-			<?php
-				if (!empty($_SESSION['error_msg'])) {
-					echo "<span class=\"vst-error\"> → ".htmlentities($_SESSION['error_msg'])."</span>";
-				} else {
-					if (!empty($_SESSION['ok_msg'])) {
-						echo "<span class=\"vst-ok\"> → ".$_SESSION['ok_msg']."</span>";
-					}
-				}
-			?>
-			<a href="#" class="ui-button" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i> <?=_('Install');?></a>
-		</div>
-	</div>
+  <div class="l-sort clearfix">
+    <div class="l-unit-toolbar__buttonstrip">
+      <a class="ui-button cancel" dir="ltr" id="btn-back" href="/add/webapp/?domain=<?=htmlentities($v_domain);?>"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
+    </div>
+    <div class="l-unit-toolbar__buttonstrip float-right">
+      <?php
+        if (!empty($_SESSION['error_msg'])) {
+          echo "<span class=\"vst-error\"> → ".htmlentities($_SESSION['error_msg'])."</span>";
+        } else {
+          if (!empty($_SESSION['ok_msg'])) {
+            echo "<span class=\"vst-ok\"> → ".$_SESSION['ok_msg']."</span>";
+          }
+        }
+      ?>
+      <a href="#" class="ui-button" data-action="submit" data-id="vstobjects"><i class="fas fa-save status-icon purple"></i> <?=_('Install');?></a>
+    </div>
+  </div>
 </div>
 <!-- End toolbar -->
 
@@ -24,74 +24,74 @@
 
 <div class="l-center animated fadeIn">
 
-	<?php if( !empty($WebappInstaller->getOptions())): ?>
-		<form id="vstobjects" method="POST" name="v_setup_webapp">
-			<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
-			<input type="hidden" name="ok" value="true">
+  <?php if( !empty($WebappInstaller->getOptions())): ?>
+    <form id="vstobjects" method="POST" name="v_setup_webapp">
+      <input type="hidden" name="token" value="<?=$_SESSION['token']?>">
+      <input type="hidden" name="ok" value="true">
 
-			<div class="app-form">
-				<?php if( !$WebappInstaller->isDomainRootClean()): ?>
-					<div class="alert alert-info alert-with-icon u-input-width" role="alert">
-						<i class="fas fa-info"></i>
-						<p class="u-mb10"><?=_('Data loss warning!');?></p>
-						<p class="u-mb10"><?=_('Your web folder already has files uploaded to it. The installer will overwrite your files and / or the installation might fail.');?></p>
-						<p><?php echo sprintf(_('Please make sure ~/web/%s/public_html is empty!'),$v_domain);?></p>
-					</div>
-				<?php endif; ?>
-				<div class="u-input-width u-pt18">
-					<?php foreach ($WebappInstaller->getOptions() as $form_name => $form_control):?>
-						<?php
-							$f_name = $WebappInstaller->formNs() . '_' . $form_name;
-							$f_type = $form_control;
-							$f_value = '';
-							if(isset($form_control['label'])){
-								$f_label = htmlentities($form_control['label']);
-							}else{
-								$f_label = ucwords(str_replace(['.','_'], ' ', $form_name));
-							}
-							$f_placeholder = '';
-							if (is_array($form_control)) {
-									$f_type = (!empty($form_control['type']))?$form_control['type']:'text';
-									$f_value = (!empty($form_control['value']))?$form_control['value']:'';
-									$f_placeholder = (!empty($form_control['placeholder']))?$form_control['placeholder']:'';
-							}
+      <div class="app-form">
+        <?php if( !$WebappInstaller->isDomainRootClean()): ?>
+          <div class="alert alert-info alert-with-icon u-input-width" role="alert">
+            <i class="fas fa-info"></i>
+            <p class="u-mb10"><?=_('Data loss warning!');?></p>
+            <p class="u-mb10"><?=_('Your web folder already has files uploaded to it. The installer will overwrite your files and / or the installation might fail.');?></p>
+            <p><?php echo sprintf(_('Please make sure ~/web/%s/public_html is empty!'),$v_domain);?></p>
+          </div>
+        <?php endif; ?>
+        <div class="u-input-width u-pt18">
+          <?php foreach ($WebappInstaller->getOptions() as $form_name => $form_control):?>
+            <?php
+              $f_name = $WebappInstaller->formNs() . '_' . $form_name;
+              $f_type = $form_control;
+              $f_value = '';
+              if(isset($form_control['label'])){
+                $f_label = htmlentities($form_control['label']);
+              }else{
+                $f_label = ucwords(str_replace(['.','_'], ' ', $form_name));
+              }
+              $f_placeholder = '';
+              if (is_array($form_control)) {
+                  $f_type = (!empty($form_control['type']))?$form_control['type']:'text';
+                  $f_value = (!empty($form_control['value']))?$form_control['value']:'';
+                  $f_placeholder = (!empty($form_control['placeholder']))?$form_control['placeholder']:'';
+              }
 
-							$f_value = htmlentities($f_value);
-							$f_label = htmlentities($f_label);
-							$f_name = htmlentities($f_name);
-							$f_placeholder = htmlentities($f_placeholder);
-						?>
-						<div class="u-mb10">
-							<?php if($f_type != 'boolean'): ?>
-								<label for="<?=$f_name?>" class="form-label">
-									<?=$f_label?>
-									<?php if ($f_type === 'password'):?> / <a href="javascript:applyRandomStringToTarget('<?=$f_name?>');" class="generate"><?=_('generate');?></a> <?php endif?>
-								</label>
-							<?php endif; ?>
-							<?php if (in_array($f_type, ['select']) && count($form_control['options']) ):?>
-								<select class="form-select" name="<?=$f_name?>" id="<?=$f_name?>">
-									<?php foreach ($form_control['options'] as $key => $option){
-										if(is_numeric($key)){
-											$key = $option;
-										}
-									?>
-										<?php $selected = (!empty($form_control['value']) && $key == $form_control['value'])?'selected':''?>
-										<option value="<?=$key?>" <?=$selected?>><?=htmlentities($option)?></option>
-									<?php }; ?>
-								</select>
-							<?php elseif (in_array($f_type, ['boolean'])):?>
-								<div class="form-check">
-									<?php $checked = (!empty($f_value))?'checked':''?>
-									<input class="form-check-input" type="checkbox" name="<?=$f_name?>" id="<?=$f_name?>" <?=$checked?> value="true">
-									<label for="<?=$f_name?>"><?=$f_label?></label>
-								</div>
-							<?php else:?>
-								<input type="text" class="form-control" name="<?=$f_name?>" id="<?=$f_name?>" placeholder="<?=$f_placeholder?>" value="<?=$f_value?>">
-							<?php endif; ?>
-						</div>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		</form>
-	<?php endif ?>
+              $f_value = htmlentities($f_value);
+              $f_label = htmlentities($f_label);
+              $f_name = htmlentities($f_name);
+              $f_placeholder = htmlentities($f_placeholder);
+            ?>
+            <div class="u-mb10">
+              <?php if($f_type != 'boolean'): ?>
+                <label for="<?=$f_name?>" class="form-label">
+                  <?=$f_label?>
+                  <?php if ($f_type === 'password'):?> / <a href="javascript:applyRandomStringToTarget('<?=$f_name?>');" class="generate"><?=_('generate');?></a> <?php endif?>
+                </label>
+              <?php endif; ?>
+              <?php if (in_array($f_type, ['select']) && count($form_control['options']) ):?>
+                <select class="form-select" name="<?=$f_name?>" id="<?=$f_name?>">
+                  <?php foreach ($form_control['options'] as $key => $option){
+                    if(is_numeric($key)){
+                      $key = $option;
+                    }
+                  ?>
+                    <?php $selected = (!empty($form_control['value']) && $key == $form_control['value'])?'selected':''?>
+                    <option value="<?=$key?>" <?=$selected?>><?=htmlentities($option)?></option>
+                  <?php }; ?>
+                </select>
+              <?php elseif (in_array($f_type, ['boolean'])):?>
+                <div class="form-check">
+                  <?php $checked = (!empty($f_value))?'checked':''?>
+                  <input class="form-check-input" type="checkbox" name="<?=$f_name?>" id="<?=$f_name?>" <?=$checked?> value="true">
+                  <label for="<?=$f_name?>"><?=$f_label?></label>
+                </div>
+              <?php else:?>
+                <input type="text" class="form-control" name="<?=$f_name?>" id="<?=$f_name?>" placeholder="<?=$f_placeholder?>" value="<?=$f_value?>">
+              <?php endif; ?>
+            </div>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </form>
+  <?php endif ?>
 </div>


### PR DESCRIPTION
Diffs are difficult to read when they also change the indentation type of the file.

This replaces tabs with spaces in all remaining HTML files for consistency, and to cut down on noise in future PRs.

It also adds an ".editorconfig" file to the root of the project in an attempt to enforce some rules going forward.