### PR TITLE
Fix issue when enabling mysqld-iptables in Fail2Ban

### DIFF
--- a/install/deb/fail2ban/jail.local
+++ b/install/deb/fail2ban/jail.local
@@ -28,7 +28,7 @@ logpath  = /var/log/dovecot.log
 enabled  = false
 filter   = mysqld-auth
 action   = hestia[name=DB]
-logpath  = /var/log/mysql.log
+logpath  = /var/log/mysql/error.log
 maxretry = 5
 
 [hestia-iptables]

--- a/install/rpm/fail2ban/jail.local
+++ b/install/rpm/fail2ban/jail.local
@@ -28,7 +28,7 @@ logpath  = /var/log/dovecot.log
 enabled  = false
 filter   = mysqld-auth
 action   = hestia[name=DB]
-logpath  = /var/log/mysql.log
+logpath  = /var/log/mysql/error.log
 maxretry = 5
 
 [hestia-iptables]

--- a/install/upgrade/versions/1.6.12.sh
+++ b/install/upgrade/versions/1.6.12.sh
@@ -15,6 +15,12 @@
 ####### You can use \n within the string to create new lines.                   #######
 #######################################################################################
 
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'no'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
 if [ -f "/etc/fail2ban/jail.local" ]; then
     sed -i "s|/var/log/mysql.log|/var/log/mysql/error.log|g" /etc/fail2ban/jail.local
 fi

--- a/install/upgrade/versions/1.6.12.sh
+++ b/install/upgrade/versions/1.6.12.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.6.12
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+if [ -f "/etc/fail2ban/jail.local" ]; then
+    sed -i "s|/var/log/mysql.log|/var/log/mysql/error.log|g" /etc/fail2ban/jail.local
+fi


### PR DESCRIPTION
As reported in [Discord](https://discord.com/channels/737721354937303161/831166855422935051/1038910847612891136) Fail2Ban doesn't start after setting "enabled" to true in [mysqld-iptables] section

P.S.: All credits to "Krzysiek86" from HestiaCP Discord server, who discovered the issue and the fix.