### PR TITLE
Include Actions in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "composer" # See documentation for possible values
-    directory: "/web/inc/" # Location of package manifests
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for npm
+  # TODO: Enable this when we build JS and have no checked-in minified JS/CSS
+  # - package-ecosystem: "npm"
+  #   directory: "/web"
+  #   schedule:
+  #     interval: "weekly"
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/web/inc" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Includes the GitHub Actions ecosystem in dependabot.yml.

This ensures the Actions we use like "actions/setup-node" remain up to date, checked weekly.

It also adds npm ecosystem, but this is commented out for now. Probably best not to merge npm updates without rebuilding the minified CSS that is checked in to the repo.