### PR TITLE
Added ability to install MySQL 8 

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -40,7 +40,7 @@ body:
         - Control Panel Installation or Upgrade
         - Control Panel Web Interface
         - (Backend) Web Server (Nginx, Apache2)
-        - Database (MariaDB, PostgreSQL)
+        - Database (MariaDB, MySQL, PostgreSQL)
         - Let's Encrypt SSL
         - Mail (Exim, Dovecot)
         - Mail Security (Antivirus, Antispam)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features and Services
 * Multiple PHP versions (5.6 - 8.1, 8.0 as default)
 * DNS Server (Bind) with clustering capabilities
 * POP/IMAP/SMTP mail services with Anti-Virus, Anti-Spam, and Webmail (ClamAV, SpamAssassin, Sieve, Roundcube)
-* MariaDB and/or PostgreSQL databases
+* MariaDB/MySQL and/or PostgreSQL databases
 * Let's Encrypt SSL support with wildcard certificates
 * Firewall with brute-force attack detection and IP lists (iptables, fail2ban, and ipset).
 

--- a/bin/v-add-sys-roundcube
+++ b/bin/v-add-sys-roundcube
@@ -13,6 +13,7 @@
 source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
 source $HESTIA/func/main.sh
+source $HESTIA/func/db.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 # upgrade config file
@@ -135,16 +136,21 @@ if [ "$UPDATE" == "no" ]; then
     chown www-data:www-data $RC_LOG
     chmod 751 $RC_LOG
 
-    if [ ! -z "$(echo "$DB_SYSTEM" | grep -w 'mysql')" ]; then
-        mysql -e "DROP DATABASE IF EXISTS roundcube"
-        mysql -e "DROP USER IF EXISTS roundcube@localhost"
-        mysql -e "CREATE DATABASE roundcube"
-        # Mysql available on system
-        r=$(generate_password)
-        mysql -e "GRANT ALL ON roundcube.*
-         TO roundcube@localhost IDENTIFIED BY '$r'"
-        sed -i "s/%password%/$r/g" $RC_CONFIG_DIR/config.inc.php
-        mysql roundcube < /var/lib/roundcube/SQL/mysql.initial.sql
+    if [ ! -z "$(echo "$DB_SYSTEM" | grep -E 'mysql|pgsql')" ]; then
+        host='localhost'
+        database='roundcube'
+        dbuser="$database"
+        dbpass=$(generate_password)
+        charset='UTF8'
+        sed -i "s/%password%/$dbpass/g" $RC_CONFIG_DIR/config.inc.php
+
+        if [ ! -z "$(echo "$DB_SYSTEM" | grep -w 'mysql')" ]; then
+            add_mysql_database
+            mysql_query "USE $database; $(< /var/lib/roundcube/SQL/mysql.initial.sql)"
+        else
+            add_pgsql_database
+            psql_query "USE $database; $(< /var/lib/roundcube/SQL/postgres.initial.sql)"
+        fi
     fi
 
     # TODO: Add support for PostgreSQL

--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -239,7 +239,7 @@ if [ -n "$DB_SYSTEM" ] && [ "$DB_SYSTEM" != 'remote' ]; then
             mariadb_string="MariaDB"
             if [[ ! $mysql_version =~ $mariadb_string ]]; then
                 # MySQL
-                service='mysqld'
+                service='mysql'
                 proc_name='mysqld'
             else
                 # MariaDB

--- a/func/db.sh
+++ b/func/db.sh
@@ -291,9 +291,16 @@ add_mysql_database() {
         if [ "$mysql_ver_sub" -ge 8 ] || { [ "$mysql_ver_sub" -eq 5 ] && [ "$mysql_ver_sub_sub" -ge 7 ]; } then
             if [ "$mysql_ver_sub" -ge 8 ]; then
                 # mysql >= 8
-                md5=$(mysql_query "SHOW CREATE USER \`$dbuser\`" 2>/dev/null)
+
+                # This query will be proceeding with the usage of Print identified with as hex feature
+                md5=$(mysql_query "SET print_identified_with_as_hex=ON; SHOW CREATE USER \`$dbuser\`" 2>/dev/null)
+
                 # echo $md5
-                md5=$(echo "$md5" |grep password |cut -f4 -d \')
+                if [[ "$md5" =~ 0x([^ ]+) ]]; then
+                    md5=$(echo "$md5" |grep password |grep -E -o '0x([^ ]+)')
+                else
+                    md5=$(echo "$md5" |grep password |cut -f4 -d \')
+                fi
                 # echo $md5
             else
                 # mysql < 8
@@ -410,9 +417,16 @@ change_mysql_password() {
           if [ "$mysql_ver_sub" -ge 8 ] || { [ "$mysql_ver_sub" -eq 5 ] && [ "$mysql_ver_sub_sub" -ge 7 ]; } then
               if [ "$mysql_ver_sub" -ge 8 ]; then
                   # mysql >= 8
-                  md5=$(mysql_query "SHOW CREATE USER \`$DBUSER\`" 2>/dev/null)
+
+                  # This query will be proceeding with the usage of Print identified with as hex feature
+                  md5=$(mysql_query "SET print_identified_with_as_hex=ON; SHOW CREATE USER \`$DBUSER\`" 2>/dev/null)
+
                   # echo $md5
-                  md5=$(echo "$md5" |grep password |cut -f4 -d \')
+                  if [[ "$md5" =~ 0x([^ ]+) ]]; then
+                      md5=$(echo "$md5" |grep password |grep -E -o '0x([^ ]+)')
+                  else
+                      md5=$(echo "$md5" |grep password |cut -f4 -d \')
+                  fi
                   # echo $md5
               else
                   # mysql < 8

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -790,7 +790,12 @@ rebuild_mysql_database() {
             # mysql >= 5.7
             mysql_query "CREATE USER IF NOT EXISTS \`$DBUSER\`" > /dev/null
             mysql_query "CREATE USER IF NOT EXISTS \`$DBUSER\`@localhost" > /dev/null
-            query="UPDATE mysql.user SET authentication_string='$MD5'"
+            # mysql >= 8, with enabled Print identified with as hex feature
+            if [[ "$mysql_ver_sub" -ge 8 && "$MD5" =~ ^0x.* ]]; then
+                query="UPDATE mysql.user SET authentication_string=UNHEX('${MD5:2}')"
+            else
+                query="UPDATE mysql.user SET authentication_string='$MD5'"
+            fi
             query="$query WHERE User='$DBUSER'"
         else
             # mysql < 5.7

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -319,6 +319,9 @@ fi
 if [ "$apache" = "no" ]; then
     phpfpm='yes'
 fi
+if [ "$mysql" = 'yes' ] && [ "$mysqlclassic" = 'yes' ]; then
+    mysql='no'
+fi
 
 # Checking root permissions
 if [ "x$(id -u)" != 'x0' ]; then

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -725,6 +725,24 @@ if [ "$mysql" = 'yes' ]; then
     curl -s https://mariadb.org/mariadb_release_signing_key.asc | gpg --dearmor | tee /usr/share/keyrings/mariadb-keyring.gpg >/dev/null 2>&1
 fi
 
+# Installing Mysql8 repo
+if [ "$mysqlclassic" = 'yes' ]; then
+    echo "[ * ] Mysql 8"
+    echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-apt-config" >> /etc/apt/sources.list.d/mysql.list
+    echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
+    echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-tools" >> /etc/apt/sources.list.d/mysql.list
+    echo "#deb [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-tools-preview" >> /etc/apt/sources.list.d/mysql.list
+    echo "deb-src [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
+
+    GNUPGHOME="$(mktemp -d)"
+    export GNUPGHOME
+    for keyserver in $(shuf -e ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80)
+    do
+        gpg --no-default-keyring --keyring /usr/share/keyrings/mysql-keyring.gpg --keyserver "${keyserver}" --recv-keys "467B942D3A79BD29" >/dev/null 2>&1 && break
+    done
+fi
+
+
 # Installing HestiaCP repo
 echo "[ * ] Hestia Control Panel"
 echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/hestia-keyring.gpg] https://$RHOST/ $codename main" > $apt/hestia.list

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -44,7 +44,7 @@ software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
     cron curl dnsutils dovecot-imapd dovecot-pop3d dovecot-sieve dovecot-managesieved
     e2fslibs e2fsprogs exim4 exim4-daemon-heavy expect fail2ban flex ftp git idn2
     imagemagick libapache2-mod-fcgid libapache2-mod-php$fpm_v libapache2-mod-rpaf
-    lsof mc mariadb-client mariadb-common mariadb-server nginx
+    lsof mc mariadb-client mariadb-common mariadb-server mysql-client mysql-common mysql-server nginx
     php$fpm_v php$fpm_v-cgi php$fpm_v-common php$fpm_v-curl
     php$fpm_v-mysql php$fpm_v-imap php$fpm_v-ldap php$fpm_v-apcu phppgadmin
     php$fpm_v-pgsql php$fpm_v-zip php$fpm_v-bz2 php$fpm_v-cli php$fpm_v-gd
@@ -66,6 +66,7 @@ help() {
   -j, --proftpd           Install ProFTPD       [yes|no]  default: no
   -k, --named             Install Bind          [yes|no]  default: yes
   -m, --mysql             Install MariaDB       [yes|no]  default: yes
+  -M, --mysql-classic     Install MySQL         [yes|no]  default: no
   -g, --postgresql        Install PostgreSQL    [yes|no]  default: no
   -x, --exim              Install Exim          [yes|no]  default: yes
   -z, --dovecot           Install Dovecot       [yes|no]  default: yes
@@ -204,6 +205,7 @@ for arg; do
         --proftpd)              args="${args}-j " ;;
         --named)                args="${args}-k " ;;
         --mysql)                args="${args}-m " ;;
+        --mysql-classic)        args="${args}-M " ;;
         --postgresql)           args="${args}-g " ;;
         --exim)                 args="${args}-x " ;;
         --dovecot)              args="${args}-z " ;;
@@ -231,7 +233,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:w:v:j:k:m:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:e:p:D:fh" Option; do
+while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:e:p:D:fh" Option; do
     case $Option in
         a) apache=$OPTARG ;;            # Apache
         w) phpfpm=$OPTARG ;;            # PHP-FPM
@@ -240,6 +242,7 @@ while getopts "a:w:v:j:k:m:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:e:p:D:fh" Option; do
         j) proftpd=$OPTARG ;;           # Proftpd
         k) named=$OPTARG ;;             # Named
         m) mysql=$OPTARG ;;             # MariaDB
+        M) mysqlclassic=$OPTARG ;;      # MySQL
         g) postgresql=$OPTARG ;;        # PostgreSQL
         x) exim=$OPTARG ;;              # Exim
         z) dovecot=$OPTARG ;;           # Dovecot
@@ -272,6 +275,7 @@ set_default_value 'vsftpd' 'yes'
 set_default_value 'proftpd' 'no'
 set_default_value 'named' 'yes'
 set_default_value 'mysql' 'yes'
+set_default_value 'mysqlclassic' 'no'
 set_default_value 'postgresql' 'no'
 set_default_value 'exim' 'yes'
 set_default_value 'dovecot' 'yes'
@@ -543,6 +547,9 @@ echo
 # Database stack
 if [ "$mysql" = 'yes' ]; then
     echo '   - MariaDB Database Server'
+fi
+if [ "$mysqlclassic" = 'yes' ]; then
+    echo '   - MySQL Database Server'
 fi
 if [ "$postgresql" = 'yes' ]; then
     echo '   - PostgreSQL Database Server'
@@ -878,6 +885,13 @@ if [ "$mysql" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/mariadb-server//")
     software=$(echo "$software" | sed -e "s/mariadb-client//")
     software=$(echo "$software" | sed -e "s/mariadb-common//")
+fi
+if [ "$mysqlclassic" = 'no' ]; then
+    software=$(echo "$software" | sed -e "s/mysql-server//")
+    software=$(echo "$software" | sed -e "s/mysql-client//")
+    software=$(echo "$software" | sed -e "s/mysql-common//")
+fi
+if [ "$mysql" = 'no' ] && [ "$mysqlclassic" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/php$fpm_v-mysql//")
     if [ "$multiphp" = 'yes' ]; then
         for v in "${multiphp_v[@]}"; do
@@ -1174,7 +1188,7 @@ if [ "$phpfpm" = 'yes' ] || [ "$multiphp" = 'yes' ]; then
 fi
 
 # Database stack
-if [ "$mysql" = 'yes' ]; then
+if [ "$mysql" = 'yes' ] || [ "$mysqlclassic" = 'yes' ]; then
     installed_db_types='mysql'
 fi
 
@@ -1536,11 +1550,12 @@ fi
 
 
 #----------------------------------------------------------#
-#                  Configure MariaDB                       #
+#               Configure MariaDB / MySQL                  #
 #----------------------------------------------------------#
 
-if [ "$mysql" = 'yes' ]; then
-    echo "[ * ] Configuring MariaDB database server..."
+if [ "$mysql" = 'yes' ] || [ "$mysqlclassic" = 'yes' ]; then
+    [ "$mysql" = 'yes' ] && mysql_type="MariaDB" || mysql_type="MySQL"
+    echo "[ * ] Configuring $mysql_type database server..."
     mycnf="my-small.cnf"
     if [ $memory -gt 1200000 ]; then
         mycnf="my-medium.cnf"
@@ -1549,28 +1564,43 @@ if [ "$mysql" = 'yes' ]; then
         mycnf="my-large.cnf"
     fi
 
-    # Run mysql_install_db
-    mysql_install_db >> $LOG
+    if [ "$mysql_type" = 'MariaDB' ]; then
+        # Run mysql_install_db
+        mysql_install_db >> $LOG
+    fi
+
     # Remove symbolic link
     rm -f /etc/mysql/my.cnf
     # Configuring MariaDB
     cp -f $HESTIA_INSTALL_DIR/mysql/$mycnf /etc/mysql/my.cnf
 
+    # Switch MariaDB inclusions to the MySQL
+    if [ "$mysql_type" = 'MySQL' ]; then
+        sed -i '/query_cache_size/d' /etc/mysql/my.cnf
+        sed -i 's|mariadb.conf.d|mysql.conf.d|g' /etc/mysql/my.cnf
+    fi
+
     update-rc.d mysql defaults > /dev/null 2>&1
     systemctl start mysql >> $LOG
-    check_result $? "mariadb start failed"
+    check_result $? "${mysql_type,,} start failed"
 
-    # Securing MariaDB installation
+    # Securing MariaDB/MySQL installation
     mpass=$(gen_pass)
     echo -e "[client]\npassword='$mpass'\n" > /root/.my.cnf
     chmod 600 /root/.my.cnf
 
-    # Ater root password
+    # Alter root password
     mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '$mpass'; FLUSH PRIVILEGES;"
-    # Allow mysql access via socket for startup
-    mysql -e "UPDATE mysql.global_priv SET priv=json_set(priv, '$.password_last_changed', UNIX_TIMESTAMP(), '$.plugin', 'mysql_native_password', '$.authentication_string', 'invalid', '$.auth_or', json_array(json_object(), json_object('plugin', 'unix_socket'))) WHERE User='root';"
-    # Disable anonymous users
-    mysql -e "DELETE FROM mysql.global_priv WHERE User='';"
+    if [ "$mysql_type" = 'MariaDB' ]; then
+        # Allow mysql access via socket for startup
+        mysql -e "UPDATE mysql.global_priv SET priv=json_set(priv, '$.password_last_changed', UNIX_TIMESTAMP(), '$.plugin', 'mysql_native_password', '$.authentication_string', 'invalid', '$.auth_or', json_array(json_object(), json_object('plugin', 'unix_socket'))) WHERE User='root';"
+        # Disable anonymous users
+        mysql -e "DELETE FROM mysql.global_priv WHERE User='';"
+    else
+        mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY '$mpass';"
+        mysql -e "DELETE FROM mysql.user WHERE User='';"
+        mysql -e "DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');"
+    fi
     # Drop test database
     mysql -e "DROP DATABASE IF EXISTS test"
     mysql -e "DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%'"
@@ -1587,7 +1617,7 @@ fi
 # shellcheck source=/usr/local/hestia/install/upgrade/upgrade.conf
 source $HESTIA/install/upgrade/upgrade.conf
 
-if [ "$mysql" = 'yes' ]; then
+if [ "$mysql" = 'yes' ] || [ "$mysqlclassic" = 'yes' ]; then
     # Display upgrade information
     echo "[ * ] Installing phpMyAdmin version v$pma_v..."
 
@@ -1855,12 +1885,21 @@ if [ "$fail2ban" = 'yes' ]; then
     check_result $? "fail2ban start failed"
 fi
 
+# Configuring MariaDB/MySQL host
+if [ "$mysql" = 'yes' ] || [ "$mysqlclassic" = 'yes' ]; then
+    $HESTIA/bin/v-add-database-host mysql localhost root $mpass
+fi
+
+# Configuring PostgreSQL host
+if [ "$postgresql" = 'yes' ]; then
+    $HESTIA/bin/v-add-database-host pgsql localhost postgres $ppass
+fi
 
 #----------------------------------------------------------#
 #                       Install Roundcube                  #
 #----------------------------------------------------------#
 # Min requirements Dovecot + Exim + Mysql
-if [ "$mysql" == 'yes' ] && [ "$dovecot" == "yes" ]; then
+if ([ "$mysql" == 'yes' ] || [ "$mysqlclassic" == 'yes' ]) && [ "$dovecot" == "yes" ]; then
     echo "[ * ] Install Roundcube..."
     $HESTIA/bin/v-add-sys-roundcube
     write_config_value "WEBMAIL_ALIAS" "webmail"
@@ -2015,16 +2054,6 @@ if [ "$apache" = 'yes' ] && [ "$nginx"  = 'yes' ] ; then
     sed -i "s/LogFormat \"%h/LogFormat \"%a/g" /etc/apache2/apache2.conf
     a2enmod remoteip >> $LOG
     systemctl restart apache2
-fi
-
-# Configuring MariaDB host
-if [ "$mysql" = 'yes' ]; then
-    $HESTIA/bin/v-add-database-host mysql localhost root $mpass
-fi
-
-# Configuring PostgreSQL host
-if [ "$postgresql" = 'yes' ]; then
-    $HESTIA/bin/v-add-database-host pgsql localhost postgres $ppass
 fi
 
 # Adding default domain

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -317,6 +317,9 @@ fi
 if [ "$apache" = "no" ]; then
     phpfpm='yes'
 fi
+if [ "$mysql" = 'yes' ] && [ "$mysqlclassic" = 'yes' ]; then
+    mysql='no'
+fi
 
 # Checking root permissions
 if [ "x$(id -u)" != 'x0' ]; then

--- a/install/rpm/mysql/mysql.repo
+++ b/install/rpm/mysql/mysql.repo
@@ -1,0 +1,7 @@
+[mysql80-community]
+name = MySQL 8.0 Server for RHEL $releasever - $basearch
+baseurl = http://repo.mysql.com/yum/mysql-8.0-community/el/$releasever/$basearch/
+module_hotfixes=1
+gpgkey=https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+gpgcheck=1
+enabled=1


### PR DESCRIPTION
This PR contains an implementation of the new installation switch `--mysql-classic`, which allows proceeding with the installation of the classic MySQL. 
Also, additionally refactored `v-add-sys-roundcube` and added support the MySQL/PostgreSQL.