### PR TITLE
Fixing the template for WordPress to avoid caching of WordPress REST API

### DIFF
--- a/install/deb/templates/web/nginx/caching.stpl
+++ b/install/deb/templates/web/nginx/caching.stpl
@@ -26,7 +26,7 @@ server {
         proxy_no_cache $no_cache;
 
         set $no_cache 0;
-            if ($request_uri ~* "/wp-admin/|wp-.*.php|xmlrpc.php|/store.*|/cart.*|/my-account.*|/checkout.*|/user/|/admin/|/administrator/|/manager/|index.php") {
+            if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|/store.*|/cart.*|/my-account.*|/checkout.*|/user/|/admin/|/administrator/|/manager/|index.php") {
                 set $no_cache 1;
             }
             if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {

--- a/install/deb/templates/web/nginx/caching.tpl
+++ b/install/deb/templates/web/nginx/caching.tpl
@@ -21,7 +21,7 @@ server {
         proxy_no_cache $no_cache;
 
         set $no_cache 0;
-            if ($request_uri ~* "/wp-admin/|wp-.*.php|xmlrpc.php|/store.*|/cart.*|/my-account.*|/checkout.*|/user/|/admin/|/administrator/|/manager/|index.php") {
+            if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|/store.*|/cart.*|/my-account.*|/checkout.*|/user/|/admin/|/administrator/|/manager/|index.php") {
                 set $no_cache 1;
             }
             if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {

--- a/install/deb/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress.stpl
@@ -55,7 +55,7 @@ server {
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
             include %home%/%user%/conf/web/%domain%/nginx.fastcgi_cache.conf*;
-            if ($request_uri ~* "/wp-admin/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
+            if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
                 set $no_cache 1;
             }
             if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {

--- a/install/deb/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress.tpl
@@ -50,7 +50,7 @@ server {
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
             include %home%/%user%/conf/web/%domain%/nginx.fastcgi_cache.conf*;
-            if ($request_uri ~* "/wp-admin/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
+            if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
                 set $no_cache 1;
             }
             if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {


### PR DESCRIPTION
Hi guys,
There is a minor fix for the WordPress and common caching template to avoid nginx caching the WordPress [API Routes](https://developer.wordpress.org/rest-api/key-concepts/)