### PR TITLE
Fix firewalll icon

### DIFF
--- a/web/templates/pages/edit_server.html
+++ b/web/templates/pages/edit_server.html
@@ -5,7 +5,7 @@
       <a class="button button-secondary" id="btn-back" href="/list/server/"><i class="fas fa-arrow-left status-icon blue"></i><?=_('Back');?></a>
       <a href="/list/ip/" class="button button-secondary"><i class="fas fa-ethernet status-icon blue"></i><?=_('IP');?></a>
       <?php if ((isset($_SESSION['FIREWALL_SYSTEM'])) && (!empty($_SESSION['FIREWALL_SYSTEM']))) {?>
-        <a href="/list/firewall/" class="button button-secondary"><i class="fas fa-shield-blank status-icon red"></i><?=_('Firewall');?></a>
+        <a href="/list/firewall/" class="button button-secondary"><i class="fas fa-shield-halved status-icon red"></i><?=_('Firewall');?></a>
       <?php }?>
     </div>
     <div class="l-unit-toolbar__buttonstrip">

--- a/web/templates/pages/list_services.html
+++ b/web/templates/pages/list_services.html
@@ -6,7 +6,7 @@
       <a href="/list/rrd/" class="button button-secondary"><i class="fas fa-chart-area status-icon blue"></i><?=_('Graphs');?></a>
       <a href="/list/updates/" class="button button-secondary"><i class="fas fa-arrows-rotate status-icon green"></i><?=_('Updates');?></a>
       <?php if (!empty($_SESSION['FIREWALL_SYSTEM']) && $_SESSION['FIREWALL_SYSTEM'] == "iptables" ) {?>
-      <a href="/list/firewall/" class="button button-secondary"><i class="fas fa-shield-blank status-icon red"></i><?=_('Firewall');?></a>
+      <a href="/list/firewall/" class="button button-secondary"><i class="fas fa-shield-halved status-icon red"></i><?=_('Firewall');?></a>
       <?php }?>
       <a href="/list/log/?user=system&token=<?=$_SESSION['token']?>" class="button button-secondary"><i class="fas fa-binoculars status-icon orange"></i><?=_('Logs');?></a>
       <div class="actions-panel" key-action="js">


### PR DESCRIPTION
Replace: fa-shield-blank with fa-shield-halved

Release
<img width="717" alt="Screenshot 2022-11-26 at 00 20 45" src="https://user-images.githubusercontent.com/9754650/204062703-455d607c-de7f-40d9-a8a7-80be0410daeb.png">


Currently:
<img width="697" alt="Screenshot 2022-11-26 at 00 06 16" src="https://user-images.githubusercontent.com/9754650/204062667-69fedcfb-dcf8-4198-aa95-b16a0f1388ef.png">

Fixed:
<img width="754" alt="Screenshot 2022-11-26 at 00 21 22" src="https://user-images.githubusercontent.com/9754650/204062723-150a908c-5760-4f66-a258-f28a8f698c01.png">
