### PR TITLE
Install postgresql 13 instead of latest version

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -47,7 +47,7 @@ software="nginx apache2 apache2-utils apache2-suexec-custom
   php$fpm_v-opcache php$fpm_v-pspell php$fpm_v-readline php$fpm_v-xml
   awstats vsftpd proftpd-basic bind9 exim4 exim4-daemon-heavy
   clamav-daemon spamassassin dovecot-imapd dovecot-pop3d dovecot-sieve dovecot-managesieved
-  net-tools mariadb-client mariadb-common mariadb-server mysql-client mysql-common mysql-server postgresql
+  net-tools mariadb-client mariadb-common mariadb-server mysql-client mysql-common mysql-server postgresql-13
   postgresql-contrib phppgadmin mc flex whois git idn2 unzip zip sudo bc ftp lsof
   rrdtool quota e2fslibs bsdutils e2fsprogs curl imagemagick fail2ban
   dnsutils bsdmainutils cron hestia=${HESTIA_INSTALL_VER} hestia-nginx

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -50,7 +50,7 @@ software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
     php$fpm_v-pgsql php$fpm_v-zip php$fpm_v-bz2 php$fpm_v-cli php$fpm_v-gd
     php$fpm_v-imagick php$fpm_v-intl php$fpm_v-mbstring
     php$fpm_v-opcache php$fpm_v-pspell php$fpm_v-readline php$fpm_v-xml
-    postgresql postgresql-contrib proftpd-basic quota rrdtool spamassassin sudo hestia=${HESTIA_INSTALL_VER}
+    postgresql-13 postgresql-contrib proftpd-basic quota rrdtool spamassassin sudo hestia=${HESTIA_INSTALL_VER}
     hestia-nginx hestia-php vim-common vsftpd whois unzip zip acl sysstat setpriv rsyslog
     ipset libonig5 libzip5 openssh-server lsb-release zstd jq"
 


### PR DESCRIPTION
The installation script is installing PGA 7.13.1 which is only compatible with PostgreSQL 13 but the latest version of PostgreSQL is installed (currently 15) then when accessing PGA the message "Version of PostgreSQL not supported. Please upgrade to version or later." is shown.

This way is installed the latest compatible version (13) avoiding the error message.