### PR TITLE
Improve firewall rules clean up and doc

### DIFF
--- a/bin/v-stop-firewall
+++ b/bin/v-stop-firewall
@@ -12,7 +12,6 @@
 
 # Defining absolute path for iptables and modprobe
 iptables="/sbin/iptables"
-modprobe="/sbin/modprobe"
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -39,7 +38,7 @@ check_hestia_demo_mode
 heal_iptables_links
 
 # Creating temporary file
-tmp=$(mktemp)
+tmp="$(mktemp)"
 
 # Flushing INPUT chain
 echo "$iptables -P INPUT ACCEPT" >> $tmp
@@ -49,9 +48,8 @@ echo "$iptables -F INPUT" >> $tmp
 echo "$iptables -X hestia" >> $tmp
 
 # Deleting custom chains
-chains=$(cat $HESTIA/data/firewall/chains.conf 2> /dev/null)
 IFS=$'\n'
-for chain in $chains; do
+for chain in $(cat $HESTIA/data/firewall/chains.conf 2> /dev/null); do
 	parse_object_kv_list "$chain"
 	echo "$iptables -F fail2ban-$CHAIN" >> $tmp
 	echo "$iptables -X fail2ban-$CHAIN" >> $tmp
@@ -63,12 +61,12 @@ bash $tmp 2> /dev/null
 # Deleting temporary file
 rm -f $tmp
 
-# Saving rules to the master iptables file
+# Clean up and saving rules to the master iptables file
 if [ -d "/etc/sysconfig" ]; then
-	/sbin/iptables-save > /etc/sysconfig/iptables
+	/sbin/iptables-save | sed -e 's/[[0-9]\+:[0-9]\+]/[0:0]/g' -e '/^-A fail2ban-[A-Z]\+ -s .\+$/d' > /etc/sysconfig/iptables
 else
-	/sbin/iptables-save > /etc/iptables.rules
-	iptablesversion=$(iptables --version | head -1 | awk '{print $2}' | cut -f -2 -d .)
+	/sbin/iptables-save | sed -e 's/[[0-9]\+:[0-9]\+]/[0:0]/g' -e '/^-A fail2ban-[A-Z]\+ -s .\+$/d' > /etc/iptables.rules
+	iptablesversion="$(iptables --version | head -1 | awk '{print $2}' | cut -f -2 -d .)"
 	sd_unit="/lib/systemd/system/hestia-iptables.service"
 	if [ ! -e "$sd_unit" ]; then
 		echo "[Unit]" >> $sd_unit

--- a/bin/v-stop-firewall
+++ b/bin/v-stop-firewall
@@ -10,7 +10,7 @@
 #                Variables & Functions                     #
 #----------------------------------------------------------#
 
-# Defining absolute path for iptables and modprobe
+# Defining absolute path for iptables
 iptables="/sbin/iptables"
 
 # Includes

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -67,10 +67,10 @@ if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22" ]; then
 fi
 
 # Load ipset lists before adding Hestia iptables rules
-$BIN/v-update-firewall-ipset
+$BIN/v-update-firewall-ipset load
 
 # Creating temporary file
-tmp=$(mktemp)
+tmp="$(mktemp)"
 
 # Flushing INPUT chain
 echo "$iptables -P INPUT ACCEPT" >> $tmp
@@ -83,7 +83,7 @@ if [ "$conntrack" != 'no' ] || grep --quiet container=lxc /proc/1/environ; then
 	echo "$str" >> $tmp
 fi
 
-ips=$(ls $HESTIA/data/ips)
+ips="$(ls $HESTIA/data/ips)"
 # Handling local traffic
 for ip in $ips; do
 	echo "$iptables -A INPUT -s $ip -j ACCEPT" >> $tmp
@@ -102,7 +102,7 @@ for line in $(sort -r -n -k 2 -t \' $rules); do
 
 		if [[ "$IP" =~ ^ipset: ]]; then
 			ipset_name="${IP#ipset:}"
-			$(v-list-firewall-ipset plain | grep "^$ipset_name\s" > /dev/null) || log_event $E_NOTEXIST "ipset object ($ipset_name) not found"
+			$(v-list-firewall-ipset plain | grep "^$ipset_name\s" > /dev/null) || log_event $E_NOTEXIST "IPset IP list ($ipset_name) not found"
 			ip="-m set --match-set '${ipset_name}' src"
 		else
 			ip="-s $IP"
@@ -176,12 +176,12 @@ if [ -n "$FIREWALL_EXTENSION" ]; then
 	rm -f $tmp
 fi
 
-# Saving rules to the master iptables file
+# Clean up and saving rules to the master iptables file
 if [ -d "/etc/sysconfig" ]; then
-	/sbin/iptables-save > /etc/sysconfig/iptables
+	/sbin/iptables-save | sed -e 's/[[0-9]\+:[0-9]\+]/[0:0]/g' -e '/^-A fail2ban-[A-Z]\+ -s .\+$/d' > /etc/sysconfig/iptables
 else
-	/sbin/iptables-save > /etc/iptables.rules
-	iptablesversion=$(iptables --version | head -1 | awk '{print $2}' | cut -f -2 -d .)
+	/sbin/iptables-save | sed -e 's/[[0-9]\+:[0-9]\+]/[0:0]/g' -e '/^-A fail2ban-[A-Z]\+ -s .\+$/d' > /etc/iptables.rules
+	iptablesversion="$(iptables --version | head -1 | awk '{print $2}' | cut -f -2 -d .)"
 	sd_unit="/lib/systemd/system/hestia-iptables.service"
 	if [ ! -e "$sd_unit" ]; then
 		echo "[Unit]" >> $sd_unit

--- a/docs/docs/server-administration/firewall.md
+++ b/docs/docs/server-administration/firewall.md
@@ -1,7 +1,7 @@
 # Firewall
 
 ::: warning
-After every restart, Hestia will clear the current iptables unless the rules are added via Hestia.
+After every edit or update the firewall, Hestia will clear the current iptables unless the rules are added via Hestia and [custom script](#how-can-i-customize-iptables-rules).
 :::
 
 ## How can I open or block a port or IP?
@@ -35,6 +35,37 @@ IPSet are large lists of IP addresses or subnets. They can be used for blacklist
 7. Selected the desired IP version (v4 or v6).
 8. Choose whether to auto-update the list or not.
 9. Click the **<i class="fas fa-fw fa-save"></i> Save** button in the top right.
+
+## How can I customize iptables rules?
+
+::: danger
+This is dangerously advanced feature, please make sure you understand what you are doing.
+:::
+
+Hestia supports setting custom rules, chains or flags, etc. using script.
+
+Script must be here: `/usr/local/hestia/data/firewall/custom.sh`
+
+1. Create custom.sh: `touch /usr/local/hestia/data/firewall/custom.sh`
+2. Make it executable: `chmod +x /usr/local/hestia/data/firewall/custom.sh`
+3. Edit it with your favorite editor.
+4. Test and make sure it works.
+5. To make custom rules persistent, run: `v-update-firewall`
+
+**IMPLICIT PROTECTION:** Before making the rules persistent, if you screw up or lock yourself out of the server, just reboot.
+
+custom.sh example:
+
+```bash
+#!/bin/bash
+
+IPTABLES="$(command -v iptables)"
+
+$IPTABLES -N YOURCHAIN
+$IPTABLES -F YOURCHAIN
+$IPTABLES -I YOURCHAIN -s 0.0.0.0/0 -j RETURN
+$IPTABLES -I INPUT -p TCP -m multiport --dports 1:65535 -j YOURCHAIN
+```
 
 ## My IPSet doesn’t work
 

--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -66,31 +66,31 @@ upgrade_welcome_message() {
 	echo '                 |_| |_|\___||___/\__|_|\__,_|\____|_|                        '
 	echo "                                                                              "
 	echo "                    Hestia Control Panel Software Update                      "
-	echo "                               Version: ${DISPLAY_VER}                         "
+	echo "                               Version: ${DISPLAY_VER}"
 	if [[ "$new_version" =~ "beta" ]]; then
-		echo "                                BETA RELEASE                               "
+		echo "                                BETA RELEASE                                 "
 	fi
 	if [[ "$new_version" =~ "alpha" ]]; then
-		echo "                            DEVELOPMENT SNAPSHOT                           "
-		echo "                      NOT INTENDED FOR PRODUCTION USE                      "
-		echo "                            USE AT YOUR OWN RISK                           "
+		echo "                            DEVELOPMENT SNAPSHOT                             "
+		echo "                      NOT INTENDED FOR PRODUCTION USE                        "
+		echo "                            USE AT YOUR OWN RISK                             "
 	fi
 	echo
-	echo "=============================================================================="
+	echo "============================================================================="
 	echo
-	echo "[ ! ] IMPORTANT INFORMATION:                                                  "
+	echo "[ ! ] IMPORTANT INFORMATION:                                                 "
 	echo
-	echo "Default configuration files and templates may be modified or replaced         "
-	echo "during the upgrade process. You may restore these files from:                 "
+	echo "Default configuration files and templates may be modified or replaced        "
+	echo "during the upgrade process. You may restore these files from:                "
 	echo ""
-	echo "Backup directory: $HESTIA_BACKUP/                                             "
-	echo "Installation log: $LOG                                                        "
+	echo "Backup directory: $HESTIA_BACKUP/"
+	echo "Installation log: $LOG"
 }
 
 upgrade_welcome_message_log() {
-	echo "=============================================================================="
+	echo "============================================================================="
 	echo "Hestia Control Panel Software Update Log"
-	echo "=============================================================================="
+	echo "============================================================================="
 	echo
 	echo "OPERATING SYSTEM:      $OS_TYPE ($OS_VERSION)"
 	echo "CURRENT VERSION:       $VERSION"
@@ -274,38 +274,6 @@ upgrade_init_backup() {
 	# Hestia Control Panel configuration files
 	mkdir -p $HESTIA_BACKUP/conf/hestia/
 
-	# System services (apache2, nginx, bind9, vsftpd, etc).
-	if [ -n "$WEB_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$WEB_SYSTEM/
-	fi
-	if [ -n "$IMAP_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$IMAP_SYSTEM/
-	fi
-	if [ -n "$MAIL_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$MAIL_SYSTEM/
-	fi
-	if [ -n "$DNS_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$DNS_SYSTEM/
-	fi
-	if [ -n "$PROXY_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$PROXY_SYSTEM/
-	fi
-	if [ -n "$DB_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$DB_SYSTEM/
-	fi
-	if [ -n "$FTP_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$FTP_SYSTEM/
-	fi
-	if [ -n "$FIREWALL_SYSTEM" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$FIREWALL_SYSTEM/
-	fi
-	if [ -n "$FIREWALL_EXTENSION" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/$FIREWALL_EXTENSION/
-	fi
-	if [ -e "/etc/ssh/sshd_config" ]; then
-		mkdir -p $HESTIA_BACKUP/conf/ssh/
-	fi
-
 	# Hosting Packages
 	mkdir -p $HESTIA_BACKUP/packages/
 
@@ -461,6 +429,13 @@ upgrade_start_backup() {
 			cp -f /etc/proftpd/proftpd.conf $HESTIA_BACKUP/conf/$FTP_SYSTEM/
 		fi
 	fi
+	if [ -n "$FIREWALL_SYSTEM" ]; then
+		if [ "$DEBUG_MODE" = "true" ]; then
+			echo "      ---- $FIREWALL_SYSTEM"
+		fi
+		[ -e "/etc/sysconfig/iptables" ] && cp -f /etc/sysconfig/iptables $HESTIA_BACKUP/conf/$FIREWALL_SYSTEM/
+		[ -e "/etc/iptables.rules" ] && cp -f /etc/iptables.rules $HESTIA_BACKUP/conf/$FIREWALL_SYSTEM/
+	fi
 	if [ -n "$FIREWALL_EXTENSION" ]; then
 		if [ "$DEBUG_MODE" = "true" ]; then
 			echo "      ---- $FIREWALL_EXTENSION"
@@ -601,7 +576,7 @@ upgrade_phpmyadmin() {
 			if [ ! -d /usr/share/phpmyadmin/tmp ]; then
 				mkdir /usr/share/phpmyadmin/tmp
 				chown root:www-data /usr/share/phpmyadmin/tmp
-				chmod 770 /usr/share/phpmyadmin/tmp
+				chmod 0770 /usr/share/phpmyadmin/tmp
 
 			fi
 

--- a/install/upgrade/versions/1.6.14.sh
+++ b/install/upgrade/versions/1.6.14.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.6.14
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'no'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
+# Clean up firewall rules restore file.
+if [ "$FIREWALL_SYSTEM" = "iptables" ]; then
+	add_upgrade_message "About iptables rules [non-urgent]\n\nJust in case, if you added custom iptables rules in an unsupported way, they may have been lost.\n\nSee this issue to learn more:\nhttps://github.com/hestiacp/hestiacp/issues/3128"
+	echo "[ * ] Clean up firewall rules restore file..."
+	$BIN/v-update-firewall
+fi


### PR DESCRIPTION
Clean up before saving iptables rules restore file, zeroing counts and avoiding persistent fail2ban ban lists, it should be managed by fail2ban, hope clean freaks are happy (like me:zany_face:).

Updated documentation for firewall to add custom script usage.

Upgrade backup now also include iptables rules restore file.