### PR TITLE
Update PHP requirement for latest Symfony Framework

### DIFF
--- a/web/src/app/WebApp/Installers/Symfony/SymfonySetup.php
+++ b/web/src/app/WebApp/Installers/Symfony/SymfonySetup.php
@@ -26,7 +26,7 @@ class SymfonySetup extends BaseSetup {
 				"template" => "symfony4-5",
 			],
 			"php" => [
-				"supported" => ["8.0", "8.1"],
+				"supported" => ["8.1", "8.2"],
 			],
 		],
 	];


### PR DESCRIPTION
Current Symfony (v6.2) need at least PHP 8.1 (see: https://github.com/symfony/symfony/blob/6.2/composer.json) and it's support PHP 8.2.