### PR TITLE
Update pattern for editLink

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
 		outline: [2, 3],
 
 		editLink: {
-			pattern: "https://github.com/hestiacp/hestiacp/edit/main/docs/docs/:path",
+			pattern: "https://github.com/hestiacp/hestiacp/edit/main/docs/:path",
 			text: "Edit this page on GitHub",
 		},
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
 		outline: [2, 3],
 
 		editLink: {
-			pattern: "https://github.com/hestiacp/hestiacp-docs/edit/main/docs/:path",
+			pattern: "https://github.com/hestiacp/hestiacp/edit/main/docs/docs/:path",
 			text: "Edit this page on GitHub",
 		},
 


### PR DESCRIPTION
Changed to:
pattern: "https://github.com/hestiacp/hestiacp/edit/main/docs/docs/:path",