### PR TITLE
replace custom HTTPS socket code with libcurl

### DIFF
--- a/install/common/roundcube/hestia.php
+++ b/install/common/roundcube/hestia.php
@@ -35,7 +35,7 @@ class rcube_hestia_password {
 				CURLOPT_HEADER => true,
 				CURLOPT_POST => true,
 				CURLOPT_POSTFIELDS => http_build_query($postvars),
-				CURLOPT_USERAGENT => "PHP Script", // ???
+				CURLOPT_USERAGENT => "Hestia Control Panel Password Driver",
 				CURLOPT_SSL_VERIFYPEER => false,
 				CURLOPT_SSL_VERIFYHOST => false,
 			])

--- a/install/common/roundcube/hestia.php
+++ b/install/common/roundcube/hestia.php
@@ -6,57 +6,56 @@
  * @version 1.0
  * @author HestiaCP <info@hestiacp.com>
  */
-class rcube_hestia_password
-{
-    public function save($curpass, $passwd)
-    {
-        $rcmail = rcmail::get_instance();
-        $hestia_host = $rcmail->config->get("password_hestia_host");
+class rcube_hestia_password {
+	public function save($curpass, $passwd) {
+		$rcmail = rcmail::get_instance();
+		$hestia_host = $rcmail->config->get("password_hestia_host");
 
-        if (empty($hestia_host)) {
-            $hestia_host = "localhost";
-        }
+		if (empty($hestia_host)) {
+			$hestia_host = "localhost";
+		}
 
-        $hestia_port = $rcmail->config->get("password_hestia_port");
-        if (empty($hestia_port)) {
-            $hestia_port = "8083";
-        }
+		$hestia_port = $rcmail->config->get("password_hestia_port");
+		if (empty($hestia_port)) {
+			$hestia_port = "8083";
+		}
 
-        $postvars = [
-            "email" => $_SESSION["username"],
-            "password" => $curpass,
-            "new" => $passwd,
-        ];
-        $url = "https://{$hestia_host}:{$hestia_port}/reset/mail/";
-        $ch = curl_init();
-        if (false === curl_setopt_array($ch, [
-            CURLOPT_URL => $url,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_HEADER => true,
-            CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => http_build_query($postvars),
-            CURLOPT_USERAGENT => 'PHP Script', // ???
-            CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_SSL_VERIFYHOST => false,
-            CURLOPT_FORBID_REUSE => true,
-            CURLOPT_FRESH_CONNECT => true,
-            CURLOPT_HTTPHEADER => [
-                'Connection: close',
-            ],
-        ])) {
-            // should never happen
-            throw new Exception('curl_setopt_array() failed: ' . curl_error($ch));
-        }
-        $result = curl_exec($ch);
-        if (curl_errno($ch) !== CURLE_OK) {
-            throw new Exception('curl_exec() failed: ' . curl_error($ch));
-        }
-        curl_close($ch);
-        file_put_contents("/tmp/roundcube.log", "test ok\n", LOCK_EX);
-        if (strpos($result, "ok") && !strpos($result, "error")) {
-            return PASSWORD_SUCCESS;
-        } else {
-            return PASSWORD_ERROR;
-        }
-    }
+		$postvars = [
+			"email" => $_SESSION["username"],
+			"password" => $curpass,
+			"new" => $passwd,
+		];
+		$url = "https://{$hestia_host}:{$hestia_port}/reset/mail/";
+		$ch = curl_init();
+		if (
+			false ===
+			curl_setopt_array($ch, [
+				CURLOPT_URL => $url,
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_HEADER => true,
+				CURLOPT_POST => true,
+				CURLOPT_POSTFIELDS => http_build_query($postvars),
+				CURLOPT_USERAGENT => "PHP Script", // ???
+				CURLOPT_SSL_VERIFYPEER => false,
+				CURLOPT_SSL_VERIFYHOST => false,
+				CURLOPT_FORBID_REUSE => true,
+				CURLOPT_FRESH_CONNECT => true,
+				CURLOPT_HTTPHEADER => ["Connection: close"],
+			])
+		) {
+			// should never happen
+			throw new Exception("curl_setopt_array() failed: " . curl_error($ch));
+		}
+		$result = curl_exec($ch);
+		if (curl_errno($ch) !== CURLE_OK) {
+			throw new Exception("curl_exec() failed: " . curl_error($ch));
+		}
+		curl_close($ch);
+		file_put_contents("/tmp/roundcube.log", "test ok\n", LOCK_EX);
+		if (strpos($result, "ok") && !strpos($result, "error")) {
+			return PASSWORD_SUCCESS;
+		} else {
+			return PASSWORD_ERROR;
+		}
+	}
 }

--- a/install/common/roundcube/hestia.php
+++ b/install/common/roundcube/hestia.php
@@ -48,7 +48,6 @@ class rcube_hestia_password {
 			throw new Exception("curl_exec() failed: " . curl_error($ch));
 		}
 		curl_close($ch);
-		file_put_contents("/tmp/roundcube.log", "test ok\n", LOCK_EX);
 		if (strpos($result, "ok") && !strpos($result, "error")) {
 			return PASSWORD_SUCCESS;
 		} else {

--- a/install/common/roundcube/hestia.php
+++ b/install/common/roundcube/hestia.php
@@ -38,9 +38,6 @@ class rcube_hestia_password {
 				CURLOPT_USERAGENT => "PHP Script", // ???
 				CURLOPT_SSL_VERIFYPEER => false,
 				CURLOPT_SSL_VERIFYHOST => false,
-				CURLOPT_FORBID_REUSE => true,
-				CURLOPT_FRESH_CONNECT => true,
-				CURLOPT_HTTPHEADER => ["Connection: close"],
 			])
 		) {
 			// should never happen


### PR DESCRIPTION
several reasons, for one, "$result = fread($fp, 2048);" is not the correct way to read the result, what if its more than 2048 bytes? or what if its less, and the server doesn't close the connection, then you risk a stalling read taking much longer than than required, the correct way is to parse out the "Content-Length" header and read that many bytes (which curl does, the custom https socket code didn't),

and.. its just simpler and easier to read curl code than custom https socket code~