### PR TITLE
MediaWikiSetup.php: Use version 1.39.1

### DIFF
--- a/web/src/app/WebApp/Installers/MediaWiki/MediaWikiSetup.php
+++ b/web/src/app/WebApp/Installers/MediaWiki/MediaWikiSetup.php
@@ -10,7 +10,7 @@ class MediaWikiSetup extends BaseSetup {
 		"name" => "MediaWiki",
 		"group" => "cms",
 		"enabled" => true,
-		"version" => "1.39.0",
+		"version" => "1.39.1",
 		"thumbnail" => "MediaWiki-2020-logo.svg", //Max size is 300px by 300px
 	];
 
@@ -26,7 +26,7 @@ class MediaWikiSetup extends BaseSetup {
 		"database" => true,
 		"resources" => [
 			"archive" => [
-				"src" => "https://releases.wikimedia.org/mediawiki/1.39/mediawiki-1.39.0.zip",
+				"src" => "https://releases.wikimedia.org/mediawiki/1.39/mediawiki-1.39.1.zip",
 			],
 		],
 		"server" => [
@@ -60,7 +60,7 @@ class MediaWikiSetup extends BaseSetup {
 
 		$this->appcontext->runUser(
 			"v-copy-fs-directory",
-			[$this->getDocRoot($this->extractsubdir . "/mediawiki-1.39.0/."), $this->getDocRoot()],
+			[$this->getDocRoot($this->extractsubdir . "/mediawiki-1.39.1/."), $this->getDocRoot()],
 			$result,
 		);
 


### PR DESCRIPTION
Version 1.39.1 is released on 22nd of December. See this thread for more information: https://lists.wikimedia.org/hyperkitty/list/mediawiki-l@lists.wikimedia.org/thread/UEMW64LVEH3BEXCJV43CVS6XPYURKWU3/

Follows-up: #3132