### PR TITLE
Fix prefixes not getting set correctly

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -175,6 +175,12 @@ function render_page($user, $TAB, $page) {
 	$__template_dir = dirname(__DIR__) . "/templates/";
 	$__pages_js_dir = dirname(__DIR__) . "/js/pages/";
 
+	// Panel
+	$panel = top_panel(empty($_SESSION["look"]) ? $_SESSION["user"] : $_SESSION["look"], $TAB);
+	// Extract global variables
+	// I think those variables should be passed via arguments
+	extract($GLOBALS, EXTR_SKIP);
+
 	// Header
 	include $__template_dir . "header.php";
 
@@ -182,12 +188,6 @@ function render_page($user, $TAB, $page) {
 	if (file_exists($__pages_js_dir . $page . ".js")) {
 		echo '<script defer src="/js/pages/' . $page . ".js?" . JS_LATEST_UPDATE . '"></script>';
 	}
-
-	// Panel
-	$panel = top_panel(empty($_SESSION["look"]) ? $_SESSION["user"] : $_SESSION["look"], $TAB);
-	// Extract global variables
-	// I think those variables should be passed via arguments
-	extract($GLOBALS, EXTR_SKIP);
 
 	// Policies controller
 	@include_once dirname(__DIR__) . "/inc/policies.php";

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -175,14 +175,15 @@ function render_page($user, $TAB, $page) {
 	$__template_dir = dirname(__DIR__) . "/templates/";
 	$__pages_js_dir = dirname(__DIR__) . "/js/pages/";
 
-	// Panel
-	$panel = top_panel(empty($_SESSION["look"]) ? $_SESSION["user"] : $_SESSION["look"], $TAB);
 	// Extract global variables
 	// I think those variables should be passed via arguments
 	extract($GLOBALS, EXTR_SKIP);
 
 	// Header
 	include $__template_dir . "header.php";
+
+	// Panel
+	$panel = top_panel(empty($_SESSION["look"]) ? $_SESSION["user"] : $_SESSION["look"], $TAB);
 
 	// Including page specific js file
 	if (file_exists($__pages_js_dir . $page . ".js")) {


### PR DESCRIPTION
The global variables need to be extracted  before the header.php file gets included. If they aren't, they are not available in the file, hence causing the prefixes to not get set correctly.