### PR TITLE
Increment backend port also when commented

### DIFF
--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -55,7 +55,7 @@ fi
 
 # Allocating backend port
 backend_port=9000
-ports=$(grep -v '^;' $pool/* 2> /dev/null | grep listen | grep -o :[0-9].*)
+ports=$(grep $pool/* 2> /dev/null | grep -o :[0-9].*)
 ports=$(echo "$ports" | sed "s/://" | sort -n)
 for port in $ports; do
 	if [ "$backend_port" -eq "$port" ]; then

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -62,7 +62,7 @@ delete_web_backend
 
 # Allocating backend port
 backend_port=9000
-ports=$(grep -v '^;' $pool/* 2> /dev/null | grep listen | grep -o :[0-9].*)
+ports=$(grep $pool/* 2> /dev/null | grep -o :[0-9].*)
 ports=$(echo "$ports" | sed "s/://" | sort -n)
 for port in $ports; do
 	if [ "$backend_port" -eq "$port" ]; then


### PR DESCRIPTION
This allows to grep the incremented port also for other backends then php-fpm with `%backend_lsnr%` in the web template.

This is an example how I use it in a wsgi app with gunicorn. It works out of the box with this patch applied.

Backend template:
```
;[%backend%]
;listen = 127.0.0.1:%backend_port%
```
Nginx web template:
```
server {
    listen      %ip%:%web_ssl_port% ssl http2;
    server_name %domain_idn% %alias_idn%;

    location / {
        proxy_pass          http://%backend_lsnr%/;
        proxy_redirect      off;
        proxy_set_header    Host                    $host;
        proxy_set_header    X-Real-IP               $remote_addr;
        proxy_set_header    X-Forwarded-For         $proxy_add_x_forwarded_for;
        proxy_set_header    X-Forwarded-Protocol    $scheme;
    }
}
```