### PR TITLE
Please do not use $BIN and $HESTIA/bin interchangeably; breaks override

### DIFF
--- a/bin/v-add-cron-hestia-autoupdate
+++ b/bin/v-add-cron-hestia-autoupdate
@@ -53,7 +53,7 @@ if [ -z "$mode" ] || [ "$mode" = "apt" ]; then
 	day='*'
 	month='*'
 	wday='*'
-	command='sudo /usr/local/hestia/bin/v-update-sys-hestia-all'
+	command="sudo $BIN/v-update-sys-hestia-all"
 fi
 
 if [ "$mode" = "git" ]; then
@@ -62,7 +62,7 @@ if [ "$mode" = "git" ]; then
 	day='*'
 	month='*'
 	wday='*'
-	command='sudo /usr/local/hestia/bin/v-update-sys-hestia-git'
+	command="sudo $BIN/v-update-sys-hestia-git"
 fi
 
 # Concatenating cron string

--- a/bin/v-add-cron-letsencrypt-job
+++ b/bin/v-add-cron-letsencrypt-job
@@ -30,7 +30,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Add cron job
-cmd="sudo $HESTIA/bin/v-update-sys-queue letsencrypt"
+cmd="sudo $BIN/v-update-sys-queue letsencrypt"
 check_cron=$(grep "$cmd" $HESTIA/data/users/admin/cron.conf 2> /dev/null)
 if [ -z "$check_cron" ] && [ -n "$CRON_SYSTEM" ]; then
 	$BIN/v-add-cron-job admin '*/5' '*' '*' '*' '*' "$cmd"

--- a/bin/v-add-cron-restart-job
+++ b/bin/v-add-cron-restart-job
@@ -30,7 +30,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Add cron job
-cmd="sudo $HESTIA/bin/v-update-sys-queue restart"
+cmd="sudo $BIN/v-update-sys-queue restart"
 check_cron=$(grep "$cmd" $HESTIA/data/users/admin/cron.conf 2> /dev/null)
 if [ -z "$check_cron" ] && [ -n "$CRON_SYSTEM" ]; then
 	$BIN/v-add-cron-job admin '*' '*' '*' '*' '*' "$cmd"

--- a/bin/v-add-letsencrypt-host
+++ b/bin/v-add-letsencrypt-host
@@ -29,7 +29,7 @@ domain=$(hostname -f)
 if [ -z $domain ]; then
 	domain=$HOSTNAME
 fi
-user="$($HESTIA/bin/v-search-domain-owner "$domain" web)"
+user="$($BIN/v-search-domain-owner "$domain" web)"
 [[ -z "$user" ]] && user="admin"
 
 USER_DATA=$HESTIA/data/users/$user

--- a/bin/v-add-remote-dns-host
+++ b/bin/v-add-remote-dns-host
@@ -119,7 +119,7 @@ check_result $? "$HOST sync failed" "$E_CONNECT"
 #----------------------------------------------------------#
 
 # Adding local  dns-cluster cron job
-cmd="sudo $HESTIA/bin/v-update-sys-queue dns-cluster"
+cmd="sudo $BIN/v-update-sys-queue dns-cluster"
 check_cron=$(grep "$cmd" $HESTIA/data/users/admin/cron.conf 2> /dev/null)
 if [ -z "$check_cron" ] && [ ! -z "$CRON_SYSTEM" ]; then
 	$BIN/v-add-cron-job admin '*/5' '*' '*' '*' '*' "$cmd"

--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -199,7 +199,7 @@ fi
 increase_user_value "$user" '$IP_OWNED'
 if [ "$user" = 'admin' ]; then
 	if [ "$ip_status" = 'shared' ]; then
-		for hestia_user in $($HESTIA/bin/v-list-sys-users plain); do
+		for hestia_user in $($BIN/v-list-sys-users plain); do
 			increase_user_value "$hestia_user" '$IP_AVAIL'
 		done
 	else

--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -90,7 +90,7 @@ else
 fi
 
 # Rebuilding user quota
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	$BIN/v-update-user-quota "$user"
 done
 

--- a/bin/v-backup-users
+++ b/bin/v-backup-users
@@ -31,7 +31,7 @@ mysqlrepair --all-databases --check --auto-repair > /dev/null 2>&1
 if [ -z "$BACKUP_SYSTEM" ]; then
 	exit
 fi
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	check_suspend=$(grep "SUSPENDED='no'" $HESTIA/data/users/$user/user.conf)
 	log=$HESTIA/log/backup.log
 	if [ ! -f "$HESTIA/data/users/$user/user.conf" ]; then

--- a/bin/v-change-domain-owner
+++ b/bin/v-change-domain-owner
@@ -301,7 +301,7 @@ if [ -n "$old_ip" ]; then
 fi
 # Send notification to panel
 if [ -n "$web_data" ] || [ -n "$dns_data" ] || [ -n "$mail_data" ]; then
-	$HESTIA/bin/v-add-user-notification "$user" "$domain has been added to your account" ''
+	$BIN/v-add-user-notification "$user" "$domain has been added to your account" ''
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-change-mail-domain-rate-limit
+++ b/bin/v-change-mail-domain-rate-limit
@@ -63,7 +63,7 @@ fi
 
 # Update quota
 update_object_value "mail" 'DOMAIN' "$domain" '$RATE_LIMIT' "$rate"
-$HESTIA/bin/v-rebuild-mail-domain "$user" "$domain"
+$BIN/v-rebuild-mail-domain "$user" "$domain"
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Mail" "Mail domain rate limit has changed ($rate)"

--- a/bin/v-change-sys-api
+++ b/bin/v-change-sys-api
@@ -53,12 +53,12 @@ if [ "$status" = "enable" ]; then
 		sed -i 's|die("Error: Disabled");|//die("Error: Disabled");|g' $HESTIA/web/api/index.php
 		sed -i 's|////|//|g' $HESTIA/web/api/index.php
 	fi
-	if [ "$version" = "legacy" ] || [ "$version" = "all" ]; then $HESTIA/bin/v-change-sys-config-value "API" "yes"; fi
-	if [ "$version" = "api" ] || [ "$version" = "all" ]; then $HESTIA/bin/v-change-sys-config-value "API_SYSTEM" "1"; fi
+	if [ "$version" = "legacy" ] || [ "$version" = "all" ]; then $BIN/v-change-sys-config-value "API" "yes"; fi
+	if [ "$version" = "api" ] || [ "$version" = "all" ]; then $BIN/v-change-sys-config-value "API_SYSTEM" "1"; fi
 else
-	$HESTIA/bin/v-change-sys-config-value "API" "no"
-	$HESTIA/bin/v-change-sys-config-value "API_ALLOWED_IP" ""
-	$HESTIA/bin/v-change-sys-config-value "API_SYSTEM" "0"
+	$BIN/v-change-sys-config-value "API" "no"
+	$BIN/v-change-sys-config-value "API_ALLOWED_IP" ""
+	$BIN/v-change-sys-config-value "API_SYSTEM" "0"
 	if [ "$status" != "remove" ]; then
 		sed -i 's|//die("Error: Disabled");|die("Error: Disabled");|g' $HESTIA/web/api/index.php
 	fi

--- a/bin/v-change-sys-db-alias
+++ b/bin/v-change-sys-db-alias
@@ -56,7 +56,7 @@ if [ "$type" = "pma" ] || [ "$type" = "PMA" ] || [ "$type" = "phpmyadmin" ]; the
 		sed -i "s|%pma_alias%|$alias|g" /etc/apache2/conf.d/phpmyadmin.inc
 
 		# Restart services
-		$HESTIA/bin/v-restart-service apache2
+		$BIN/v-restart-service apache2
 	fi
 
 	if [ -e "/etc/nginx/conf.d/phpmyadmin.inc" ]; then
@@ -65,7 +65,7 @@ if [ "$type" = "pma" ] || [ "$type" = "PMA" ] || [ "$type" = "phpmyadmin" ]; the
 		sed -i "s|%pma_alias%|$alias|g" /etc/nginx/conf.d/phpmyadmin.inc
 
 		# Restart services
-		$HESTIA/bin/v-restart-service nginx
+		$BIN/v-restart-service nginx
 	fi
 fi
 
@@ -84,7 +84,7 @@ if [ "$type" = "pga" ] || [ "$type" = "PGA" ] || [ "$type" = "phppgadmin" ]; the
 		sed -i "s|%pga_alias%|$alias|g" /etc/apache2/conf.d/phppgadmin.inc
 
 		# Restart services
-		$HESTIA/bin/v-restart-service apache2
+		$BIN/v-restart-service apache2
 	fi
 
 	if [ -e "/etc/nginx/conf.d/phppgadmin.inc" ]; then
@@ -93,7 +93,7 @@ if [ "$type" = "pga" ] || [ "$type" = "PGA" ] || [ "$type" = "phppgadmin" ]; the
 		sed -i "s|%pga_alias%|$alias|g" /etc/nginx/conf.d/phppgadmin.inc
 
 		# Restart services
-		$HESTIA/bin/v-restart-service nginx
+		$BIN/v-restart-service nginx
 	fi
 fi
 

--- a/bin/v-change-sys-ip-nat
+++ b/bin/v-change-sys-ip-nat
@@ -57,7 +57,7 @@ fi
 
 # Updating WEB configs
 if [ -n "$old" ] && [ -n "$WEB_SYSTEM" ]; then
-	for user in $($HESTIA/bin/v-list-sys-users plain); do
+	for user in $($BIN/v-list-sys-users plain); do
 		sed -i "s/$old/$new/" $HESTIA/data/users/$user/web.conf
 		$BIN/v-rebuild-web-domains $user no
 	done
@@ -66,7 +66,7 @@ fi
 
 # Updating DNS configs
 if [ -n "$old" ] && [ -n "$DNS_SYSTEM" ]; then
-	for user in $($HESTIA/bin/v-list-sys-users plain); do
+	for user in $($BIN/v-list-sys-users plain); do
 		sed -i "s/$old/$new/" $HESTIA/data/users/$user/dns.conf
 		if ls $HESTIA/data/users/$user/dns/*.conf 1> /dev/null 2>&1; then
 			sed -i "s/$old/$new/" $HESTIA/data/users/$user/dns/*.conf

--- a/bin/v-change-sys-ip-owner
+++ b/bin/v-change-sys-ip-owner
@@ -51,7 +51,7 @@ if [ "$ip_owner" != "$user" ]; then
 	decrease_user_value "$ip_owner" '$IP_OWNED'
 	if [ "$ip_owner" = 'admin' ]; then
 		if [ "$ip_status" = 'shared' ]; then
-			for hestia_user in $($HESTIA/bin/v-list-sys-users plain); do
+			for hestia_user in $($BIN/v-list-sys-users plain); do
 				decrease_user_value "$hestia_user" '$IP_AVAIL'
 			done
 		else
@@ -65,7 +65,7 @@ if [ "$ip_owner" != "$user" ]; then
 	increase_user_value "$user" '$IP_OWNED'
 	if [ "$user" = 'admin' ]; then
 		if [ "$ip_status" = 'shared' ]; then
-			for hestia_user in $($HESTIA/bin/v-list-sys-users plain); do
+			for hestia_user in $($BIN/v-list-sys-users plain); do
 				increase_user_value "$hestia_user" '$IP_AVAIL'
 			done
 		else
@@ -80,7 +80,7 @@ fi
 # Set status to dedicated if owner is not admin
 ip_status="$(get_ip_value '$STATUS')"
 if [ "$user" != 'admin' ] && [ "$ip_status" == 'shared' ]; then
-	$HESTIA/bin/v-change-sys-ip-status "$ip" 'dedicated'
+	$BIN/v-change-sys-ip-status "$ip" 'dedicated'
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -41,7 +41,7 @@ if [ "$web_domains" -ne '0' ] && [ "$sys_user" != "$ip_owner" ]; then
 	check_result "$E_INUSE" "ip $ip is used"
 fi
 if [ "$ip_owner" != "admin" ] && [ "$ip_status" == "shared" ]; then
-	$HESTIA/bin/v-change-sys-ip-owner "$ip" "admin"
+	$BIN/v-change-sys-ip-owner "$ip" "admin"
 fi
 
 # Perform verification if read-only mode is enabled

--- a/bin/v-change-sys-language
+++ b/bin/v-change-sys-language
@@ -54,7 +54,7 @@ fi
 
 # Update language for all existing users if specified
 if [ "$update_users" = "yes" ]; then
-	for user in $($HESTIA/bin/v-list-sys-users plain); do
+	for user in $($BIN/v-list-sys-users plain); do
 		$BIN/v-change-user-language "$user" "$language"
 	done
 fi

--- a/bin/v-change-sys-php
+++ b/bin/v-change-sys-php
@@ -28,7 +28,7 @@ if [[ ! $version =~ ^[0-9]\.[0-9]+ ]]; then
 fi
 
 # Check if php version exists
-version_check=$($HESTIA/bin/v-list-sys-php plain | grep "$version")
+version_check=$($BIN/v-list-sys-php plain | grep "$version")
 if [ -z "$version_check" ]; then
 	echo "ERROR: Specified PHP version is not installed."
 	exit "$E_INVALID"
@@ -47,15 +47,15 @@ php_fpm="/etc/init.d/php$version-fpm"
 rm -f /etc/php/*/fpm/pool.d/www.conf
 cp -f $HESTIA/install/deb/php-fpm/www.conf /etc/php/$version/fpm/pool.d/www.conf
 
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	$BIN/v-rebuild-web-domains "$user" 'no' > /dev/null 2>&1
 	$BIN/v-rebuild-mail-domains "$user" 'no' > /dev/null 2>&1
 done
 
 # restart
-$HESTIA/bin/v-restart-web-backend
-$HESTIA/bin/v-restart-web
-$HESTIA/bin/v-restart-proxy
+$BIN/v-restart-web-backend
+$BIN/v-restart-web
+$BIN/v-restart-proxy
 
 update-alternatives --set php /usr/bin/php$version
 

--- a/bin/v-change-sys-port
+++ b/bin/v-change-sys-port
@@ -62,7 +62,7 @@ if [ "$ORIGINAL_PORT" = "$PORT" ]; then
 	exit
 else
 	# Set new port in config via v-change-sys-config-value
-	$HESTIA/bin/v-change-sys-config-value "BACKEND_PORT" "$PORT"
+	$BIN/v-change-sys-config-value "BACKEND_PORT" "$PORT"
 	# Replace port in config files.
 	sed -i "/listen/c\        listen          $PORT ssl;" $HESTIA/nginx/conf/nginx.conf
 	if [ -d /etc/roundcube/ ]; then
@@ -82,12 +82,12 @@ else
 
 	# Restart services
 	if [ -n "$FIREWALL_SYSTEM" ] && [ "$FIREWALL_SYSTEM" != no ]; then
-		$HESTIA/bin/v-restart-service iptables
+		$BIN/v-restart-service iptables
 	fi
 
 	# Check if Hestia is running
 	if [[ $(ps -eaf | grep -i hestia | sed '/^$/d' | wc -l) -gt 1 ]]; then
-		$HESTIA/bin/v-restart-service hestia
+		$BIN/v-restart-service hestia
 	fi
 fi
 

--- a/bin/v-change-sys-webmail
+++ b/bin/v-change-sys-webmail
@@ -35,7 +35,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Delete old webmail configuration
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	for domain in $($BIN/v-list-mail-domains "$user" plain | cut -f 1); do
 		$BIN/v-delete-mail-domain-webmail "$user" "$domain"
 	done
@@ -45,7 +45,7 @@ done
 $BIN/v-change-sys-config-value 'WEBMAIL_ALIAS' $NEW_ALIAS
 
 # Add new webmail configuration
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	for domain in $($BIN/v-list-mail-domains "$user" plain | cut -f 1); do
 		$BIN/v-add-mail-domain-webmail "$user" "$domain"
 	done

--- a/bin/v-change-user-sort-order
+++ b/bin/v-change-user-sort-order
@@ -39,7 +39,7 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-$HESTIA/bin/v-change-user-config-value "$user" 'PREF_UI_SORT' "$sort_order"
+$BIN/v-change-user-config-value "$user" 'PREF_UI_SORT' "$sort_order"
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-change-user-theme
+++ b/bin/v-change-user-theme
@@ -34,7 +34,7 @@ is_object_valid 'user' 'USER' "$user"
 
 is_object_unsuspended 'user' 'USER' "$user"
 
-themes=$($HESTIA/bin/v-list-sys-themes plain)
+themes=$($BIN/v-list-sys-themes plain)
 
 if ! echo "$themes" | grep -q -x "$theme"; then
 	echo "Theme does not exists"

--- a/bin/v-delete-cron-restart-job
+++ b/bin/v-delete-cron-restart-job
@@ -30,7 +30,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Add cron job
-cmd="sudo $HESTIA/bin/v-update-sys-queue restart"
+cmd="sudo $BIN/v-update-sys-queue restart"
 check_cron=$(grep "$cmd" $HESTIA/data/users/admin/cron.conf 2> /dev/null)
 if [ -n "$check_cron" ]; then
 	parse_object_kv_list "$check_cron"

--- a/bin/v-delete-remote-dns-host
+++ b/bin/v-delete-remote-dns-host
@@ -52,7 +52,7 @@ if [ "$check_cluster" -eq '0' ]; then
 	sed -i "/DNS_CLUSTER=/d" "$HESTIA/conf/hestia.conf"
 
 	# Delete cron job
-	cmd="sudo $HESTIA/bin/v-update-sys-queue dns-cluster"
+	cmd="sudo $BIN/v-update-sys-queue dns-cluster"
 	check_cron=$(grep "$cmd" $HESTIA/data/users/admin/cron.conf 2> /dev/null)
 	if [ -n "$check_cron" ]; then
 		parse_object_kv_list "$check_cron"

--- a/bin/v-delete-sys-ip
+++ b/bin/v-delete-sys-ip
@@ -135,7 +135,7 @@ fi
 
 if [ "$OWNER" = 'admin' ]; then
 	if [ "$STATUS" = 'shared' ]; then
-		for hestia_user in $($HESTIA/bin/v-list-sys-users plain); do
+		for hestia_user in $($BIN/v-list-sys-users plain); do
 			decrease_user_value "$hestia_user" '$IP_AVAIL'
 		done
 	else

--- a/bin/v-delete-web-php
+++ b/bin/v-delete-web-php
@@ -45,7 +45,7 @@ fi
 [ -f $HESTIA/data/templates/web/php-fpm/PHP-${version/\./_}.tpl ] && rm -f $HESTIA/data/templates/web/php-fpm/PHP-${version/\./_}.tpl
 
 # Check if php version exists
-version_check=$($HESTIA/bin/v-list-sys-php plain | grep "$version")
+version_check=$($BIN/v-list-sys-php plain | grep "$version")
 if [ -z "$version_check" ]; then
 	echo "ERROR: Specified PHP version is not installed."
 	exit "$E_INVALID"

--- a/bin/v-generate-debug-report
+++ b/bin/v-generate-debug-report
@@ -53,22 +53,22 @@ time_n_date=$(echo "$time_n_date" | sed "s|:||g" | sed "s| |_|g")
 # If logging specified, export shellcheck output to log
 if [ "$log" = "yes" ]; then
 	if [ "$mode" = "all" ]; then
-		shellcheck -x "$HESTIA/bin/$script" > "$DEBUG_PATH/${script}_$time_n_date.log"
+		shellcheck -x "$BIN/$script" > "$DEBUG_PATH/${script}_$time_n_date.log"
 	fi
 	if [ "$mode" = "warn" ]; then
-		shellcheck -x -e "SC2086,SC1090,SC2154,SC2153" "$HESTIA/bin/$script" > "$DEBUG_PATH/${script}_$time_n_date.log"
+		shellcheck -x -e "SC2086,SC1090,SC2154,SC2153" "$BIN/$script" > "$DEBUG_PATH/${script}_$time_n_date.log"
 	else
-		shellcheck -x -e "SC2086,SC2016,SC2153,SC2154,SC1090,SC2034,SC2119" "$HESTIA/bin/$script" > "$DEBUG_PATH/${script}_$time_n_date.log"
+		shellcheck -x -e "SC2086,SC2016,SC2153,SC2154,SC1090,SC2034,SC2119" "$BIN/$script" > "$DEBUG_PATH/${script}_$time_n_date.log"
 	fi
 else
 	# Prompt user to scroll output from shellcheck
 	clear
 	if [ "$mode" = "all" ]; then
-		shellcheck -x "$HESTIA/bin/$script"
+		shellcheck -x "$BIN/$script"
 	fi
 	if [ "$mode" = "warn" ]; then
-		shellcheck -x -e "SC2086,SC1090,SC2154,SC2153" "$HESTIA/bin/$script"
+		shellcheck -x -e "SC2086,SC1090,SC2154,SC2153" "$BIN/$script"
 	else
-		shellcheck -x -e "SC2086,SC2016,SC2153,SC2154,SC1090,SC2034,SC2119" "$HESTIA/bin/$script"
+		shellcheck -x -e "SC2086,SC2016,SC2153,SC2154,SC1090,SC2034,SC2119" "$BIN/$script"
 	fi
 fi

--- a/bin/v-rebuild-users
+++ b/bin/v-rebuild-users
@@ -37,7 +37,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Rebuild loop
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	$BIN/v-rebuild-user "$user" "$restart"
 done
 

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -709,7 +709,7 @@ if [ "$mail" != 'no' ] && [ -n "$MAIL_SYSTEM" ]; then
 				-exec chown $exim_user {} \;
 		fi
 
-		$HESTIA/bin/v-rebuild-mail-domain $user $domain
+		$BIN/v-rebuild-mail-domain $user $domain
 
 	done
 
@@ -919,7 +919,7 @@ subj="$user → restore has been completed"
 cat $tmpdir/restore.log | $SENDMAIL -s "$subj" $email $notify
 
 # Send notification to panel
-$HESTIA/bin/v-add-user-notification "$user" "Backup restored successfully" "<b>Archive:</b> $backup"
+$BIN/v-add-user-notification "$user" "Backup restored successfully" "<b>Archive:</b> $backup"
 
 # Deleting temporary data
 rm -rf $tmpdir

--- a/bin/v-search-command
+++ b/bin/v-search-command
@@ -37,8 +37,8 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-SearchResults=$(ls -a $HESTIA/bin/ | sort)
-TotalItems=$(ls -a $HESTIA/bin/ | sort | wc -l)
+SearchResults=$(ls -a $BIN/ | sort)
+TotalItems=$(ls -a $BIN/ | sort | wc -l)
 
 for i; do
 	SearchResults=$(echo $SearchResults | tr " " "\n" | grep $i)

--- a/bin/v-search-object
+++ b/bin/v-search-object
@@ -93,7 +93,7 @@ OLD_IFS=$IFS
 IFS=$'\n'
 
 # User loop
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	# Search query
 	search=$(grep "$object" \
 		$HESTIA/data/users/$user/web.conf \

--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -37,7 +37,7 @@ if [ "$LE_STAGING" = "yes" ]; then
 fi
 
 # Checking user certificates
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	USER_DATA=$HESTIA/data/users/$user
 
 	for domain in $(search_objects 'web' 'LETSENCRYPT' 'yes' 'DOMAIN'); do
@@ -159,11 +159,11 @@ for user in $($HESTIA/bin/v-list-sys-users plain); do
 done
 
 # Restart related services
-$HESTIA/bin/v-restart-web yes
-$HESTIA/bin/v-restart-mail yes
+$BIN/v-restart-web yes
+$BIN/v-restart-mail yes
 
 if [ -n "$PROXY_SYSTEM" ]; then
-	$HESTIA/bin/v-restart-proxy yes
+	$BIN/v-restart-proxy yes
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-update-mail-templates
+++ b/bin/v-update-mail-templates
@@ -32,7 +32,7 @@ cp -rf $HESTIA_INSTALL_DIR/templates/mail $HESTIA/data/templates/
 # Rebuild mail domains if mail services are enabled
 if [ -z "$skip" ]; then
 	if [ -n "$MAIL_SYSTEM" ]; then
-		for user in $($HESTIA/bin/v-list-sys-users plain); do
+		for user in $($BIN/v-list-sys-users plain); do
 			$BIN/v-rebuild-mail-domains "$user" no
 		done
 	fi

--- a/bin/v-update-sys-hestia-git
+++ b/bin/v-update-sys-hestia-git
@@ -201,7 +201,7 @@ if [ -n "$branch" ]; then
 		echo "ERROR: invalid branch name specified."
 		exit 1
 	else
-		/usr/local/hestia/bin/v-change-sys-config-value 'RELEASE_BRANCH' "$branch"
+		$BIN/v-change-sys-config-value 'RELEASE_BRANCH' "$branch"
 		echo "[!] Changed system release branch to: $branch."
 	fi
 else

--- a/bin/v-update-sys-hestia-git
+++ b/bin/v-update-sys-hestia-git
@@ -350,7 +350,7 @@ cd $BUILD_DIR/hestiacp-$branch_dash
 if [ "$install" = "install" ] || [ "$install" = "yes" ] || [ "$install" = "install-auto" ]; then
 	install_build
 	if [ "$install" = "install-auto" ]; then
-		$HESTIA/bin/v-add-cron-hestia-autoupdate git
+		$BIN/v-add-cron-hestia-autoupdate git
 	fi
 else
 	warning_message

--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -68,7 +68,7 @@ if [ ! -z "$new" ]; then
 			mv $old.conf $new.conf
 			sed -i "s/$old/$new/g" $new.conf
 		fi
-		for user in $($HESTIA/bin/v-list-sys-users plain); do
+		for user in $($BIN/v-list-sys-users plain); do
 			sed -i "s/$old/$new/g" $HESTIA/data/users/$user/web.conf
 			$BIN/v-rebuild-web-domains "$user" no
 		done
@@ -86,14 +86,14 @@ if [ ! -z "$new" ]; then
 	fi
 
 	if [ -n "$IMAP_SYSTEM" ]; then
-		for user in $($HESTIA/bin/v-list-sys-users plain); do
+		for user in $($BIN/v-list-sys-users plain); do
 			$BIN/v-rebuild-mail-domains "$user" no
 		done
 	fi
 
 	# Updating DNS
 	if [ ! -z "$DNS_SYSTEM" ]; then
-		for user in $($HESTIA/bin/v-list-sys-users plain); do
+		for user in $($BIN/v-list-sys-users plain); do
 			sed -i "s/$old/$new/g" $HESTIA/data/users/$user/dns.conf
 			sed -i "s/$old/$new/g" $HESTIA/data/users/$user/dns/*.conf
 			$BIN/v-rebuild-dns-domains "$user" no

--- a/bin/v-update-sys-queue
+++ b/bin/v-update-sys-queue
@@ -34,9 +34,9 @@ check_args '1' "$#" 'QUEUE'
 #                       Action                             #
 #----------------------------------------------------------#
 
-b_task=$(ps auxf | grep -v "grep" | grep "$HESTIA/bin/v-update-sys-queue backup")
+b_task=$(ps auxf | grep -v "grep" | grep "$BIN/v-update-sys-queue backup")
 b_task=$(echo "$b_task" | grep -v sudo | wc -l)
-d_task=$(ps auxf | grep -v "grep" | grep "$HESTIA/bin/v-update-sys-queue dns")
+d_task=$(ps auxf | grep -v "grep" | grep "$BIN/v-update-sys-queue dns")
 d_task=$(echo "$d_task" | grep -v sudo | wc -l)
 if [ "$b_task" -gt 2 ] || [ "$d_task" -gt 2 ]; then
 	exit

--- a/bin/v-update-user-counters
+++ b/bin/v-update-user-counters
@@ -37,7 +37,7 @@ fi
 
 # Creating user_list
 if [ -z "$user" ]; then
-	user_list=$($HESTIA/bin/v-list-sys-users plain)
+	user_list=$($BIN/v-list-sys-users plain)
 else
 	user_list="$user"
 fi
@@ -85,7 +85,7 @@ for user in $user_list; do
 	if [ "$user" = 'admin' ]; then
 		spnd=$(grep "SUSPENDED='yes'" $HESTIA/data/users/*/user.conf | wc -l)
 		SUSPENDED_USERS=$spnd
-		U_USERS=$($HESTIA/bin/v-list-sys-users plain | wc -l)
+		U_USERS=$($BIN/v-list-sys-users plain | wc -l)
 	fi
 
 	ips=$(ls $HESTIA/data/ips)

--- a/bin/v-update-user-package
+++ b/bin/v-update-user-package
@@ -33,7 +33,7 @@ is_package_valid
 #                       Action                             #
 #----------------------------------------------------------#
 
-for user in $($HESTIA/bin/v-list-sys-users plain); do
+for user in $($BIN/v-list-sys-users plain); do
 	check_package=$(grep "PACKAGE='$package'" $USER_DATA/$user/user.conf)
 	if [ -n "$check_package" ]; then
 		$BIN/v-change-user-package "$user" "$package" 'yes'

--- a/bin/v-update-user-stats
+++ b/bin/v-update-user-stats
@@ -43,7 +43,7 @@ fi
 
 # Creating user_list
 if [ -z "$user" ]; then
-	user_list=$($HESTIA/bin/v-list-sys-users plain)
+	user_list=$($BIN/v-list-sys-users plain)
 	update_overall_stats='yes'
 else
 	user_list="$user"

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -663,7 +663,7 @@ rebuild_mail_domain_conf() {
 
 		# Webamil client
 		if [ "$WEBMAIL" = '' ]; then
-			$HESTIA/bin/v-add-mail-domain-webmail $user $domain 'roundcube' 'no'
+			$BIN/v-add-mail-domain-webmail $user $domain 'roundcube' 'no'
 		fi
 
 		# Adding catchall email

--- a/func/remote.sh
+++ b/func/remote.sh
@@ -81,9 +81,9 @@ send_ssh_cmd() {
 	fi
 
 	if [ "$USER" = 'root' ]; then
-		args="$HESTIA/bin/$1 \"$2\" \"$3\" \"$4\" \"$5\""
+		args="$BIN/$1 \"$2\" \"$3\" \"$4\" \"$5\""
 	else
-		args="sudo $HESTIA/bin/$1 \"$2\" \"$3\" \"$4\" \"$5\""
+		args="sudo $BIN/$1 \"$2\" \"$3\" \"$4\" \"$5\""
 	fi
 	ssh -i $IDENTITY_FILE $USER@$HOST -p $PORT "$args" > /dev/null 2>&1
 	if [ "$?" -ne '0' ]; then

--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -287,7 +287,7 @@ function syshealth_repair_system_config() {
 	if [[ -z $(check_key_exists 'BACKEND_PORT') ]]; then
 		ORIGINAL_PORT=$(cat $HESTIA/nginx/conf/nginx.conf | grep "listen" | sed 's/[^0-9]*//g')
 		echo "[ ! ] Adding missing variable to hestia.conf: BACKEND_PORT ('$ORIGINAL_PORT')"
-		$HESTIA/bin/v-change-sys-config-value 'BACKEND_PORT' $ORIGINAL_PORT
+		$BIN/v-change-sys-config-value 'BACKEND_PORT' $ORIGINAL_PORT
 	fi
 
 	# Upgrade: Send email notification
@@ -509,14 +509,14 @@ function syshealth_repair_system_config() {
 # Repair System Cron Jobs
 # Add default cron jobs to "admin" user account's cron tab
 function syshealth_repair_system_cronjobs() {
-	$HESTIA/bin/v-add-cron-job 'admin' '*/2' '*' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-queue restart" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '10' '00' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-queue daily" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '15' '02' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-queue disk" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '10' '00' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-queue traffic" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '30' '03' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-queue webstats" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '*/5' '*' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-queue backup" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '10' '05' '*' '*' '*' "sudo $HESTIA/bin/v-backup-users" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '20' '00' '*' '*' '*' "sudo $HESTIA/bin/v-update-user-stats" '' 'no'
-	$HESTIA/bin/v-add-cron-job 'admin' '*/5' '*' '*' '*' '*' "sudo $HESTIA/bin/v-update-sys-rrd" '' 'no'
-	$HESTIA/bin/v-restart-cron
+	$BIN/v-add-cron-job 'admin' '*/2' '*' '*' '*' '*' "sudo $BIN/v-update-sys-queue restart" '' 'no'
+	$BIN/v-add-cron-job 'admin' '10' '00' '*' '*' '*' "sudo $BIN/v-update-sys-queue daily" '' 'no'
+	$BIN/v-add-cron-job 'admin' '15' '02' '*' '*' '*' "sudo $BIN/v-update-sys-queue disk" '' 'no'
+	$BIN/v-add-cron-job 'admin' '10' '00' '*' '*' '*' "sudo $BIN/v-update-sys-queue traffic" '' 'no'
+	$BIN/v-add-cron-job 'admin' '30' '03' '*' '*' '*' "sudo $BIN/v-update-sys-queue webstats" '' 'no'
+	$BIN/v-add-cron-job 'admin' '*/5' '*' '*' '*' '*' "sudo $BIN/v-update-sys-queue backup" '' 'no'
+	$BIN/v-add-cron-job 'admin' '10' '05' '*' '*' '*' "sudo $BIN/v-backup-users" '' 'no'
+	$BIN/v-add-cron-job 'admin' '20' '00' '*' '*' '*' "sudo $BIN/v-update-user-stats" '' 'no'
+	$BIN/v-add-cron-job 'admin' '*/5' '*' '*' '*' '*' "sudo $BIN/v-update-sys-rrd" '' 'no'
+	$BIN/v-restart-cron
 }

--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -199,7 +199,7 @@ upgrade_send_notification_to_panel() {
 upgrade_send_notification_to_email() {
 	if [ "$UPGRADE_SEND_EMAIL" = "true" ]; then
 		# Retrieve admin email address, sendmail path, and message temp file path
-		admin_email=$($HESTIA/bin/v-list-user admin json | grep "CONTACT" | cut -d'"' -f4)
+		admin_email=$($BIN/v-list-user admin json | grep "CONTACT" | cut -d'"' -f4)
 		send_mail="$HESTIA/web/inc/mail-wrapper.php"
 		message_tmp_file="/tmp/hestia-upgrade-complete.txt"
 
@@ -603,8 +603,8 @@ upgrade_filemanager() {
 		if [ "$fm_version" != "$fm_v" ]; then
 			echo "[ ! ] Upgrading File Manager to version $fm_v..."
 			# Reinstall the File Manager
-			$HESTIA/bin/v-delete-sys-filemanager quiet yes
-			$HESTIA/bin/v-add-sys-filemanager quiet
+			$BIN/v-delete-sys-filemanager quiet yes
+			$BIN/v-add-sys-filemanager quiet
 		else
 			echo "[ * ] File Manager is up to date ($fm_v)..."
 
@@ -614,7 +614,7 @@ upgrade_filemanager() {
 					# Update configuration.php
 					cp -f $HESTIA_INSTALL_DIR/filemanager/filegator/configuration.php $HESTIA/web/fm/configuration.php
 					# Set environment variable for interface
-					$HESTIA/bin/v-change-sys-config-value 'FILE_MANAGER' 'true'
+					$BIN/v-change-sys-config-value 'FILE_MANAGER' 'true'
 				fi
 			fi
 		fi
@@ -630,7 +630,7 @@ upgrade_roundcube() {
 			rc_version=$(cat /var/lib/roundcube/index.php | grep -o -E '[0-9].[0-9].[0-9]+' | head -1)
 			if [ "$rc_version" != "$rc_v" ]; then
 				echo "[ ! ] Upgrading Roundcube to version $rc_v..."
-				$HESTIA/bin/v-add-sys-roundcube
+				$BIN/v-add-sys-roundcube
 			else
 				echo "[ * ] Roundcube is up to date ($rc_v)..."
 			fi
@@ -643,7 +643,7 @@ upgrade_rainloop() {
 		rl_version=$(cat /var/lib/rainloop/data/VERSION)
 		if [ "$rl_version" != "$rl_v" ]; then
 			echo "[ ! ] Upgrading Rainloop to version $rl_v..."
-			$HESTIA/bin/v-add-sys-rainloop
+			$BIN/v-add-sys-rainloop
 		else
 			echo "[ * ] Rainloop is up to date ($rl_v)..."
 		fi
@@ -652,7 +652,7 @@ upgrade_rainloop() {
 
 upgrade_dependencies() {
 	echo "[ ! ] Update Hesita PHP dependencies"
-	$HESTIA/bin/v-add-sys-dependencies
+	$BIN/v-add-sys-dependencies
 }
 
 upgrade_rebuild_web_templates() {
@@ -683,7 +683,7 @@ upgrade_rebuild_users() {
 		else
 			echo "[ * ] Rebuilding user accounts and domains, this may take a few minutes..."
 		fi
-		for user in $($HESTIA/bin/v-list-sys-users plain); do
+		for user in $($BIN/v-list-sys-users plain); do
 			export restart="no"
 			if [ "$DEBUG_MODE" = "true" ]; then
 				echo "      - $user:"

--- a/install/upgrade/manual/migrate_ngnix_apache_nginx-php-fpm.sh
+++ b/install/upgrade/manual/migrate_ngnix_apache_nginx-php-fpm.sh
@@ -53,11 +53,11 @@ echo "WEB_SYSTEM='nginx'" >> $HESTIA/conf/hestia.conf
 
 # Rebuild web config
 
-for user in $($HESTIA/bin/v-list-users plain | cut -f1); do
+for user in $($BIN/v-list-users plain | cut -f1); do
 	echo $user
-	for domain in $($HESTIA/bin/v-list-web-domains $user plain | cut -f1); do
-		$HESTIA/bin/v-change-web-domain-tpl $user $domain 'default'
-		$HESTIA/bin/v-rebuild-web-domain $user $domain no
+	for domain in $($BIN/v-list-web-domains $user plain | cut -f1); do
+		$BIN/v-change-web-domain-tpl $user $domain 'default'
+		$BIN/v-rebuild-web-domain $user $domain no
 	done
 done
 

--- a/install/upgrade/manual/migrate_phpmyadmin.sh
+++ b/install/upgrade/manual/migrate_phpmyadmin.sh
@@ -28,7 +28,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	sso="no"
 	if [ "$PHPMYADMIN_KEY" != "" ]; then
 		sso="yes"
-		$HESTIA/bin/v-delete-sys-pma-sso
+		$BIN/v-delete-sys-pma-sso
 	fi
 
 	# Create an backup of current config
@@ -95,7 +95,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	if [ -z "$DB_PMA_ALIAS" ]; then
 		echo "DB_PMA_ALIAS='phpmyadmin'" >> $HESTIA/conf/hestia.conf
 	fi
-	$HESTIA/bin/v-change-sys-db-alias 'pma' "phpmyadmin"
+	$BIN/v-change-sys-db-alias 'pma' "phpmyadmin"
 
 	# Special thanks to Pavel Galkin (https://skurudo.ru)
 	# https://github.com/skurudo/phpmyadmin-fixer
@@ -164,6 +164,6 @@ MYSQL_PMA3
 	mysql -uroot < $HESTIA_INSTALL_DIR/phpmyadmin/create_tables.sql
 
 	if [ "$sso" == "yes" ]; then
-		$HESTIA/bin/v-add-sys-pma-sso
+		$BIN/v-add-sys-pma-sso
 	fi
 fi

--- a/install/upgrade/manual/migrate_roundcube.sh
+++ b/install/upgrade/manual/migrate_roundcube.sh
@@ -43,7 +43,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	rm -f -r /var/lib/roundcube/
 
 	# Install Roundcube
-	$HESTIA/bin/v-add-sys-roundcube
+	$BIN/v-add-sys-roundcube
 	# restore backup
 	echo "SET FOREIGN_KEY_CHECKS = 0;" > ~/drop_all_tables.sql
 	(mysqldump --add-drop-table --no-data -u root roundcube | grep 'DROP TABLE') >> ./drop_all_tables.sql

--- a/src/deb/hestia/postinst
+++ b/src/deb/hestia/postinst
@@ -11,10 +11,10 @@ fi
 source /etc/hestiacp/hestia.conf
 
 # Load upgrade functions and variables
-# shellcheck source=/usr/local/hestia/func/upgrade.sh
-source $HESTIA/func/upgrade.sh
 # shellcheck source=/usr/local/hestia/func/main.sh
 source $HESTIA/func/main.sh
+# shellcheck source=/usr/local/hestia/func/upgrade.sh
+source $HESTIA/func/upgrade.sh
 source_conf "$HESTIA/conf/hestia.conf"
 
 ###############################################################

--- a/web/src/app/WebApp/Installers/BaseSetup.php
+++ b/web/src/app/WebApp/Installers/BaseSetup.php
@@ -45,8 +45,10 @@ abstract class BaseSetup implements InstallerInterface {
 				"7.1",
 				"7.2",
 				"7.3",
-				"7.4" . "8.0",
+				"7.4",
+				"8.0",
 				"8.1",
+				"8.2",
 			];
 		}
 		return $this->appInfo;


### PR DESCRIPTION
When including main.sh, Hestia already defines $BIN as $HESTIA/bin but API fails to use it consistently. This breaks normalization and the ability override it (for future plugin development). Currently, /etc/hestiacp/hestia.conf allows customization via local.conf; but there maybe more areas where we might change $BIN. Code should be clean and **consistent**. 