### PR TITLE
Update DKIM length

### DIFF
--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -14,7 +14,7 @@
 user=$1
 domain=$2
 domain_idn=$2
-dkim_size=${3-1024}
+dkim_size=${3-2048}
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf


### PR DESCRIPTION
For years, the standard key length was 1024 bit DKIM keys, but hackers continue to develop new methods to break DKIM keys

https://sendgrid.com/blog/2048-bit-dkim-keys/

Maybe we need to update the tests