### PR TITLE
Fix order of applied patches on upgrade

### DIFF
--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -481,7 +481,7 @@ upgrade_start_routine() {
 	VERSION=$(echo "$VERSION" | sed "s/~\([a-zA-Z0-9].*\)//g")
 
 	# Get list of all available version steps and create array
-	upgrade_steps=$(ls $HESTIA/install/upgrade/versions/*.sh)
+	upgrade_steps=$(ls -v $HESTIA/install/upgrade/versions/*.sh)
 	for script in $upgrade_steps; do
 		declare -a available_versions
 		available_versions+=($(echo $script | sed "s|/usr/local/hestia/install/upgrade/versions/||g" | sed "s|.sh||g"))


### PR DESCRIPTION
When upgrading from older versions, patches are applied in wrong order

Before:
```
root@xxx:/usr/local/hestia# ls -l $HESTIA/install/upgrade/versions/*.sh | grep '1\.6'
-rwxr-xr-x 1 root root  8586 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.0.sh
-rwxr-xr-x 1 root root  1522 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.10.sh
-rwxr-xr-x 1 root root  1824 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.12.sh
-rwxr-xr-x 1 root root  1443 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.13.sh
-rwxr-xr-x 1 root root  1851 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.14.sh
-rwxr-xr-x 1 root root  2937 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.1.sh
-rwxr-xr-x 1 root root  2763 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.2.sh
-rwxr-xr-x 1 root root  1782 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.3.sh
-rwxr-xr-x 1 root root  1440 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.4.sh
-rwxr-xr-x 1 root root  1440 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.5.sh
-rwxr-xr-x 1 root root  1753 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.6.sh
-rwxr-xr-x 1 root root  1870 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.7.sh
-rwxr-xr-x 1 root root  2613 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.8.sh
-rwxr-xr-x 1 root root  1649 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.9.sh
```

After, with natural sort of numbers `ls -v` :
```
root@xxx:/usr/local/hestia# ls -lv $HESTIA/install/upgrade/versions/*.sh | grep '1\.6'
-rwxr-xr-x 1 root root  8586 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.0.sh
-rwxr-xr-x 1 root root  2937 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.1.sh
-rwxr-xr-x 1 root root  2763 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.2.sh
-rwxr-xr-x 1 root root  1782 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.3.sh
-rwxr-xr-x 1 root root  1440 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.4.sh
-rwxr-xr-x 1 root root  1440 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.5.sh
-rwxr-xr-x 1 root root  1753 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.6.sh
-rwxr-xr-x 1 root root  1870 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.7.sh
-rwxr-xr-x 1 root root  2613 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.8.sh
-rwxr-xr-x 1 root root  1649 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.9.sh
-rwxr-xr-x 1 root root  1522 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.10.sh
-rwxr-xr-x 1 root root  1824 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.12.sh
-rwxr-xr-x 1 root root  1443 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.13.sh
-rwxr-xr-x 1 root root  1851 dec 11 13:19 /usr/local/hestia/install/upgrade/versions/1.6.14.sh
```