### PR TITLE
Rename zone to hestia-zone

### DIFF
--- a/bin/v-add-remote-dns-domain
+++ b/bin/v-add-remote-dns-domain
@@ -55,7 +55,7 @@ if [ -z "$str" ]; then
 	fi
 	exit
 fi
-if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 	str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 	str=$(echo "$str" | sed "s/SLAVE=''/SLAVE='yes'/g")
 	ip=$($BIN/v-list-sys-ips plain | cut -f1 | head -n1)
@@ -73,7 +73,7 @@ for cluster in $(grep "SUSPENDED='no'" $HESTIA/conf/dns-cluster.conf); do
 	# Parsing domain parameters
 	parse_object_kv_list "$str"
 
-	if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+	if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 		# Syncing domain data
 		cluster_cmd v-insert-dns-domain $DNS_USER "$str" $HOSTNAME $flush 'no'
 		check_result $? "$HOST connection failed" "$E_CONNECT"
@@ -101,7 +101,7 @@ for cluster in $(grep "SUSPENDED='no'" $HESTIA/conf/dns-cluster.conf); do
 	fi
 done
 
-if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 	rndc notify $domain > /dev/null 2>&1
 fi
 #----------------------------------------------------------#

--- a/bin/v-add-remote-dns-record
+++ b/bin/v-add-remote-dns-record
@@ -54,9 +54,9 @@ if [ -z "$str" ]; then
 	fi
 	exit
 fi
-# $DNS_CLUSTER_SYSTEM = "zone" doesn't need to be uopdated
+# $DNS_CLUSTER_SYSTEM = "hestia-zone" doesn't need to be uopdated
 
-if [ "$DNS_CLUSTER_SYSTEM" != "zone" ]; then
+if [ "$DNS_CLUSTER_SYSTEM" != "hestia-zone" ]; then
 	IFS=$'\n'
 	for cluster in $(grep "SUSPENDED='no'" $HESTIA/conf/dns-cluster.conf); do
 

--- a/bin/v-change-remote-dns-domain-exp
+++ b/bin/v-change-remote-dns-domain-exp
@@ -52,7 +52,7 @@ for cluster in $(grep "SUSPENDED='no'" $HESTIA/conf/dns-cluster.conf); do
 
 	# Syncing domain
 	str=$(grep "DOMAIN='$domain'" $USER_DATA/dns.conf)
-	if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+	if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 		str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 		ip=$($BIN/v-list-sys-ips plain | cut -f1)
 		str=$(echo "$str" | sed "s/MASTER='*'/MASTER='$ip'/g")

--- a/bin/v-change-remote-dns-domain-soa
+++ b/bin/v-change-remote-dns-domain-soa
@@ -52,7 +52,7 @@ for cluster in $(grep "SUSPENDED='no'" $HESTIA/conf/dns-cluster.conf); do
 	# Parsing remote host parameters
 	parse_object_kv_list "$cluster"
 
-	if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+	if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 		str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 		ip=$($BIN/v-list-sys-ips plain | cut -f1)
 		str=$(echo "$str" | sed "s/MASTER='*'/MASTER='$ip'/g")

--- a/bin/v-change-remote-dns-domain-ttl
+++ b/bin/v-change-remote-dns-domain-ttl
@@ -54,7 +54,7 @@ for cluster in $(grep "SUSPENDED='no'" $HESTIA/conf/dns-cluster.conf); do
 
 	# Syncing TTL
 	str=$(grep "DOMAIN='$domain'" $USER_DATA/dns.conf)
-	if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+	if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 		str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 		ip=$($BIN/v-list-sys-ips plain | cut -f1)
 		str=$(echo "$str" | sed "s/MASTER='*'/MASTER='$ip'/g")

--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -19,6 +19,7 @@ restart=$2
 source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
 source $HESTIA/func/main.sh
+source_conf "$HESTIA/conf/hestia.conf"
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -77,7 +78,7 @@ for service in $service_list; do
 		"$service" = "proftpd" -o \
 		"$service" = "ssh" -o \
 		"$service" = "fail2ban" ]; then
-		systemctl reload-or-restart "$service" > /dev/null 2>&1
+		systemctl reload-or-restart "$service" >> $log 2>&1
 	else
 		systemctl reset-failed "$service" >> $log 2>&1
 		systemctl restart "$service" >> $log 2>&1

--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -68,7 +68,7 @@ for cluster in $hosts; do
 				unset $SLAVE
 				parse_object_kv_list "$str"
 				if [ "$SLAVE" != "yes" ]; then
-					if [ "$DNS_CLUSTER_SYSTEM" != "zone" ]; then
+					if [ "$DNS_CLUSTER_SYSTEM" != "hestia-zone" ]; then
 						# Syncing domain index
 
 						cluster_cmd v-insert-dns-domain "$DNS_USER" "$str" "$HOSTNAME" ' ' "no"
@@ -82,7 +82,7 @@ for cluster in $hosts; do
 						cluster_cmd v-insert-dns-records "$DNS_USER" "$DOMAIN" "$tmp_file" 'no'
 						check_result $? "$HOST connection failed" "$E_CONNECT"
 					fi
-					if [ "$DNS_CLUSTER_SYSTEM" = "zone" ]; then
+					if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 						str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 						str=$(echo "$str" | sed "s/SLAVE=''/SLAVE='yes'/g")
 
@@ -100,7 +100,7 @@ for cluster in $hosts; do
 			done
 		fi
 	done
-	if [ "$DNS_CLUSTER_SYSTEM" != "zone" ]; then
+	if [ "$DNS_CLUSTER_SYSTEM" != "hestia-zone" ]; then
 		# Rebuilding dns zones
 		cluster_cmd v-rebuild-dns-domains "$DNS_USER"
 		check_result $? "$TYPE connection to $HOST failed" "$E_CONNECT"

--- a/docs/docs/server-administration/dns.md
+++ b/docs/docs/server-administration/dns.md
@@ -48,7 +48,7 @@ There is no limitation on how to chain DNS servers.
 ### DNS Cluster with the Hestia API (Master -> Slave)
 
 1. Create a new user on the Hestia server that will act as a “Slave”.
-2. In `/usr/local/hestia/conf/hestia.conf`, change `DNS_CLUSTER_SYSTEM='hestia'` to `DNS_CLUSTER_SYSTEM='zone'`.
+2. In `/usr/local/hestia/conf/hestia.conf`, change `DNS_CLUSTER_SYSTEM='hestia'` to `DNS_CLUSTER_SYSTEM='hestia-zone'`.
 3. On the master server, open `/etc/bind/named.options`, do the following changes, then restart bind9 with `systemctl restart bind9`.
 
    ```bash
@@ -87,7 +87,7 @@ There is no limitation on how to chain DNS servers.
 
 ### Converting an existing DNS cluster to Master -> Slave
 
-1. In `/usr/local/hestia/conf/hestia.conf`, change `DNS_CLUSTER_SYSTEM='hestia'` to `DNS_CLUSTER_SYSTEM='zone'`.
+1. In `/usr/local/hestia/conf/hestia.conf`, change `DNS_CLUSTER_SYSTEM='hestia'` to `DNS_CLUSTER_SYSTEM='hestia-zone'`.
 2. On the master server, open `/etc/bind/named.options`, do the following changes, then restart bind9 with `systemctl restart bind9`.
 
    ```bash


### PR DESCRIPTION
Allow "zone" to be used for "full" implementation of Zone transfer without the need of "Hestia API"