### PR TITLE
PHP8.2 fixes, fix dynamic property creation

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
+++ b/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
@@ -10,6 +10,7 @@ use Filegator\Services\Tmpfs\TmpfsInterface;
 use function Hestiacp\quoteshellarg\quoteshellarg;
 
 class HestiaZipArchiver extends ZipArchiver implements Service, ArchiverInterface {
+	public TmpfsInterface $tmpfs;
 	protected $container;
 
 	public function __construct(TmpfsInterface $tmpfs, Container $container) {

--- a/install/deb/phpmyadmin/hestia-sso.php
+++ b/install/deb/phpmyadmin/hestia-sso.php
@@ -10,6 +10,13 @@ define("API_HESTIA_PORT", "%API_HESTIA_PORT%");
 define("API_KEY", "%API_KEY%");
 
 class Hestia_API {
+	/** @var string */
+	public $hostname;
+	/** @var string */
+	public $key;
+	/** @var string */
+	public $pma_key;
+	/** @var string */
 	private $api_url;
 	public function __construct() {
 		$this->hostname = "https://" . API_HOST_NAME . ":" . API_HESTIA_PORT . "/api/";

--- a/web/src/app/System/HestiaApp.php
+++ b/web/src/app/System/HestiaApp.php
@@ -6,6 +6,8 @@ namespace Hestia\System;
 use function Hestiacp\quoteshellarg\quoteshellarg;
 
 class HestiaApp {
+	/** @var string[] */
+	public $errors;
 	protected const TMPDIR_DOWNLOADS = "/tmp/hestia-webapp";
 	protected $phpsupport = false;
 

--- a/web/src/app/WebApp/Installers/BaseSetup.php
+++ b/web/src/app/WebApp/Installers/BaseSetup.php
@@ -11,6 +11,8 @@ use Hestia\WebApp\Installers\Resources\ComposerResource;
 use Hestia\WebApp\Installers\Resources\WpResource;
 
 abstract class BaseSetup implements InstallerInterface {
+	public $appInfo;
+	public $config;
 	protected $domain;
 	protected $extractsubdir;
 	protected $AppDirInstall;


### PR DESCRIPTION
as of PHP8.2, dynamic property creation is no longer allowed by default (with the exception of StdClass), and triggers E_DEPRECATED, ref https://wiki.php.net/rfc/deprecate_dynamic_properties

violations were detected with PHP-Rector using CompleteDynamicPropertiesRector ( https://github.com/rectorphp/rector/blob/main/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php )