### PR TITLE
Correct representation of IP addresses in plain and csv mode

### DIFF
--- a/bin/v-list-sys-ip
+++ b/bin/v-list-sys-ip
@@ -59,7 +59,7 @@ shell_list() {
 
 # PLAIN list function
 plain_list() {
-	echo -ne "$IP\t$OWNER\t$STATUS\t$NAME\t$U_SYS_USERS\t$U_WEB_DOMAINS\t"
+	echo -ne "$ip\t$OWNER\t$STATUS\t$NAME\t$U_SYS_USERS\t$U_WEB_DOMAINS\t"
 	echo -e "$INTERFACE\t$NETMASK\t$NAT\t$TIME\t$DATE"
 }
 
@@ -67,7 +67,7 @@ plain_list() {
 csv_list() {
 	echo -n "IP,OWNER,STATUS,NAME,U_SYS_USERS,U_WEB_DOMAINS,INTERFACE"
 	echo "NETMASK,NAT,TIME,DATE"
-	echo -n "$IP,$OWNER,$STATUS,$NAME,\"$U_SYS_USERS\",$U_WEB_DOMAINS,"
+	echo -n "$ip,$OWNER,$STATUS,$NAME,\"$U_SYS_USERS\",$U_WEB_DOMAINS,"
 	echo "$INTERFACE, $NETMASK,$NAT,$TIME,$DATE"
 }
 

--- a/func/main.sh
+++ b/func/main.sh
@@ -742,7 +742,7 @@ is_ip_format_valid() {
 
 # IPv6 format validator
 is_ipv6_format_valid() {
-	object_name=${2-ip6}
+	object_name=${2-ipv6}
 	ip_regex='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
 	t_ip=$(echo $1 | awk -F / '{print $1}')
 	t_cidr=$(echo $1 | awk -F / '{print $2}')


### PR DESCRIPTION
Shell script "bin/v-list-sys-ip" shows parameters of configured IP addresses from "data/ips". For options "plain" and "csv" (which are not used by hestia actually) IP address could not be represented correctly due to wron variable $IP (capital letters). Correct name of this variable is $ip (small letters).