### PR TITLE
Add Not Yet option to feature request template sponsoring dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -20,6 +20,7 @@ body:
       label: Would you like to sponsor this feature to have it implemented?
       description: While there is no obligation, our development team has a limited number of resources and time available and a financial contribution would help prioritize your request.
       options:
+        - "Not Yet"
         - "Yes"
         - "No"
     validations:


### PR DESCRIPTION
Just a suggestion - oftentimes I do not have a definite Yes or No - because I might consider sponsoring at a later stage.
And I am not sure if it is so good to have Yes as default, either.