### PR TITLE
Add IPV4 regex to func/ip.sh for best robustness against wrong and IPV6 addresses

### DIFF
--- a/func/ip.sh
+++ b/func/ip.sh
@@ -6,6 +6,9 @@
 #                                                                           #
 #===========================================================================#
 
+# Global definitions
+REGEX_IPV4="^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}$"
+
 # Check ip ownership
 is_ip_owner() {
 	owner=$(grep 'OWNER=' $HESTIA/data/ips/$ip | cut -f 2 -d \')
@@ -224,9 +227,9 @@ get_broadcast() {
 # Get user ips
 get_user_ips() {
 	dedicated=$(grep -H "OWNER='$user'" $HESTIA/data/ips/*)
-	dedicated=$(echo "$dedicated" | cut -f 1 -d : | sed 's=.*/==')
+	dedicated=$(echo "$dedicated" | cut -f 1 -d : | sed 's=.*/==' | grep -E ${REGEX_IPV4})
 	shared=$(grep -H -A1 "OWNER='admin'" $HESTIA/data/ips/* | grep shared)
-	shared=$(echo "$shared" | cut -f 1 -d : | sed 's=.*/==' | cut -f 1 -d \-)
+	shared=$(echo "$shared" | cut -f 1 -d : | sed 's=.*/==' | cut -f 1 -d \- | grep -E ${REGEX_IPV4})
 	for dedicated_ip in $dedicated; do
 		shared=$(echo "$shared" | grep -v $dedicated_ip)
 	done


### PR DESCRIPTION
For my tests with new developed IPV6 features I created a couple of IPV6 addresses under hestia. Thereby "data/ips" contains now at my test system also names based on IPV6 addresses. In generally no linux file system nor hestia have issues with this new files, but a couple of functions in include files (for example func/ip.sh, func/main.sh) can not correct handle files in new IPV6 format or generally can have issues with each file under "data/ips", which does not have IPV4 format. As result I had for example in my test case a wrong nginx configuration with denial of start nginx.
The simplest method against this behaviour is to define a IPV4 specific regex in these include files and check/filter found IP addresses with the help of this regex.
This PullReguest defines a global regex for IPV4 addresses at the beginning of "func/ip.sh", so that it can be used in each function inside of this file or in other scripts, that includes ip.sh. Furthermore filtering based on this regex is implemented in the function get_user_ips(), which was resposible for issues in my test case.