### PR TITLE
Add google public dns as secondary resolver

### DIFF
--- a/install/deb/nginx/nginx.conf
+++ b/install/deb/nginx/nginx.conf
@@ -112,7 +112,7 @@ http {
 	ssl_dhparam                     /etc/ssl/dhparam.pem;
 	ssl_ecdh_curve                  secp384r1;
 	ssl_session_tickets             off;
-	resolver                        1.0.0.1 1.1.1.1 valid=300s ipv6=off;
+	resolver                        1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout                5s;
 	# Error pages
 	error_page                      403 /error/404.html;

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1336,8 +1336,8 @@ for ip in $dns_resolver; do
 	fi
 done
 if [ -n "$resolver" ]; then
-	sed -i "s/1.0.0.1 1.1.1.1/$resolver/g" /etc/nginx/nginx.conf
-	sed -i "s/1.0.0.1 1.1.1.1/$resolver/g" /usr/local/hestia/nginx/conf/nginx.conf
+	sed -i "s/1.1.1.1 8.8.8.8/$resolver/g" /etc/nginx/nginx.conf
+	sed -i "s/1.1.1.1 8.8.8.8/$resolver/g" /usr/local/hestia/nginx/conf/nginx.conf
 fi
 
 update-rc.d nginx defaults > /dev/null 2>&1

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1386,8 +1386,8 @@ for ip in $dns_resolver; do
 	fi
 done
 if [ -n "$resolver" ]; then
-	sed -i "s/1.0.0.1 1.1.1.1/$resolver/g" /etc/nginx/nginx.conf
-	sed -i "s/1.0.0.1 1.1.1.1/$resolver/g" /usr/local/hestia/nginx/conf/nginx.conf
+	sed -i "s/1.1.1.1 8.8.8.8/$resolver/g" /etc/nginx/nginx.conf
+	sed -i "s/1.1.1.1 8.8.8.8/$resolver/g" /usr/local/hestia/nginx/conf/nginx.conf
 fi
 
 update-rc.d nginx defaults > /dev/null 2>&1

--- a/install/rpm/nginx/nginx.conf
+++ b/install/rpm/nginx/nginx.conf
@@ -107,7 +107,7 @@ http {
 	ssl_dhparam                   /etc/ssl/dhparam.pem;
 	ssl_ecdh_curve                secp384r1;
 	ssl_session_tickets           off;
-	resolver                      1.0.0.1 1.1.1.1 valid=300s ipv6=off;
+	resolver                      1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout              5s;
 	# Error pages
 	error_page                    403 /error/404.html;

--- a/src/deb/nginx/nginx.conf
+++ b/src/deb/nginx/nginx.conf
@@ -82,7 +82,7 @@ http {
 	ssl_ecdh_curve                secp384r1;
 	# ssl_reject_handshake on;
 	ssl_session_tickets           off;
-	resolver                      1.0.0.1 1.1.1.1 valid=300s ipv6=off;
+	resolver                      1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout              5s;
 	ssl_stapling                  on;
 	ssl_stapling_verify           on;

--- a/src/rpm/nginx/nginx.conf
+++ b/src/rpm/nginx/nginx.conf
@@ -81,7 +81,7 @@ http {
 	ssl_dhparam                   /etc/ssl/dhparam.pem;
 	ssl_ecdh_curve                secp384r1;
 	ssl_session_tickets           off;
-	resolver                      1.0.0.1 1.1.1.1 valid=300s ipv6=off;
+	resolver                      1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout              5s;
 	ssl_stapling                  on;
 	ssl_stapling_verify           on;


### PR DESCRIPTION
I think it could be a good idea to not entirely rely on Cloudflare and add Google as a secondary resolver for failover.