### PR TITLE
Fix bulk edit not working and add loader

### DIFF
--- a/web/js/init.js
+++ b/web/js/init.js
@@ -1,8 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-	// Refactored
-	document.querySelector('#vstobjects')?.addEventListener('submit', () => {
+	function showLoader() {
 		document.querySelector('.fullscreen-loader').classList.add('show');
-	});
+	}
+	document.querySelector('#vstobjects')?.addEventListener('submit', showLoader);
+	document.querySelector('[x-bind="BulkEdit"]')?.addEventListener('submit', showLoader);
 
 	document.querySelectorAll('.toolbar-right .sort-by')?.forEach((el) => {
 		el.addEventListener('click', () => $('.context-menu.sort-order').toggle());

--- a/web/templates/pages/list_access_keys.php
+++ b/web/templates/pages/list_access_keys.php
@@ -15,7 +15,7 @@
 					<li entity="sort-key"><span class="name"><?= _("Access Key") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 					<li entity="sort-comment"><span class="name"><?= _("Comment") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
-				<form x-bind="BulkEdit" action="/bulk/access-key/" method="post">
+				<form x-data x-bind="BulkEdit" action="/bulk/access-key/" method="post">
 					<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 					<select class="form-select" name="action">
 						<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_backup.php
+++ b/web/templates/pages/list_backup.php
@@ -9,7 +9,7 @@
 		</div>
 		<div class="toolbar-right">
 			<?php if ($read_only !== "true") { ?>
-				<form x-bind="BulkEdit" action="/bulk/backup/" method="post">
+				<form x-data x-bind="BulkEdit" action="/bulk/backup/" method="post">
 					<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 					<select class="form-select" name="action">
 						<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_backup_detail.php
+++ b/web/templates/pages/list_backup_detail.php
@@ -6,7 +6,7 @@
 			<a href="/schedule/restore/?token=<?= $_SESSION["token"] ?>&backup=<?= htmlentities($_GET["backup"]) ?>" class="button button-secondary"><i class="fas fa-arrow-rotate-left icon-green"></i><?= _("Restore All") ?></a>
 		</div>
 		<div class="toolbar-right">
-			<form x-bind="BulkEdit" action="/bulk/restore/" method="post">
+			<form x-data x-bind="BulkEdit" action="/bulk/restore/" method="post">
 				<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 				<input type="hidden" name="backup" value="<?= htmlentities($_GET["backup"]) ?>">
 				<select class="form-select" name="action">

--- a/web/templates/pages/list_cron.php
+++ b/web/templates/pages/list_cron.php
@@ -25,7 +25,7 @@
 					<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?= _("Date") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== 'true') {?>
-					<form x-bind="BulkEdit" action="/bulk/cron/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/cron/" method="post">
 						<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 						<select class="form-select" name="action">
 							<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_db.php
+++ b/web/templates/pages/list_db.php
@@ -54,7 +54,7 @@ if (!empty($_SESSION["DB_PGA_ALIAS"])) {
 					<li entity="sort-user"><span class="name"><?= _("Username") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== 'true') {?>
-					<form x-bind="BulkEdit" action="/bulk/db/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/db/" method="post">
 						<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 						<select class="form-select" name="action">
 							<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_dns.php
+++ b/web/templates/pages/list_dns.php
@@ -23,7 +23,7 @@
 					<li entity="sort-records"><span class="name"><?= _("Records") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== 'true') {?>
-					<form x-bind="BulkEdit" action="/bulk/dns/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/dns/" method="post">
 						<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 						<select class="form-select" name="action">
 							<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_dns_public.php
+++ b/web/templates/pages/list_dns_public.php
@@ -25,7 +25,7 @@
 					<li entity="sort-records"><span class="name"><?= _("Records") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== 'true') {?>
-					<form x-bind="BulkEdit" action="/bulk/dns/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/dns/" method="post">
 						<input type="hidden" name="token" value="<?=$_SESSION['token']?>" />
 						<select class="form-select" name="action">
 							<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_dns_rec.php
+++ b/web/templates/pages/list_dns_rec.php
@@ -25,7 +25,7 @@
 					<li entity="sort-type"><span class="name"><?= _("Type") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== 'true') {?>
-					<form x-bind="BulkEdit" action="/bulk/dns/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/dns/" method="post">
 						<input type="hidden" name="domain" value="<?=htmlentities($_GET['domain'])?>">
 						<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 						<select class="form-select" name="action">

--- a/web/templates/pages/list_firewall.php
+++ b/web/templates/pages/list_firewall.php
@@ -21,7 +21,7 @@
 					<li entity="sort-ip" sort_as_int="1"><span class="name"><?= _("IP address") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 					<li entity="sort-comment"><span class="name"><?= _("Comment") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
-				<form x-bind="BulkEdit" action="/bulk/firewall/" method="post">
+				<form x-data x-bind="BulkEdit" action="/bulk/firewall/" method="post">
 					<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 					<select class="form-select" name="action">
 						<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_firewall_banlist.php
+++ b/web/templates/pages/list_firewall_banlist.php
@@ -6,7 +6,7 @@
 			<a href="/add/firewall/banlist/" class="button button-secondary" id="btn-create"><i class="fas fa-circle-plus icon-green"></i><?= _("Ban IP Address") ?></a>
 		</div>
 		<div class="toolbar-right">
-			<form x-bind="BulkEdit" action="/bulk/firewall/banlist/" method="post">
+			<form x-data x-bind="BulkEdit" action="/bulk/firewall/banlist/" method="post">
 				<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 				<select class="form-select" name="action">
 					<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_firewall_ipset.php
+++ b/web/templates/pages/list_firewall_ipset.php
@@ -6,7 +6,7 @@
 			<a href="/add/firewall/ipset/" class="button button-secondary" id="btn-create"><i class="fas fa-circle-plus icon-green"></i><?= _("Add IP list") ?></a>
 		</div>
 		<div class="toolbar-right">
-			<form x-bind="BulkEdit" action="/bulk/firewall/ipset/" method="post">
+			<form x-data x-bind="BulkEdit" action="/bulk/firewall/ipset/" method="post">
 				<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 				<select class="form-select" name="action">
 					<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_ip.php
+++ b/web/templates/pages/list_ip.php
@@ -18,7 +18,7 @@
 					<li entity="sort-domains" sort_as_int="1"><span class="name"><?= _("Domains") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 					<li entity="sort-owner"><span class="name"><?= _("Owner") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
-				<form x-bind="BulkEdit" action="/bulk/ip/" method="post">
+				<form x-data x-bind="BulkEdit" action="/bulk/ip/" method="post">
 					<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 					<select class="form-select" name="action">
 						<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_mail.php
+++ b/web/templates/pages/list_mail.php
@@ -22,7 +22,7 @@
 					<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?= _("Name") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== 'true') {?>
-					<form x-bind="BulkEdit" action="/bulk/mail/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/mail/" method="post">
 						<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 						<select class="form-select" name="action">
 							<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_mail_acc.php
+++ b/web/templates/pages/list_mail_acc.php
@@ -30,7 +30,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 					<li entity="sort-quota" sort_as_int="1"><span class="name"><?= _("Quota") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== "true") { ?>
-					<form x-bind="BulkEdit" action="/bulk/mail/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/mail/" method="post">
 						<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 						<input type="hidden" value="<?= htmlspecialchars($_GET["domain"]) ?>" name="domain">
 						<select class="form-select" name="action">

--- a/web/templates/pages/list_packages.php
+++ b/web/templates/pages/list_packages.php
@@ -67,7 +67,7 @@
 			sort-bandwidth="<?=$data[$key]['BANDWIDTH']?>" sort-disk="<?=$data[$key]['DISK_QUOTA']?>">
 			<div class="l-unit__col l-unit__col--right">
 				<div class="clearfix l-unit__stat-col--left super-compact">
-					<input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?= _("Select") ?>" name="user[]" value="<?=$key?>">
+					<input id="check<?=$i?>" class="ch-toggle" type="checkbox" title="<?= _("Select") ?>" name="package[]" value="<?=$key?>">
 				</div>
 				<?php if ($key == 'system'){ ?>
 					<div class="clearfix l-unit__stat-col--left wide-2 truncate"><b><?=$key?></b></div>

--- a/web/templates/pages/list_packages.php
+++ b/web/templates/pages/list_packages.php
@@ -18,7 +18,7 @@
 					<li entity="sort-date" sort_as_int="1"><span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?= _("Date") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 					<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?= _("Name") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
-				<form x-bind="BulkEdit" action="/bulk/package/" method="post">
+				<form x-data x-bind="BulkEdit" action="/bulk/package/" method="post">
 					<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 					<select class="form-select" name="action">
 						<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_services.php
+++ b/web/templates/pages/list_services.php
@@ -30,7 +30,7 @@
 			</div>
 		</div>
 		<div class="toolbar-right">
-			<form x-bind="BulkEdit" action="/bulk/service/" method="post">
+			<form x-data x-bind="BulkEdit" action="/bulk/service/" method="post">
 				<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 				<select class="form-select" name="action">
 					<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_stats.php
+++ b/web/templates/pages/list_stats.php
@@ -8,7 +8,7 @@
 		</div>
 		<div class="toolbar-right">
 			<?php if ($_SESSION["userContext"] === "admin" && !isset($_SESSION["look"])) { ?>
-				<form x-bind="BulkEdit" action="/list/stats/" method="get">
+				<form x-data x-bind="BulkEdit" action="/list/stats/" method="get">
 					<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 					<select class="form-select" name="user">
 						<option value=""><?= _("show per user") ?></option>

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -20,7 +20,7 @@
 					<li entity="sort-disk" sort_as_int="1"><span class="name"><?= _("Disk") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 					<li entity="sort-name"><span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?= _("Name") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
-				<form x-bind="BulkEdit" action="/bulk/user/" method="post">
+				<form x-data x-bind="BulkEdit" action="/bulk/user/" method="post">
 					<input type="hidden" name="token" value="<?=$_SESSION['token']?>">
 					<select class="form-select" name="action">
 						<option value=""><?= _("apply to selected") ?></option>

--- a/web/templates/pages/list_web.php
+++ b/web/templates/pages/list_web.php
@@ -25,7 +25,7 @@
 					<li entity="sort-ip" sort_as_int="1"><span class="name"><?= _("IP address") ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span></li>
 				</ul>
 				<?php if ($read_only !== "true") { ?>
-					<form x-bind="BulkEdit" action="/bulk/web/" method="post">
+					<form x-data x-bind="BulkEdit" action="/bulk/web/" method="post">
 						<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 						<select class="form-select" name="action">
 							<option value=""><?= _("apply to selected") ?></option>


### PR DESCRIPTION
The bulk edit feature wasn't working anywhere, since I forgot to add `x-data` to it. This serves as a note to everyone using Alpine who missed the most important part of the doc: **Any element using Alpine needs to have an `x-data` attribute or be inside of an element that has one**. In this case, the bulk edit forms had a `x-bind` attribute, to help reuse the same function for each one, but didn't have `x-data`, so Alpine ignored it.

I also made sure the forms trigger the loader, so that it's clearer that it loads :)