### PR TITLE
Bump hestia-nginx

### DIFF
--- a/src/deb/nginx/control
+++ b/src/deb/nginx/control
@@ -1,7 +1,7 @@
 Source: hestia-nginx
 Package: hestia-nginx
 Priority: optional
-Version: 1.23.3
+Version: 1.23.3-1
 Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com


### PR DESCRIPTION
Allow updates to openssl  it should not matter for apt.hestiacp.com but for beta version1.23.3 has been pushed allready
