### PR TITLE
Fix: #3323 Web domain redirect with IDN2

### DIFF
--- a/bin/v-add-web-domain-redirect
+++ b/bin/v-add-web-domain-redirect
@@ -42,18 +42,22 @@ is_object_unsuspended 'user' 'USER' "$user"
 is_object_valid 'web' 'DOMAIN' "$domain"
 is_object_unsuspended 'web' 'DOMAIN' "$domain"
 
-idn_redirect=$(idn2 --quiet $3)
-if [ $? == 0 ]; then
-	redirect=$idn_redirect
-fi
-
 if [[ "$3" =~ http://|https:// ]]; then
-	scheme=1
+	scheme_check=1
+	scheme=$($HESTIA_PHP -r '$url=parse_url($argv[1]); echo $url["scheme"];' "$redirect")
+	host=$($HESTIA_PHP -r '$url=parse_url($argv[1]); echo $url["host"];' "$redirect")
+	path=$($HESTIA_PHP -r '$url=parse_url($argv[1]); if(!empty($url["path"])){echo $url["path"];}' "$redirect")
+	host=$(idn2 --quiet $host)
+	redirect="$scheme://$host$path"
 	isValidUrl=$(php -r '$url=$argv[1]; $url=filter_var($url,FILTER_VALIDATE_URL); echo $url;' "$redirect")
 	if [ -z "$isValidUrl" ]; then
 		check_result $E_INVALID "Invalid redirect"
 	fi
 else
+	host=$($HESTIA_PHP -r '$url=parse_url($argv[1]); echo $url["host"];' "http://$redirect")
+	path=$($HESTIA_PHP -r '$url=parse_url($argv[1]); if(!empty($url["path"])){echo $url["path"];}' "http://$redirect")
+	host=$(idn2 --quiet $host)
+	redirect="$host$path"
 	isValidUrl=$(php -r '$url=$argv[1]; $url=filter_var($url,FILTER_VALIDATE_URL); echo $url;' "http://$redirect")
 	if [ -z "$isValidUrl" ]; then
 		check_result $E_INVALID "Invalid redirect"
@@ -72,9 +76,10 @@ if [ "$WEB_SYSTEM" = 'nginx' ] || [ "$PROXY_SYSTEM" = 'nginx' ]; then
 	conf="$HOMEDIR/$user/conf/web/$domain/nginx.conf_redirect"
 	sconf="$HOMEDIR/$user/conf/web/$domain/nginx.ssl.conf_redirect"
 fi
+
 # Insert redirect commands
 if [ -n "$PROXY_SYSTEM" ] || [ "$WEB_SYSTEM" = 'nginx' ]; then
-	if [ "$scheme" = 1 ]; then
+	if [ "$scheme_check" = 1 ]; then
 		echo "   return $code $redirect\$request_uri;" > $conf
 		if [ ! -e "$sconf" ]; then
 			ln -s "$conf" "$sconf"

--- a/bin/v-add-web-domain-redirect
+++ b/bin/v-add-web-domain-redirect
@@ -47,7 +47,7 @@ if [[ "$3" =~ http://|https:// ]]; then
 	scheme=$($HESTIA_PHP -r '$url=parse_url($argv[1]); echo $url["scheme"];' "$redirect")
 	host=$($HESTIA_PHP -r '$url=parse_url($argv[1]); echo $url["host"];' "$redirect")
 	path=$($HESTIA_PHP -r '$url=parse_url($argv[1]); if(!empty($url["path"])){echo $url["path"];}' "$redirect")
-	host=$(idn2 --quiet $host)
+	host=$(idn2 --quiet "$host")
 	redirect="$scheme://$host$path"
 	isValidUrl=$(php -r '$url=$argv[1]; $url=filter_var($url,FILTER_VALIDATE_URL); echo $url;' "$redirect")
 	if [ -z "$isValidUrl" ]; then
@@ -56,7 +56,7 @@ if [[ "$3" =~ http://|https:// ]]; then
 else
 	host=$($HESTIA_PHP -r '$url=parse_url($argv[1]); echo $url["host"];' "http://$redirect")
 	path=$($HESTIA_PHP -r '$url=parse_url($argv[1]); if(!empty($url["path"])){echo $url["path"];}' "http://$redirect")
-	host=$(idn2 --quiet $host)
+	host=$(idn2 --quiet "$host")
 	redirect="$host$path"
 	isValidUrl=$(php -r '$url=$argv[1]; $url=filter_var($url,FILTER_VALIDATE_URL); echo $url;' "http://$redirect")
 	if [ -z "$isValidUrl" ]; then

--- a/func/main.sh
+++ b/func/main.sh
@@ -17,6 +17,7 @@ BIN=$HESTIA/bin
 HESTIA_INSTALL_DIR="$HESTIA/install/deb"
 HESTIA_COMMON_DIR="$HESTIA/install/common"
 HESTIA_BACKUP="/root/hst_backups/$(date +%d%m%Y%H%M)"
+HESTIA_PHP="$HESTIA/php/bin/php"
 USER_DATA=$HESTIA/data/users/$user
 WEBTPL=$HESTIA/data/templates/web
 MAILTPL=$HESTIA/data/templates/mail


### PR DESCRIPTION
Bug was caused by `idn2 --quiet $3` that rewrites idn domain to their puny code equivalent version.
Causing paths to get rewriten to lowercase. To prevent this issue we split now:
$scheme $host and $path and only convert the $host one and keep the reset untouched.
