### PR TITLE
Load alpine last (because of alpine:init)

### DIFF
--- a/web/templates/includes/js.php
+++ b/web/templates/includes/js.php
@@ -1,11 +1,11 @@
 <script defer src="/js/main.js?<?= JS_LATEST_UPDATE ?>"></script>
-<script defer src="/js/vendor/alpine-3.10.5.min.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script defer src="/js/vendor/jquery-3.6.3.min.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script defer src="/js/vendor/jquery-ui.min.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script defer src="/js/vendor/chart.min.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script defer src="/js/shortcuts.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script defer src="/js/events.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script defer src="/js/init.js?<?= JS_LATEST_UPDATE ?>"></script>
+<script defer src="/js/vendor/alpine-3.10.5.min.js?<?= JS_LATEST_UPDATE ?>"></script>
 <script>
 	// TODO: REMOVE
 	const App = {


### PR DESCRIPTION
The `alpine:init` event fires once Alpine is loaded, so if a script loads after Alpine and uses this event, it will never work. This broke the shortcuts. These need to load after jQuery, but before Alpine.