### PR TITLE
Update LXD  build script

### DIFF
--- a/src/lxd_build_all.sh
+++ b/src/lxd_build_all.sh
@@ -13,7 +13,7 @@
 #
 
 # Configs:
-oslist=('debian=9,10' 'ubuntu=18.04,20.04')
+oslist=('debian=10,11' 'ubuntu=18.04,20.04,22.04')
 branch='main'
 
 function setup_container() {

--- a/src/lxd_build_all.sh
+++ b/src/lxd_build_all.sh
@@ -43,8 +43,10 @@ if [ -z "$user" ] || [ -z "$user_id" ] || [ -z "$user_gid" ] || [ "$user" = 'roo
 	echo "Script must be run with sudo, not directly as root" && exit 1
 fi
 
-if ! dpkg-query -s lxd > /dev/null 2>&1; then
-	apt -y install lxd
+if ! which lxd > /dev/null 2>&1; then
+	# Use snapd instead
+	apt -y install snapd
+	snap install lxd
 	lxd init --auto
 
 	echo "root:$user_id:1" | sudo tee -a /etc/subuid

--- a/src/lxd_build_all.sh
+++ b/src/lxd_build_all.sh
@@ -13,7 +13,8 @@
 #
 
 # Configs:
-oslist=('debian=10,11' 'ubuntu=18.04,20.04,22.04')
+# Use focal and jammy instead of "20.04 an 22.04"
+oslist=('debian=10,11' 'ubuntu=18.04,focal,jammy')
 branch='main'
 
 function setup_container() {

--- a/src/lxd_compile.sh
+++ b/src/lxd_compile.sh
@@ -4,7 +4,7 @@ branch=${1-main}
 
 apt -y install curl wget
 
-curl https://raw.githubusercontent.com/hestiacp/hestiacp/main/src/hst_autocompile.sh > /tmp/hst_autocompile.sh
+curl https://raw.githubusercontent.com/hestiacp/hestiacp/$branch/src/hst_autocompile.sh > /tmp/hst_autocompile.sh
 chmod +x /tmp/hst_autocompile.sh
 
 mkdir -p /opt/hestiacp

--- a/src/lxd_compile.sh
+++ b/src/lxd_compile.sh
@@ -11,15 +11,15 @@ mkdir -p /opt/hestiacp
 
 # Building Hestia
 if bash /tmp/hst_autocompile.sh --hestia --noinstall --keepbuild $branch; then
-	cp /tmp/hestiacp-src/debs/*.deb /opt/hestiacp/
+	cp /tmp/hestiacp-src/deb/*.deb /opt/hestiacp/
 fi
 
 # Building PHP
 if bash /tmp/hst_autocompile.sh --php --noinstall --keepbuild $branch; then
-	cp /tmp/hestiacp-src/debs/*.deb /opt/hestiacp/
+	cp /tmp/hestiacp-src/deb/*.deb /opt/hestiacp/
 fi
 
 # Building NGINX
 if bash /tmp/hst_autocompile.sh --nginx --noinstall --keepbuild $branch; then
-	cp /tmp/hestiacp-src/debs/*.deb /opt/hestiacp/
+	cp /tmp/hestiacp-src/deb/*.deb /opt/hestiacp/
 fi


### PR DESCRIPTION
- Ubuntu uses focal and jammy instead of version number
- Install LXC/LXD via snap
- Update path to copy from