### PR TITLE
Disable dialog button focus

### DIFF
--- a/web/js/events.js
+++ b/web/js/events.js
@@ -219,9 +219,14 @@ const VE = {
 					},
 				},
 				create: function () {
-					const buttonGroup = $(this).closest('.ui-dialog').find('.ui-dialog-buttonset');
-					buttonGroup.find('button:first').addClass('button submit');
-					buttonGroup.find('button:last').addClass('button button-secondary cancel');
+					const buttons = $(this).dialog('widget').find('.ui-dialog-buttonpane button');
+					buttons.first().addClass('button submit');
+					buttons.last().addClass('button button-secondary cancel');
+				},
+				focus: function () {
+					const buttons = $(this).dialog('widget').find('.ui-dialog-buttonpane button');
+					// Disable default "focus first button" behavior
+					buttons.first().blur();
 				},
 			};
 


### PR DESCRIPTION
When a [jQuery UI dialog](https://jqueryui.com/dialog/#modal-message) is opened it by default focuses the first form element in the dialog. In our case this is usually the "OK" button of the confirmation dialogs, and makes the button look "already pressed" and a bit weird.

This PR disables this behaviour by calling [.blur()](https://api.jquery.com/blur/) on this first button after the dialog is opened. Pressing enter still confirms the dialog, and pressing tab still advances the focus to the "Cancel" button.

**Note:** This is a sticking plaster to solve a minor UI annoyance. The real solution is to replace jQuery UI dialogs with the native [dialog element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog), and refactor button "focus" styles as necessary, perhaps adding just an outline on focus.

**Before:**
![image](https://user-images.githubusercontent.com/247634/224393568-6f46a2c5-5e38-42db-bf3e-4abf3cfa2b5f.png)

**After:**
![image](https://user-images.githubusercontent.com/247634/224393576-4db47a9a-904f-436a-9781-432dce5f1347.png)