### PR TITLE
Fix: Fatal error filemanager

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
+++ b/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
@@ -10,7 +10,6 @@ use Filegator\Services\Tmpfs\TmpfsInterface;
 use function Hestiacp\quoteshellarg\quoteshellarg;
 
 class HestiaZipArchiver extends ZipArchiver implements Service, ArchiverInterface {
-	public TmpfsInterface $tmpfs;
 	protected $container;
 
 	public function __construct(TmpfsInterface $tmpfs, Container $container) {


### PR DESCRIPTION
PHP message: PHP Fatal error:  Type of Filegator\Services\Archiver\Adapters\HestiaZipArchiver::$tmpfs must not be defined (as in class Filegator\Services\Archiver\Adapters\ZipArchiver)