### PR TITLE
Fix messages in hst-install.sh

### DIFF
--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -8,7 +8,7 @@
 #
 # Currently Supported Operating Systems:
 #
-# Debian 9, 10, 11
+# Debian 10, 11
 # Ubuntu 20.04, 22.04
 # AlmaLinux, EuroLinux, Red Hat EnterPrise Linux, Rocky Linux 8, 9
 #
@@ -82,7 +82,7 @@ no_support_message() {
 	echo "Hestia Control Panel. Officially supported releases:"
 	echo "****************************************************"
 	echo "  Debian 10, 11"
-	echo "  Ubuntu 18.04, 20.04, 22.04 LTS"
+	echo "  Ubuntu 20.04, 22.04 LTS"
 	# Commenting this out for now
 	# echo "  AlmaLinux, EuroLinux, Red Hat EnterPrise Linux, Rocky Linux 8,9"
 	echo ""


### PR DESCRIPTION
remove Ubuntu 18 from "no_support_message" and Debian 9 from header