### PR TITLE
fix-dns-record-suspend

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -531,7 +531,10 @@ update_domain_zone() {
 				fi
 			fi
 		fi
-		eval echo -e "\"$fields\"" | sed "s/%quote%/'/g" >> $zn_conf
+		
+		if [ "$SUSPENDED" != 'yes' ]; then
+			eval echo -e "\"$fields\"" | sed "s/%quote%/'/g" >> $zn_conf
+		fi
 	done < $USER_DATA/dns/$domain.conf
 }
 

--- a/func/domain.sh
+++ b/func/domain.sh
@@ -531,7 +531,7 @@ update_domain_zone() {
 				fi
 			fi
 		fi
-		
+
 		if [ "$SUSPENDED" != 'yes' ]; then
 			eval echo -e "\"$fields\"" | sed "s/%quote%/'/g" >> $zn_conf
 		fi


### PR DESCRIPTION
fix for: suspended dns records not removed from zonefile

as reference the vestacp codebase was used:
https://github.com/serghey-rodin/vesta/blob/master/func/domain.sh line 433

As an (maybe better) option it could be styled like in line 224:
( https://github.com/hestiacp/hestiacp/blob/release/func/domain.sh#L224 )
```
if [ "$SUSPENDED" = 'no' ]; then
```