### PR TITLE
Update v-backup-user

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -245,7 +245,7 @@ if [ -n "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
 	# Parsing domain exclusions
 	conf="$USER_DATA/web.conf"
 	for domain in $(search_objects 'web' 'SUSPENDED' "*" 'DOMAIN'); do
-		exclusion=$(echo -e "$WEB" | tr ',' '\n' | grep "^$domain\|\*$")
+		exclusion=$(echo -e "$WEB" | tr ',' '\n' | grep "^$domain$\|^\*$")
 		if [ -z "$exclusion" ]; then
 			web_list="$web_list $domain"
 		else


### PR DESCRIPTION
Fixed a bug where it was excluding ALL the folders in a listed domain, not just specified ones with stuff like:

foo.com:public_html

Instead of just excluding public_html, it ignored the whole domain. The wildcards worked as expected:

*:public_html