### PR TITLE
don't rely on deb control file for rpm version

### DIFF
--- a/src/deb/nginx/control
+++ b/src/deb/nginx/control
@@ -1,7 +1,7 @@
 Source: hestia-nginx
 Package: hestia-nginx
 Priority: optional
-Version: 1.23.3-3
+Version: 1.23.4
 Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -246,13 +246,14 @@ if [ "$dontinstalldeps" != 'true' ]; then
 	# Install needed software
 	if [ "$OSTYPE" = 'rhel' ]; then
 		# Set package dependencies for compiling
-		SOFTWARE='gcc gcc-c++ make libxml2-devel zlib-devel libzip-devel gmp-devel libcurl-devel gnutls-devel unzip openssl openssl-devel pkg-config sqlite-devel oniguruma-devel rpm-build wget tar git curl perl-IPC-Cmd'
+		SOFTWARE='gcc gcc-c++ make libxml2-devel zlib-devel libzip-devel gmp-devel libcurl-devel gnutls-devel unzip openssl openssl-devel pkg-config sqlite-devel oniguruma-devel rpm-build wget tar git curl perl-IPC-Cmd perl-File-Copy-Recursive perl-FindBin perl-File-Compare'
 
 		echo "Updating system DNF repositories..."
 		dnf install -y -q 'dnf-command(config-manager)'
-		dnf install -y -q dnf-plugins-core
+		dnf install -y -q dnf-plugins-core epel-release
 		dnf config-manager --set-enabled powertools > /dev/null 2>&1
 		dnf config-manager --set-enabled PowerTools > /dev/null 2>&1
+		dnf config-manager --set-enabled crb > /dev/null 2>&1
 		dnf upgrade -y -q
 		echo "Installing dependencies for compilation..."
 		dnf install -y -q $SOFTWARE

--- a/src/rpm/hestia/hestia.spec
+++ b/src/rpm/hestia/hestia.spec
@@ -1,6 +1,8 @@
+%global _hardened_build 1
+
 Name:           hestia
-Version:        %HESTIA-VERSION%
-Release:        1%{dist}
+Version:        1.7.2
+Release:        1~alpha%{dist}
 Summary:        Hestia Control Panel
 Group:          System Environment/Base
 License:        GPLv3

--- a/src/rpm/nginx/hestia-nginx.spec
+++ b/src/rpm/nginx/hestia-nginx.spec
@@ -1,5 +1,7 @@
+%global _hardened_build 1
+
 Name:           hestia-nginx
-Version:        %HESTIA-NGINX-VERSION%
+Version:        1.23.4
 Release:        1%{dist}
 Summary:        Hestia internal nginx web server
 Group:          System Environment/Base

--- a/src/rpm/php/hestia-php.spec
+++ b/src/rpm/php/hestia-php.spec
@@ -1,5 +1,7 @@
+%global _hardened_build 1
+
 Name:           hestia-php
-Version:        %HESTIA-PHP-VERSION%
+Version:        8.2.4
 Release:        1%{dist}
 Summary:        Hestia internal PHP
 Group:          System Environment/Base
@@ -39,7 +41,7 @@ mkdir -p %{buildroot}%{_unitdir}
 %defattr(-,root,root)
 %attr(755,root,root) /usr/local/hestia/php
 %attr(775,admin,admin) /usr/local/hestia/php/var/log
-%attr(775,admin,admin) /usr/local/hestia/php/run
+%attr(775,admin,admin) /usr/local/hestia/php/var/run
 %config(noreplace) /usr/local/hestia/php/etc/php-fpm.conf
 %config(noreplace) /usr/local/hestia/php/lib/php.ini
 %{_unitdir}/hestia-php.service


### PR DESCRIPTION
Previous hestia-nginx debian release versioning broke rpm builds. Separated them.