### PR TITLE
Fix named command warning

### DIFF
--- a/bin/v-list-sys-config
+++ b/bin/v-list-sys-config
@@ -268,11 +268,13 @@ csv_list() {
 #                       Action                             #
 #----------------------------------------------------------#
 
-version=$(named -v | awk 'NR==1{print $2}')
-if version_ge '9.16.18' $version; then
-	SUPPORT_DNSSEC="no"
-else
-	SUPPORT_DNSSEC="yes"
+if [ -n "$DNS_SYSTEM" ]; then
+	version=$(named -v | awk 'NR==1{print $2}')
+	if version_ge '9.16.18' $version; then
+		SUPPORT_DNSSEC="no"
+	else
+		SUPPORT_DNSSEC="yes"
+	fi
 fi
 
 # Listing data


### PR DESCRIPTION
Fixed warning when updating HestiaCP to v1.7.2 if the installation don't have DNS stack

Warning:
`/usr/local/hestia/bin/v-list-sys-config: line 271: named: command not found`