### PR TITLE
Added missing OS details and "warning" message in `getting-started.md`

### DIFF
--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -10,6 +10,7 @@ The installer needs to be run as **root**, either directly from the terminal or 
 
 ::: warning
 Hestia must be installed on top of a fresh operating system installation to ensure proper functionality.
+If on a VPS/KVM, and there is already an admin account, either delete that default admin ID, or use `--force` to continue with the installation. See custom installation below for further details.
 :::
 
 |                      | Minimum                             | Recommended                          |
@@ -17,7 +18,7 @@ Hestia must be installed on top of a fresh operating system installation to ensu
 | **CPU**              | 1 core, 64-bit                      | 4 cores                              |
 | **Memory**           | 1 GB (no SpamAssassin and ClamAV)   | 4 GB                                 |
 | **Disk**             | 10 GB HDD                           | 40 GB SSD                            |
-| **Operating System** | Debian 10, 11 <br> 20.04, 22.04 LTS | Latest Debian <br> Latest Ubuntu LTS |
+| **Operating System** | Debian 10, 11 <br>Ubuntu 20.04, 22.04 LTS | Latest Debian <br> Latest Ubuntu LTS |
 
 ::: warning
 Hestia only runs on AMD64 / x86_64 and ARM64 / AArch64 processors. It also requires a 64bit operating system!


### PR DESCRIPTION
1. Added missing "Ubuntu" in the supported OS details.
2. Added under "warning" about an existing "admin" account when installing on a VPS/KVM, and the usage of `--force` as a workaround and move forward with the installation.