### PR TITLE
Fix: Bug in sftp backup

### DIFF
--- a/func/backup.sh
+++ b/func/backup.sh
@@ -196,7 +196,7 @@ ftp_delete() {
 # SFTP Functions
 # sftp command function
 sftpc() {
-	if [ $PRIVATEKEY != "yes" ]; then
+	if [ "$PRIVATEKEY" != "yes" ]; then
 		expect -f "-" "$@" << EOF
             set timeout 60
             set count 0


### PR DESCRIPTION
/usr/local/hestia/func/backup.sh: line 199: [: !=: unary operator expected
