### PR TITLE
Fix minor grammatical error in HestiaCP doc page.

### DIFF
--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -137,6 +137,6 @@ This command will install Hestia in French with the following software:
 
 ## What’s next?
 
-By now, you should have a Hestia installation on your server. You are be ready to add new users, so that you (or they) can add new websites on your server.
+By now, you should have a Hestia installation on your server. You are ready to add new users, so that you (or they) can add new websites on your server.
 
 To access your control panel, navigate to `https://host.domain.tld:8083` or `http://your.public.ip.address:8083`


### PR DESCRIPTION
### Documentation Issue

On the getting started page on [**What's Next** ](https://hestiacp.com/docs/introduction/getting-started.html#what-s-next) section, there is a minor grammatical error in the following sentence: 

> By now, you should have a Hestia installation on your server. You are **_be_** ready to add new users, so that you (or they) can add new websites on your server.

### Suggested Improvements

Correcting the grammatical error by removing '**be**' from the sentence.