### PR TITLE
Simplify suspend/unsuspend dialog translations

### DIFF
--- a/web/templates/pages/list_cron.php
+++ b/web/templates/pages/list_cron.php
@@ -84,11 +84,13 @@
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend the cron job?') ;
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend the cron job?') ;
 			}
@@ -121,7 +123,7 @@
 									<a
 										class="data-controls js-confirm-action"
 										href="/<?= $spnd_action ?>/cron/?job=<?= $data[$key]["JOB"] ?>&token=<?= $_SESSION["token"] ?>"
-										data-confirm-title="<?= _($spnd_action) ?>"
+										data-confirm-title="<?= $spnd_action_title ?>"
 										data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 									>
 										<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_db.php
+++ b/web/templates/pages/list_db.php
@@ -109,11 +109,13 @@ if (!empty($_SESSION["DB_PGA_ALIAS"])) {
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend database %s?') ;
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend database %s?') ;
 			}
@@ -158,7 +160,7 @@ if (!empty($_SESSION["DB_PGA_ALIAS"])) {
 										<a
 											class="data-controls js-confirm-action"
 											href="/<?=$spnd_action?>/db/?database=<?=$key?>&token=<?=$_SESSION['token']?>"
-											data-confirm-title="<?= _($spnd_action) ?>"
+											data-confirm-title="<?= $spnd_action_title ?>"
 											data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 										>
 											<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_dns.php
+++ b/web/templates/pages/list_dns.php
@@ -80,11 +80,13 @@
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend domain %s?');
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend domain %s?');
 				if ($data[$key]['DNSSEC'] !== 'yes') {
@@ -124,7 +126,7 @@
 									<a
 										class="data-controls js-confirm-action"
 										href="/<?=$spnd_action?>/dns/?domain=<?=htmlentities($key);?>&token=<?=$_SESSION['token']?>"
-										data-confirm-title="<?= _($spnd_action) ?>"
+										data-confirm-title="<?= $spnd_action_title ?>"
 										data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 									>
 										<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_firewall.php
+++ b/web/templates/pages/list_firewall.php
@@ -67,11 +67,13 @@
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend rule #%s?') ;
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend rule #%s?') ;
 			}
@@ -106,7 +108,7 @@
 									<a
 										class="data-controls js-confirm-action"
 										href="/<?=$spnd_action?>/firewall/?rule=<?=$key?>&token=<?=$_SESSION['token']?>"
-										data-confirm-title="<?= _($spnd_action) ?>"
+										data-confirm-title="<?= $spnd_action_title ?>"
 										data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 									>
 										<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_mail.php
+++ b/web/templates/pages/list_mail.php
@@ -82,6 +82,7 @@
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend domain %s?');
 				if ($data[$key]['ANTIVIRUS'] == 'no') {
@@ -107,6 +108,7 @@
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend domain %s?');
 				if ($data[$key]['ANTIVIRUS'] == 'no') {
@@ -169,7 +171,7 @@
 										<a
 											class="data-controls js-confirm-action"
 											href="/<?=$spnd_action?>/mail/?domain=<?=$key?>&token=<?=$_SESSION['token']?>"
-											data-confirm-title="<?= _($spnd_action) ?>"
+											data-confirm-title="<?= $spnd_action_title ?>"
 											data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 										>
 											<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_mail_acc.php
+++ b/web/templates/pages/list_mail_acc.php
@@ -90,6 +90,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend %s?');
 				if ($data[$key]['ALIAS'] == '') {
@@ -110,6 +111,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend %s?');
 				if ($data[$key]['ALIAS'] == '') {
@@ -167,7 +169,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 									<a
 										class="data-controls js-confirm-action"
 										href="/<?=$spnd_action?>/mail/?domain=<?=htmlspecialchars($_GET['domain'])?>&account=<?=$key?>&token=<?=$_SESSION['token']?>"
-										data-confirm-title="<?= _($spnd_action) ?>"
+										data-confirm-title="<?= $spnd_action_title ?>"
 										data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 									>
 										<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -88,11 +88,13 @@
 			if ($data[$key]['SUSPENDED'] == 'yes') {
 				$status = 'suspended';
 				$spnd_action = 'unsuspend';
+				$spnd_action_title = _('Unsuspend');
 				$spnd_icon = 'fa-play';
 				$spnd_confirmation = _('Are you sure you want to unsuspend user %s?');
 			} else {
 				$status = 'active';
 				$spnd_action = 'suspend';
+				$spnd_action_title = _('Suspend');
 				$spnd_icon = 'fa-pause';
 				$spnd_confirmation = _('Are you sure you want to suspend user %s?');
 			}
@@ -138,7 +140,7 @@
 									<a
 										class="data-controls js-confirm-action"
 										href="/<?= $spnd_action ?>/user/?user=<?= $key ?>&token=<?= $_SESSION["token"] ?>"
-										data-confirm-title="<?= _($spnd_action) ?>"
+										data-confirm-title="<?= $spnd_action_title ?>"
 										data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 									>
 										<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>

--- a/web/templates/pages/list_web.php
+++ b/web/templates/pages/list_web.php
@@ -81,11 +81,13 @@
 				if ($data[$key]['SUSPENDED'] == 'yes') {
 						$status = 'suspended';
 						$spnd_action = 'unsuspend';
+						$spnd_action_title = _('Unsuspend');
 						$spnd_icon = 'fa-play';
 						$spnd_confirmation = _('Are you sure you want to unsuspend domain %s?');
 				} else {
 						$status = 'active';
 						$spnd_action = 'suspend';
+						$spnd_action_title = _('Suspend');
 						$spnd_icon = 'fa-pause';
 						$spnd_confirmation = _('Are you sure you want to suspend domain %s?');
 				}
@@ -207,7 +209,7 @@
 										<a
 											class="data-controls js-confirm-action"
 											href="/<?=$spnd_action?>/web/?domain=<?=$key?>&token=<?=$_SESSION['token']?>"
-											data-confirm-title="<?= _($spnd_action) ?>"
+											data-confirm-title="<?= $spnd_action_title ?>"
 											data-confirm-message="<?= sprintf($spnd_confirmation, $key) ?>"
 										>
 											<i class="fas <?= $spnd_icon ?> icon-highlight icon-dim"></i>


### PR DESCRIPTION
The suspend/unsuspend confirmation dialog titles have wrong casing due to translation changes.

Instead of translating the dynamic lowercase value of "suspend" and "unsuspend", use separate dedicated translation strings for this to avoid potential confusion e.g. the translators don't need to know that "suspend" should be "Suspend".

**Before:**
![image](https://github.com/hestiacp/hestiacp/assets/247634/63f82aae-a941-4cac-9f72-7ac92208834c)

**After:**
![image](https://github.com/hestiacp/hestiacp/assets/247634/9ffb7e28-fc40-4a7e-bb33-f5c3fb81c9a9)