### PR TITLE
Fix bug in v-update-sys-ip

### DIFF
--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -48,13 +48,13 @@ for nic in $physical_nics; do
 	if [ -z "$ips" ]; then
 		ips="$nic_ipv4s"
 	else
-		ips="$ips\n$nic_ipv4s"
+		ips="$ips $nic_ipv4s"
 	fi
 done
 
 v_ips="$(ls $HESTIA/data/ips/)"
-ip_num="$(echo "$ips" | wc -l)"
-v_ip_num="$(echo "$v_ips" | wc -l)"
+ip_num="$(echo "$ips" | wc -w)"
+v_ip_num="$(echo "$v_ips" | wc -w)"
 
 # Checking primary IP change
 if [ "$ip_num" -eq "1" ] && [ "$v_ip_num" -eq "1" ]; then


### PR DESCRIPTION
Fixed an issue in new system for ip detections

In cause on setups with multiple ip addresses or multiple ethernet ports  the returned sting was 

ip.1.1.1\nip.2.2.2 instead of 
ip1.1.1
ip.2.2.2

This caused issues in the next step...
See: https://forum.hestiacp.com/t/debian-12-bookworm-released/9807/12?u=eris

This patch solves the issue by splitting it based on " " instead and use -w instead of -l

Haven't tested it on ipv6 might need some improvement on there...

@myrevery  