### PR TITLE
Fix #3687 Improve check if alias allready exists

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -680,7 +680,9 @@ is_mail_new() {
 		check_result "$E_EXISTS" "mail account $1 is already exists"
 	fi
 	check_als=$(awk -F "ALIAS='" '{print $2}' $USER_DATA/mail/$domain.conf)
-	check_als=$(echo "$check_als" | cut -f 1 -d "'" | grep -w $1)
+	match=$(echo $check_als | cut -d "'" -f1)
+	parse_object_kv_list $(grep "ALIAS='$match'" $USER_DATA/mail/$domain.conf)
+	check_als=$(echo ",$ALIAS," | grep ",$1,")
 	if [ -n "$check_als" ]; then
 		check_result "$E_EXISTS" "mail alias $1 is already exists"
 	fi


### PR DESCRIPTION
Old check checked if the string "alias" already exists. So in the case have the email account: 

info@domain.com
- Alias: jaap.marcus@domain.com 

Alias jaap couldn't been added any more