### PR TITLE
Fix: DNS cluster expected return code instead of string

### DIFF
--- a/bin/v-add-remote-dns-record
+++ b/bin/v-add-remote-dns-record
@@ -75,7 +75,7 @@ if [ "$DNS_CLUSTER_SYSTEM" != "hestia-zone" ]; then
 		check_result $? "$HOST connection failed (soa sync)" "$E_CONNECT"
 
 		# Syncing record
-		str=$(grep "ID='$id'" $USER_DATA/dns/$domain.conf | sed 's/"/\\"/g')
+		str=$(grep "ID='$id'" $USER_DATA/dns/$domain.conf)
 		cluster_cmd v-insert-dns-record $DNS_USER $domain "$str" 'no'
 		check_result $? "$HOST connection failed (record sync)" "$E_CONNECT"
 

--- a/bin/v-check-access-key
+++ b/bin/v-check-access-key
@@ -16,7 +16,7 @@
 access_key_id="$(basename "$1")"
 secret_access_key=$2
 hst_command=$3
-ip=${4-127.0.0.1}
+ip46=${4-127.0.0.1}
 format=${5-shell}
 
 # Includes
@@ -56,11 +56,11 @@ shell_list() {
 # Callback to intercept invalid result validation
 abort_missmatch() {
 	echo "Error: $2"
-	echo "$date $time ${access_key_id:-api} $ip failed to login" >> $HESTIA/log/auth.log
+	echo "$date $time ${access_key_id:-api} $ip46 failed to login" >> $HESTIA/log/auth.log
 
 	# Add a log for user
 	if [[ "$1" == "$E_PASSWORD" && -n "$user" ]]; then
-		log_history "[$ip] $access_key_id $2" "Error" "$user" "API"
+		log_history "[$ip46] $access_key_id $2" "Error" "$user" "API"
 	fi
 
 	if [[ "$1" == "$E_FORBIDEN" ]]; then
@@ -78,7 +78,7 @@ abort_missmatch() {
 CHECK_RESULT_CALLBACK="abort_missmatch"
 
 check_args '3' "$#" 'ACCESS_KEY_ID SECRET_ACCESS_KEY COMMAND [IP] [FORMAT]'
-is_format_valid 'access_key_id' 'ip' 'command'
+is_format_valid 'access_key_id' 'ip46' 'command'
 is_object_valid 'key' 'KEY' "$access_key_id"
 is_format_valid 'secret_access_key'
 check_access_key_secret "$access_key_id" "$secret_access_key" user
@@ -108,7 +108,7 @@ esac
 #----------------------------------------------------------#
 
 # Logging
-log_history "[$ip] Access key $access_key_id successfully launched with command $hst_command" "Info" "$user" "API"
-echo "$date $time $access_key_id $ip $hst_command successfully launched" >> $HESTIA/log/auth.log
+log_history "[$ip46] Access key $access_key_id successfully launched with command $hst_command" "Info" "$user" "API"
+echo "$date $time $access_key_id $ip46 $hst_command successfully launched" >> $HESTIA/log/auth.log
 
 exit

--- a/func/remote.sh
+++ b/func/remote.sh
@@ -47,6 +47,11 @@ send_api_cmd() {
 			--data-urlencode "arg8=$9" \
 			https://$HOST:$PORT/api/)
 	fi
+
+	if [ "$DEBUG_MODE" = "yes" ]; then
+		# log out going request if wanted for debugging
+		echo "$1 $2 $3 $4 $5 $6 $7 $8 $9" >> /var/log/hestia/api_out.log
+	fi
 	return $answer
 }
 

--- a/func/remote.sh
+++ b/func/remote.sh
@@ -47,6 +47,7 @@ send_api_cmd() {
 			--data-urlencode "arg8=$9" \
 			https://$HOST:$PORT/api/)
 	fi
+	echo $answer
 	return $answer
 }
 

--- a/func/remote.sh
+++ b/func/remote.sh
@@ -47,7 +47,6 @@ send_api_cmd() {
 			--data-urlencode "arg8=$9" \
 			https://$HOST:$PORT/api/)
 	fi
-	echo $answer
 	return $answer
 }
 

--- a/install/upgrade/versions/1.8.0.sh
+++ b/install/upgrade/versions/1.8.0.sh
@@ -201,7 +201,7 @@ exim_version=$(exim4 --version | head -1 | awk '{print $3}' | cut -f -2 -d .)
 # if Exim version > 4.9.4 or greater!
 if ! version_ge "4.9.4" "$exim_version"; then
 	if ! grep -q 'SRS_SECRET' /etc/exim4/exim4.conf.template; then
-		srs=$(gen_pass)
+		srs=$(generate_password)
 		echo $srs > /etc/exim4/srs.conf
 		chmod 640 /etc/exim4/srs.conf
 		echo "[ * ] Update exim4.conf.template ..."

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -27,7 +27,7 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/helpers.php";
  * @param string $user
  * @return void
  */
-function api_error($exit_code, $message, bool $add_log = false, $user = "system") {
+function api_error($exit_code, $message, $hst_return, bool $add_log = false, $user = "system") {
 	$message = trim(is_array($message) ? implode("\n", $message) : $message);
 
 	// Add log
@@ -56,20 +56,21 @@ function api_error($exit_code, $message, bool $add_log = false, $user = "system"
  * @return void
  */
 function api_legacy(array $request_data) {
+	$hst_return = ($request_data["returncode"] ?? "no") === "yes" ? "code" : "data";
 	exec(HESTIA_CMD . "v-list-sys-config json", $output, $return_var);
 	$settings = json_decode(implode("", $output), true);
 	unset($output);
 
 	if ($settings["config"]["API"] != "yes") {
 		echo "Error: API has been disabled";
-		api_error(E_DISABLED, "Error: API Disabled");
+		api_error(E_DISABLED, "Error: API Disabled", $hst_return);
 	}
 
 	if ($settings["config"]["API_ALLOWED_IP"] != "allow-all") {
 		$ip_list = explode(",", $settings["config"]["API_ALLOWED_IP"]);
 		$ip_list[] = "";
 		if (!in_array(get_real_user_ip(), $ip_list)) {
-			api_error(E_FORBIDDEN, "Error: IP is not allowed to connect with API");
+			api_error(E_FORBIDDEN, "Error: IP is not allowed to connect with API", $hst_return);
 		}
 	}
 
@@ -77,11 +78,11 @@ function api_legacy(array $request_data) {
 	// Authentication
 	if (empty($request_data["hash"])) {
 		if ($request_data["user"] != "admin") {
-			api_error(E_FORBIDDEN, "Error: authentication failed");
+			api_error(E_FORBIDDEN, "Error: authentication failed", $hst_return);
 		}
 		$password = $request_data["password"];
 		if (!isset($password)) {
-			api_error(E_PASSWORD, "Error: authentication failed");
+			api_error(E_PASSWORD, "Error: authentication failed", $hst_return);
 		}
 		$v_ip = quoteshellarg(get_real_user_ip());
 		unset($output);
@@ -135,7 +136,7 @@ function api_legacy(array $request_data) {
 
 		// Check API answer
 		if ($return_var > 0) {
-			api_error(E_PASSWORD, "Error: authentication failed");
+			api_error(E_PASSWORD, "Error: authentication failed", $hst_return);
 		}
 	} else {
 		$key = "/usr/local/hestia/data/keys/" . basename($request_data["hash"]);
@@ -148,11 +149,10 @@ function api_legacy(array $request_data) {
 		unset($output);
 		// Check API answer
 		if ($return_var > 0) {
-			api_error(E_PASSWORD, "Error: authentication failed");
+			api_error(E_PASSWORD, "Error: authentication failed", $hst_return);
 		}
 	}
 
-	$hst_return = ($request_data["returncode"] ?? "no") === "yes" ? "code" : "data";
 	$hst_cmd = trim($request_data["cmd"] ?? "");
 	$hst_cmd_args = [];
 	for ($i = 1; $i <= 9; $i++) {
@@ -162,9 +162,9 @@ function api_legacy(array $request_data) {
 	}
 
 	if (empty($hst_cmd)) {
-		api_error(E_INVALID, "Command not provided");
+		api_error(E_INVALID, "Command not provided", $hst_return);
 	} elseif (!preg_match('/^[a-zA-Z0-9_-]+$/', $hst_cmd)) {
-		api_error(E_INVALID, "$hst_cmd command invalid");
+		api_error(E_INVALID, "$hst_cmd command invalid", $hst_return);
 	}
 
 	// Check command
@@ -207,6 +207,7 @@ function api_legacy(array $request_data) {
  * @return void
  */
 function api_connection(array $request_data) {
+	$hst_return = ($request_data["returncode"] ?? "no") === "yes" ? "code" : "data";
 	$v_real_user_ip = get_real_user_ip();
 
 	exec(HESTIA_CMD . "v-list-sys-config json", $output, $return_var);
@@ -220,7 +221,7 @@ function api_connection(array $request_data) {
 			: 0;
 	if ($api_status == 0) {
 		// Check if API is disabled for all users
-		api_error(E_DISABLED, "API has been disabled");
+		api_error(E_DISABLED, "API has been disabled", $hst_return);
 	}
 
 	// Check if API access is enabled for the user
@@ -228,14 +229,13 @@ function api_connection(array $request_data) {
 		$ip_list = explode(",", $settings["config"]["API_ALLOWED_IP"]);
 		$ip_list[] = "";
 		if (!in_array($v_real_user_ip, $ip_list) && !in_array("0.0.0.0", $ip_list)) {
-			api_error(E_FORBIDDEN, "IP is not allowed to connect with API");
+			api_error(E_FORBIDDEN, "IP is not allowed to connect with API", $hst_return);
 		}
 	}
 
 	// Get POST Params
 	$hst_access_key_id = trim($request_data["access_key"] ?? "");
 	$hst_secret_access_key = trim($request_data["secret_key"] ?? "");
-	$hst_return = ($request_data["returncode"] ?? "no") === "yes" ? "code" : "data";
 	$hst_cmd = trim($request_data["cmd"] ?? "");
 	$hst_cmd_args = [];
 	for ($i = 1; $i <= 9; $i++) {
@@ -245,13 +245,13 @@ function api_connection(array $request_data) {
 	}
 
 	if (empty($hst_cmd)) {
-		api_error(E_INVALID, "Command not provided");
+		api_error(E_INVALID, "Command not provided", $hst_return);
 	} elseif (!preg_match('/^[a-zA-Z0-9_-]+$/', $hst_cmd)) {
-		api_error(E_INVALID, "$hst_cmd command invalid");
+		api_error(E_INVALID, "$hst_cmd command invalid", $hst_return);
 	}
 
 	if (empty($hst_access_key_id) || empty($hst_secret_access_key)) {
-		api_error(E_PASSWORD, "Authentication failed");
+		api_error(E_PASSWORD, "Authentication failed", $hst_return);
 	}
 
 	// Authenticates the key and checks permission to run the script
@@ -270,7 +270,7 @@ function api_connection(array $request_data) {
 		$return_var,
 	);
 	if ($return_var > 0) {
-		//api_error($return_var, "Key $hst_access_key_id - authentication failed");
+		//api_error($return_var, "Key $hst_access_key_id - authentication failed", $hst_return);
 		api_error($return_var, $output);
 	}
 	$key_data = json_decode(implode("", $output), true) ?? [];
@@ -284,7 +284,7 @@ function api_connection(array $request_data) {
 
 	# Check if API access is enabled for nonadmin users
 	if ($key_user != "admin" && $api_status < 2) {
-		api_error(E_API_DISABLED, "API has been disabled");
+		api_error(E_API_DISABLED, "API has been disabled", $hst_return);
 	}
 
 	// Checks if the value entered in the "user" argument matches the user of the key

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -271,7 +271,7 @@ function api_connection(array $request_data) {
 	);
 	if ($return_var > 0) {
 		//api_error($return_var, "Key $hst_access_key_id - authentication failed", $hst_return);
-		api_error($return_var, $output);
+		api_error($return_var, $output, $hst_return);
 	}
 	$key_data = json_decode(implode("", $output), true) ?? [];
 	unset($output, $return_var);
@@ -296,6 +296,7 @@ function api_connection(array $request_data) {
 		api_error(
 			E_FORBIDDEN,
 			"Key $hst_access_key_id - the \"user\" argument doesn\'t match the key\'s user",
+			$hst_return,
 		);
 	}
 
@@ -350,6 +351,7 @@ if (isset($_POST["access_key"]) || isset($_POST["user"]) || isset($_POST["hash"]
 	api_error(
 		405,
 		"Error: data received is null or invalid, check https://hestiacp.com/docs/server-administration/rest-api.html",
+		"",
 	);
 }
 
@@ -376,5 +378,6 @@ if (isset($request_data["access_key"]) && isset($request_data["secret_key"])) {
 	api_error(
 		405,
 		"Error: data received is null or invalid, check https://hestiacp.com/docs/server-administration/rest-api.html",
+		"",
 	);
 }

--- a/web/inc/helpers.php
+++ b/web/inc/helpers.php
@@ -23,6 +23,7 @@ const E_DB = 17;
 const E_RRD = 18;
 const E_UPDATE = 19;
 const E_RESTART = 20;
+const E_API_DISABLED = 21;
 
 /**
  * Looks for a code equivalent to "exit_code" to use in http_code.
@@ -50,6 +51,7 @@ function exit_code_to_http_code(int $exit_code, int $default = 400): int {
 		case E_UNSUSPENDED:
 		case E_FORBIDEN:
 		case E_FORBIDDEN:
+		case E_API_DISABLED:
 			return 401;
 		// return 403;
 		case E_DISABLED:


### PR DESCRIPTION
DNS cluster syncing / set up requires always an numeric code in return. 

https://github.com/hestiacp/hestiacp/blob/8c26daac3469f2d5e021080d19901553d1801ff0/func/remote.sh#L50

In the past by default the text was shown if an error code was generated if the users tries to connect  with an incorrect  password/key or ip is not allowed

