### PR TITLE
Rename #vstobjects to #main-form

### DIFF
--- a/web/js/src/alpineInit.js
+++ b/web/js/src/alpineInit.js
@@ -27,7 +27,7 @@ export default function alpineInit() {
 		},
 	});
 	document
-		.querySelectorAll('#vstobjects input, #vstobjects select, #vstobjects textarea')
+		.querySelectorAll('#main-form input, #main-form select, #main-form textarea')
 		.forEach((el) => {
 			el.addEventListener('change', () => {
 				Alpine.store('form').makeDirty();

--- a/web/js/src/cronGenerator.js
+++ b/web/js/src/cronGenerator.js
@@ -7,7 +7,7 @@ export default function handleCronGenerator() {
 
 			inputNames.forEach((inputName) => {
 				const value = fieldset.querySelector(`[name=h_${inputName}]`).value;
-				const formInput = document.querySelector(`#vstobjects input[name=v_${inputName}]`);
+				const formInput = document.querySelector(`#main-form input[name=v_${inputName}]`);
 
 				formInput.value = value;
 				formInput.classList.add('highlighted');

--- a/web/js/src/focusFirstInput.js
+++ b/web/js/src/focusFirstInput.js
@@ -4,8 +4,7 @@ export default function focusFirstInput() {
 	const openDialogs = document.querySelectorAll('dialog[open]');
 	if (openDialogs.length === 0) {
 		const input = document.querySelector(
-			'#vstobjects .form-control:not([disabled]),\
-		#vstobjects .form-select:not([disabled])'
+			'#main-form .form-control:not([disabled]), #main-form .form-select:not([disabled])'
 		);
 		if (input) {
 			input.focus();

--- a/web/js/src/formSubmit.js
+++ b/web/js/src/formSubmit.js
@@ -3,14 +3,14 @@ import { updateAdvancedTextarea } from './toggleAdvanced';
 import { showSpinner } from './helpers';
 
 export default function handleFormSubmit() {
-	const pageForm = document.querySelector('#vstobjects');
-	if (pageForm) {
-		pageForm.addEventListener('submit', () => {
+	const mainForm = document.querySelector('#main-form');
+	if (mainForm) {
+		mainForm.addEventListener('submit', () => {
 			// Show loading spinner
 			showSpinner();
 
 			// Enable any disabled inputs to ensure all fields are submitted
-			if (pageForm.classList.contains('js-enable-inputs-on-submit')) {
+			if (mainForm.classList.contains('js-enable-inputs-on-submit')) {
 				document.querySelectorAll('input[disabled]').forEach((input) => {
 					input.disabled = false;
 				});

--- a/web/js/src/shortcuts.js
+++ b/web/js/src/shortcuts.js
@@ -137,7 +137,7 @@ export default function handleShortcuts() {
 			{ disabledInInput: true }
 		)
 		.register({ code: 'Enter', ctrlKey: true }, (_evt) => {
-			document.querySelector('form#vstobjects').submit();
+			document.querySelector('#main-form').submit();
 		})
 		.register({ code: 'Backspace', ctrlKey: true }, (_evt) => {
 			const redirect = document.querySelector('a.js-button-back').href;
@@ -429,8 +429,8 @@ export default function handleShortcuts() {
 		.register(
 			{ code: 'Enter' },
 			(evt) => {
-				if (evt.target.tagName == 'INPUT' && evt.target.form.id == 'vstobjects') {
-					document.querySelector('form#vstobjects').submit();
+				if (evt.target.tagName === 'INPUT' && evt.target.form.id === 'main-form') {
+					evt.target.form.submit();
 				}
 
 				if (Alpine.store('form').dirty) {

--- a/web/js/src/toggleAdvanced.js
+++ b/web/js/src/toggleAdvanced.js
@@ -24,7 +24,7 @@ function toggleAdvancedOptions() {
 // Update the "advanced options" textarea with "basic options" input values
 export function updateAdvancedTextarea() {
 	const advancedTextarea = document.querySelector('.js-advanced-textarea');
-	const textInputs = document.querySelectorAll('#vstobjects input[type=text]');
+	const textInputs = document.querySelectorAll('#main-form input[type=text]');
 
 	textInputs.forEach((textInput) => {
 		const search = textInput.dataset.regexp;

--- a/web/templates/pages/add_access_key.php
+++ b/web/templates/pages/add_access_key.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -16,7 +16,7 @@
 <!-- End toolbar -->
 
 <div class="container animate__animated animate__fadeIn">
-	<form id="vstobjects" name="v_add_access_key" method="post">
+	<form id="main-form" name="v_add_access_key" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/add_cron.php
+++ b/web/templates/pages/add_cron.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_cron" method="post">
+	<form id="main-form" name="v_add_cron" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/add_db.php
+++ b/web/templates/pages/add_db.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			showAdvanced: <?= empty($v_adv) ? "false" : "true" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_db"
 		method="post"
 	>

--- a/web/templates/pages/add_dns.php
+++ b/web/templates/pages/add_dns.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			showAdvanced: <?= empty($v_adv) ? "false" : "true" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_dns"
 		method="post"
 	>

--- a/web/templates/pages/add_dns_rec.php
+++ b/web/templates/pages/add_dns_rec.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_dns_rec" method="post">
+	<form id="main-form" name="v_add_dns_rec" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok_rec" value="add">
 

--- a/web/templates/pages/add_firewall.php
+++ b/web/templates/pages/add_firewall.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_ip" method="post">
+	<form id="main-form" name="v_add_ip" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/add_firewall_banlist.php
+++ b/web/templates/pages/add_firewall_banlist.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_ip" method="post">
+	<form id="main-form" name="v_add_ip" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/add_firewall_ipset.php
+++ b/web/templates/pages/add_firewall_ipset.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_ipset" method="post">
+	<form id="main-form" name="v_add_ipset" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/add_ip.php
+++ b/web/templates/pages/add_ip.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			showUserTable: <?= empty($v_dedicated) ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_ip"
 		method="post"
 	>

--- a/web/templates/pages/add_key.php
+++ b/web/templates/pages/add_key.php
@@ -13,7 +13,7 @@
 			<?php } ?>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -23,7 +23,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_key" method="post">
+	<form id="main-form" name="v_add_key" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/add_mail.php
+++ b/web/templates/pages/add_mail.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			hasSmtpRelay: <?= $v_smtp_relay == "true" ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_mail"
 		method="post"
 	>

--- a/web/templates/pages/add_mail_acc.php
+++ b/web/templates/pages/add_mail_acc.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			showAdvanced: <?= empty($v_adv) ? "false" : "true" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_mail_acc"
 		method="post"
 	>

--- a/web/templates/pages/add_package.php
+++ b/web/templates/pages/add_package.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -25,7 +25,7 @@
 			showDatabaseOptions: false,
 			showSystemOptions: false,
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_package"
 		method="post"
 	>

--- a/web/templates/pages/add_user.php
+++ b/web/templates/pages/add_user.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			loginDisabled: <?= $v_login_disabled == "yes" ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_add_user"
 		method="post"
 	>

--- a/web/templates/pages/add_web.php
+++ b/web/templates/pages/add_web.php
@@ -8,7 +8,7 @@
 		</div>
 		<div class="toolbar-buttons">
 			<?php if (($user_plain == "admin" && $_GET["accept"] === "true") || $user_plain !== "admin") { ?>
-				<button type="submit" class="button" form="vstobjects">
+				<button type="submit" class="button" form="main-form">
 					<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 				</button>
 			<?php } ?>
@@ -19,7 +19,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_add_web" method="post" class="js-enable-inputs-on-submit">
+	<form id="main-form" name="v_add_web" method="post" class="js-enable-inputs-on-submit">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="ok" value="Add">
 

--- a/web/templates/pages/edit_backup_exclusions.php
+++ b/web/templates/pages/edit_backup_exclusions.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_edit_backup_exclusions" method="post" class="<?= _($v_status) ?>">
+	<form id="main-form" name="v_edit_backup_exclusions" method="post" class="<?= _($v_status) ?>">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_cron.php
+++ b/web/templates/pages/edit_cron.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_edit_cron" method="post" class="<?= $v_status ?>">
+	<form id="main-form" name="v_edit_cron" method="post" class="<?= $v_status ?>">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_db.php
+++ b/web/templates/pages/edit_db.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_edit_db" method="post" class="<?= $v_status ?>">
+	<form id="main-form" name="v_edit_db" method="post" class="<?= $v_status ?>">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_dns.php
+++ b/web/templates/pages/edit_dns.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_edit_dns" method="post" class="<?= $v_status ?>">
+	<form id="main-form" name="v_edit_dns" method="post" class="<?= $v_status ?>">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_dns_rec.php
+++ b/web/templates/pages/edit_dns_rec.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_edit_dns_rec" method="post" class="<?= $v_status ?>">
+	<form id="main-form" name="v_edit_dns_rec" method="post" class="<?= $v_status ?>">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_firewall.php
+++ b/web/templates/pages/edit_firewall.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_edit_firewall" method="post" class="<?= $v_status ?>">
+	<form id="main-form" name="v_edit_firewall" method="post" class="<?= $v_status ?>">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_ip.php
+++ b/web/templates/pages/edit_ip.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			showUserTable: <?= empty($v_dedicated) ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_edit_ip"
 		method="post"
 	>

--- a/web/templates/pages/edit_mail.php
+++ b/web/templates/pages/edit_mail.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -23,7 +23,7 @@
 			letsEncryptEnabled: <?= $v_letsencrypt == "yes" ? "true" : "false" ?>,
 			hasSmtpRelay: <?= $v_smtp_relay == "true" ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_edit_mail"
 		method="post"
 		class="<?= $v_status ?> js-enable-inputs-on-submit"

--- a/web/templates/pages/edit_mail_acc.php
+++ b/web/templates/pages/edit_mail_acc.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			hasAutoReply: <?= $v_autoreply == "yes" ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_edit_mail_acc"
 		method="post"
 		class="<?= $v_status ?>"

--- a/web/templates/pages/edit_package.php
+++ b/web/templates/pages/edit_package.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -25,7 +25,7 @@
 			showDatabaseOptions: false,
 			showSystemOptions: false,
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_edit_package"
 		method="post"
 		class="<?= $v_status ?>"

--- a/web/templates/pages/edit_server.php
+++ b/web/templates/pages/edit_server.php
@@ -13,7 +13,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -38,7 +38,7 @@
 			showProtectionOptions: false,
 			showPolicyOptions: false,
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_configure_server"
 		method="post"
 	>

--- a/web/templates/pages/edit_server_bind9.php
+++ b/web/templates/pages/edit_server_bind9.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_dovecot.php
+++ b/web/templates/pages/edit_server_dovecot.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_httpd.php
+++ b/web/templates/pages/edit_server_httpd.php
@@ -10,7 +10,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -20,7 +20,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_mysql.php
+++ b/web/templates/pages/edit_server_mysql.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_nginx.php
+++ b/web/templates/pages/edit_server_nginx.php
@@ -10,7 +10,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -20,7 +20,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_pgsql.php
+++ b/web/templates/pages/edit_server_pgsql.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_php.php
+++ b/web/templates/pages/edit_server_php.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_server_service.php
+++ b/web/templates/pages/edit_server_service.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -17,7 +17,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_configure_server" method="post">
+	<form id="main-form" name="v_configure_server" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="save" value="save">
 

--- a/web/templates/pages/edit_user.php
+++ b/web/templates/pages/edit_user.php
@@ -33,7 +33,7 @@
 			<?php } ?>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -49,7 +49,7 @@
 			useIpAllowList: <?= $v_login_use_iplist === "yes" ? "true" : "false" ?>,
 			showAdvanced: false,
 		}"
-		id="vstobjects"
+		id="main-form"
 		method="post"
 		name="v_edit_user"
 		class="<?= $v_status ?>"

--- a/web/templates/pages/edit_web.php
+++ b/web/templates/pages/edit_web.php
@@ -15,7 +15,7 @@
 					<i class="fas fa-magic icon-blue"></i><?= _("Quick Install App") ?>
 				</a>
 			<?php } ?>
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -37,7 +37,7 @@
 			proxySupportEnabled: <?= !empty($v_proxy) ? "true" : "false" ?>,
 			customDocumentRootEnabled: <?= !empty($v_custom_doc_root) ? "true" : "false" ?>
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_edit_web"
 		method="post"
 		class="<?= $v_status ?> js-enable-inputs-on-submit"

--- a/web/templates/pages/edit_whitelabel.php
+++ b/web/templates/pages/edit_whitelabel.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -21,7 +21,7 @@
 		x-data="{
 			hide_docs: '<?= $v_hide_docs ?? "no" ?>',
 		}"
-		id="vstobjects"
+		id="main-form"
 		name="v_configure_server"
 		method="post"
 	>

--- a/web/templates/pages/generate_ssl.php
+++ b/web/templates/pages/generate_ssl.php
@@ -8,7 +8,7 @@
 
 <div class="container animate__animated animate__fadeIn">
 
-	<form id="vstobjects" name="v_generate_csr" method="post">
+	<form id="main-form" name="v_generate_csr" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 		<input type="hidden" name="generate" value="generate">
 

--- a/web/templates/pages/list_access_key.php
+++ b/web/templates/pages/list_access_key.php
@@ -21,7 +21,7 @@ if (!empty($_POST["ok"])) { ?>
 <!-- End toolbar -->
 
 <div class="container animate__animated animate__fadeIn">
-	<form id="vstobjects">
+	<form id="main-form">
 
 		<div class="form-container">
 			<h1 class="u-mb20"><?= _("Access Key") ?></h1>

--- a/web/templates/pages/list_ssl.php
+++ b/web/templates/pages/list_ssl.php
@@ -9,7 +9,7 @@
 
 <!-- Begin form -->
 <div class="container animate__animated animate__fadeIn">
-	<form id="vstobjects" name="v_generate_csr" method="post">
+	<form id="main-form" name="v_generate_csr" method="post">
 		<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 
 		<div class="form-container">

--- a/web/templates/pages/setup_webapp.php
+++ b/web/templates/pages/setup_webapp.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<button type="submit" class="button" form="vstobjects">
+			<button type="submit" class="button" form="main-form">
 				<i class="fas fa-floppy-disk icon-purple"></i><?= _("Save") ?>
 			</button>
 		</div>
@@ -19,7 +19,7 @@
 <div class="container animate__animated animate__fadeIn">
 
 	<?php if (!empty($WebappInstaller->getOptions())) { ?>
-		<form id="vstobjects" method="POST" name="v_setup_webapp">
+		<form id="main-form" method="POST" name="v_setup_webapp">
 			<input type="hidden" name="token" value="<?= $_SESSION["token"] ?>">
 			<input type="hidden" name="ok" value="true">
 


### PR DESCRIPTION
The "vstobjects" ID is found across the UI on each main form of an edit/add page, but is only used for two things:
1. To allow the "Save" buttons located outside the form element, to target the form with [form attribute](https://www.w3schools.com/tags/att_form.asp)
2. To target with JavaScript the main form on the page (rather than other forms that may exist on the page like search etc.)

Therefore, it can be easily renamed. "vstobjects" is odd with little meaning to me. "main-form" makes sense to me.