### PR TITLE
Feature/nextcloud update

### DIFF
--- a/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
+++ b/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
@@ -77,9 +77,9 @@ class NextcloudSetup extends BaseSetup {
 		array_push($result->raw, "memory_limit=512M");
 		$tmp = $this->saveTempFile(implode("\r\n", $result->raw));
 		if (!$this->appcontext->runUser("v-move-fs-file", [$tmp, $file], $result)) {
-				throw new \Exception("Error updating file in: " . $tmp . " " . $result->text);
+			throw new \Exception("Error updating file in: " . $tmp . " " . $result->text);
 		}
-		
+
 		return $status->code === 0;
 	}
 }

--- a/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
+++ b/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
@@ -29,7 +29,7 @@ class NextcloudSetup extends BaseSetup {
 				"template" => "owncloud",
 			],
 			"php" => [
-				"supported" => ["7.4", "8.0", "8.1"],
+				"supported" => ["8.0", "8.1", "8.2"],
 			],
 		],
 	];

--- a/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
+++ b/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
@@ -69,6 +69,17 @@ class NextcloudSetup extends BaseSetup {
 			],
 			$status,
 		);
+
+		// Bump minimum memory limit to 512M
+		$result = null;
+		$file = $this->getDocRoot(".user.ini");
+		$this->appcontext->runUser("v-open-fs-file", [$file], $result);
+		array_push($result->raw, "memory_limit=512M");
+		$tmp = $this->saveTempFile(implode("\r\n", $result->raw));
+		if (!$this->appcontext->runUser("v-move-fs-file", [$tmp, $file], $result)) {
+				throw new \Exception("Error updating file in: " . $tmp . " " . $result->text);
+		}
+		
 		return $status->code === 0;
 	}
 }


### PR DESCRIPTION
This addresses a couple key issues for a better (and working out-of-the-box) Nextcloud experience:

1) Bump install req. to php 8, otherwise the current installer fails and setup credentials are lost.
2) Fix Nextcloud's warning for a minimum of 512M memory; we simply append to .user.ini and Hestia does the rest.

