### PR TITLE
[nginx/templates] Add WordPress Multisite subdir support

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/wordpress_mu_subdir.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress_mu_subdir.stpl
@@ -1,0 +1,100 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://hestiacp.com/docs/server-administration/web-templates.html      #
+#=========================================================================#
+
+server {
+	listen      %ip%:%web_ssl_port% ssl;
+	server_name %domain_idn% %alias_idn%;
+	root        %sdocroot%;
+	index       index.php index.html index.htm;
+	access_log  /var/log/nginx/domains/%domain%.log combined;
+	access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+	error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+	# Rewrite requests to /wp-.* on subdirectory installs.
+	if (!-e $request_filename) {
+		rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
+	}
+
+	ssl_certificate     %ssl_pem%;
+	ssl_certificate_key %ssl_key%;
+	ssl_stapling        on;
+	ssl_stapling_verify on;
+
+	# TLS 1.3 0-RTT anti-replay
+	if ($anti_replay = 307) { return 307 https://$host$request_uri; }
+	if ($anti_replay = 425) { return 425; }
+
+	include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /robots.txt {
+		allow all;
+		log_not_found off;
+		access_log off;
+	}
+
+	location ~ /\.(?!well-known\/) {
+		deny all;
+		return 404;
+	}
+
+	location / {
+		try_files $uri $uri/ /index.php?$args;
+
+		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
+			expires 30d;
+			fastcgi_hide_header "Set-Cookie";
+		}
+
+		location ~* /(?:uploads|files)/.*.php$ {
+			deny all;
+			return 404;
+		}
+
+		location ~ [^/]\.php(/|$) {
+			try_files $uri =404;
+
+			include /etc/nginx/fastcgi_params;
+
+			fastcgi_index index.php;
+			fastcgi_param HTTP_EARLY_DATA $rfc_early_data if_not_empty;
+			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+			fastcgi_pass %backend_lsnr%;
+
+			include %home%/%user%/conf/web/%domain%/nginx.fastcgi_cache.conf*;
+
+			if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
+				set $no_cache 1;
+			}
+
+			if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {
+				set $no_cache 1;
+			}
+		}
+	}
+
+	location /error/ {
+		alias %home%/%user%/web/%domain%/document_errors/;
+	}
+
+	location /vstats/ {
+		alias   %home%/%user%/web/%domain%/stats/;
+		include %home%/%user%/web/%domain%/stats/auth.conf*;
+	}
+
+	proxy_hide_header Upgrade;
+
+	include /etc/nginx/conf.d/phpmyadmin.inc*;
+	include /etc/nginx/conf.d/phppgadmin.inc*;
+	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+}

--- a/install/deb/templates/web/nginx/php-fpm/wordpress_mu_subdir.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress_mu_subdir.tpl
@@ -1,0 +1,88 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://hestiacp.com/docs/server-administration/web-templates.html      #
+#=========================================================================#
+
+server {
+	listen      %ip%:%web_port%;
+	server_name %domain_idn% %alias_idn%;
+	root        %docroot%;
+	index       index.php index.html index.htm;
+	access_log  /var/log/nginx/domains/%domain%.log combined;
+	access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+	error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+	# Rewrite requests to /wp-.* on subdirectory installs.
+	if (!-e $request_filename) {
+		rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
+	}
+
+	include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /robots.txt {
+		allow all;
+		log_not_found off;
+		access_log off;
+	}
+
+	location ~ /\.(?!well-known\/) {
+		deny all;
+		return 404;
+	}
+
+	location / {
+		try_files $uri $uri/ /index.php?$args;
+
+		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
+			expires 30d;
+			fastcgi_hide_header "Set-Cookie";
+		}
+
+		location ~* /(?:uploads|files)/.*.php$ {
+			deny all;
+			return 404;
+		}
+
+		location ~ [^/]\.php(/|$) {
+			try_files $uri =404;
+
+			include /etc/nginx/fastcgi_params;
+
+			fastcgi_index index.php;
+			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+			fastcgi_pass %backend_lsnr%;
+
+			include %home%/%user%/conf/web/%domain%/nginx.fastcgi_cache.conf*;
+
+			if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
+				set $no_cache 1;
+			}
+
+			if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {
+				set $no_cache 1;
+			}
+		}
+	}
+
+	location /error/ {
+		alias %home%/%user%/web/%domain%/document_errors/;
+	}
+
+	location /vstats/ {
+		alias   %home%/%user%/web/%domain%/stats/;
+		include %home%/%user%/web/%domain%/stats/auth.conf*;
+	}
+
+	include /etc/nginx/conf.d/phpmyadmin.inc*;
+	include /etc/nginx/conf.d/phppgadmin.inc*;
+	include %home%/%user%/conf/web/%domain%/nginx.conf_*;
+}

--- a/install/rpm/templates/web/nginx/php-fpm/wordpress_mu_subdir.stpl
+++ b/install/rpm/templates/web/nginx/php-fpm/wordpress_mu_subdir.stpl
@@ -1,0 +1,100 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://hestiacp.com/docs/server-administration/web-templates.html      #
+#=========================================================================#
+
+server {
+	listen      %ip%:%web_ssl_port% ssl;
+	server_name %domain_idn% %alias_idn%;
+	root        %sdocroot%;
+	index       index.php index.html index.htm;
+	access_log  /var/log/nginx/domains/%domain%.log combined;
+	access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+	error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+	# Rewrite requests to /wp-.* on subdirectory installs.
+	if (!-e $request_filename) {
+		rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
+	}
+
+	ssl_certificate     %ssl_pem%;
+	ssl_certificate_key %ssl_key%;
+	ssl_stapling        on;
+	ssl_stapling_verify on;
+
+	# TLS 1.3 0-RTT anti-replay
+	if ($anti_replay = 307) { return 307 https://$host$request_uri; }
+	if ($anti_replay = 425) { return 425; }
+
+	include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /robots.txt {
+		allow all;
+		log_not_found off;
+		access_log off;
+	}
+
+	location ~ /\.(?!well-known\/) {
+		deny all;
+		return 404;
+	}
+
+	location / {
+		try_files $uri $uri/ /index.php?$args;
+
+		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
+			expires 30d;
+			fastcgi_hide_header "Set-Cookie";
+		}
+
+		location ~* /(?:uploads|files)/.*.php$ {
+			deny all;
+			return 404;
+		}
+
+		location ~ [^/]\.php(/|$) {
+			try_files $uri =404;
+
+			include /etc/nginx/fastcgi_params;
+
+			fastcgi_index index.php;
+			fastcgi_param HTTP_EARLY_DATA $rfc_early_data if_not_empty;
+			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+			fastcgi_pass %backend_lsnr%;
+
+			include %home%/%user%/conf/web/%domain%/nginx.fastcgi_cache.conf*;
+
+			if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
+				set $no_cache 1;
+			}
+
+			if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {
+				set $no_cache 1;
+			}
+		}
+	}
+
+	location /error/ {
+		alias %home%/%user%/web/%domain%/document_errors/;
+	}
+
+	location /vstats/ {
+		alias   %home%/%user%/web/%domain%/stats/;
+		include %home%/%user%/web/%domain%/stats/auth.conf*;
+	}
+
+	proxy_hide_header Upgrade;
+
+	include /etc/nginx/conf.d/phpmyadmin.inc*;
+	include /etc/nginx/conf.d/phppgadmin.inc*;
+	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+}

--- a/install/rpm/templates/web/nginx/php-fpm/wordpress_mu_subdir.tpl
+++ b/install/rpm/templates/web/nginx/php-fpm/wordpress_mu_subdir.tpl
@@ -1,0 +1,88 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://hestiacp.com/docs/server-administration/web-templates.html      #
+#=========================================================================#
+
+server {
+	listen      %ip%:%web_port%;
+	server_name %domain_idn% %alias_idn%;
+	root        %docroot%;
+	index       index.php index.html index.htm;
+	access_log  /var/log/nginx/domains/%domain%.log combined;
+	access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+	error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+	# Rewrite requests to /wp-.* on subdirectory installs.
+	if (!-e $request_filename) {
+		rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
+	}
+
+	include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /robots.txt {
+		allow all;
+		log_not_found off;
+		access_log off;
+	}
+
+	location ~ /\.(?!well-known\/) {
+		deny all;
+		return 404;
+	}
+
+	location / {
+		try_files $uri $uri/ /index.php?$args;
+
+		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
+			expires 30d;
+			fastcgi_hide_header "Set-Cookie";
+		}
+
+		location ~* /(?:uploads|files)/.*.php$ {
+			deny all;
+			return 404;
+		}
+
+		location ~ [^/]\.php(/|$) {
+			try_files $uri =404;
+
+			include /etc/nginx/fastcgi_params;
+
+			fastcgi_index index.php;
+			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+			fastcgi_pass %backend_lsnr%;
+
+			include %home%/%user%/conf/web/%domain%/nginx.fastcgi_cache.conf*;
+
+			if ($request_uri ~* "/wp-admin/|/wp-json/|wp-.*.php|xmlrpc.php|index.php|/store.*|/cart.*|/my-account.*|/checkout.*") {
+				set $no_cache 1;
+			}
+
+			if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart|woocommerce_cart_hash|PHPSESSID") {
+				set $no_cache 1;
+			}
+		}
+	}
+
+	location /error/ {
+		alias %home%/%user%/web/%domain%/document_errors/;
+	}
+
+	location /vstats/ {
+		alias   %home%/%user%/web/%domain%/stats/;
+		include %home%/%user%/web/%domain%/stats/auth.conf*;
+	}
+
+	include /etc/nginx/conf.d/phpmyadmin.inc*;
+	include /etc/nginx/conf.d/phppgadmin.inc*;
+	include %home%/%user%/conf/web/%domain%/nginx.conf_*;
+}


### PR DESCRIPTION
This collides with https://github.com/hestiacp/hestiacp/pull/3739

I'll rebase and push after #3739 goes in.

The code in question is

```
	# Rewrite requests to /wp-.* on subdirectory installs.
	if (!-e $request_filename) {
		rewrite /wp-admin$ $scheme://$host$uri/ permanent;
		rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
		rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
	}
```