### PR TITLE
[v-dump-*] Filename readability improvement / Add timestamp to v-dump-database

### DIFF
--- a/bin/v-dump-database
+++ b/bin/v-dump-database
@@ -39,6 +39,9 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
+# Create timestamp in Y-M-D_h-m-s format
+timestamp=$(date +'%G-%m-%d_%H-%M-%S')
+
 # Check db existence
 db_data=$(grep "DB='$database'" $HESTIA/data/users/$user/db.conf)
 if [ -z "$db_data" ]; then
@@ -61,10 +64,16 @@ case $TYPE in
 esac
 
 if [ "$output" = "file" ]; then
-	cp $dump $BACKUP/$user.$database.$TYPE.sql
-	echo $BACKUP/$user.$database.$TYPE.sql
+	# echo filename for use in the php
+	echo "${user}_${database}_${TYPE}_${timestamp}.sql"
 
-	echo "rm $BACKUP/$user.$database.$TYPE.sql" | at now + 1 hour
+	cp $dump $BACKUP/${user}_${database}_${TYPE}_${timestamp}.sql
+
+	# echo file location for use in the php
+	echo "$BACKUP/${user}_${database}_${TYPE}_${timestamp}.sql"
+
+	# cleanup
+	echo "rm $BACKUP/${user}_${database}_${TYPE}_${timestamp}.sql" | at now + 1 hour
 else
 	cat $dump
 fi

--- a/bin/v-dump-site
+++ b/bin/v-dump-site
@@ -40,20 +40,23 @@ check_hestia_demo_mode
 # Create timestamp in Y-M-D_h-m-s format
 timestamp=$(date +'%G-%m-%d_%H-%M-%S')
 
-# echo filename for use in the php
-echo "$user.$domain.$timestamp.zip"
-
 if [ "$type" = "full" ]; then
 	cd /home/$user/web/$domain/
 else
 	cd /home/$user/web/$domain/public_html/
 fi
 
-zip -rq $BACKUP/$user.$domain.$timestamp.zip .
+zip -rq $BACKUP/${user}_${domain}_${timestamp}.zip .
 
-if [[ -f "$BACKUP/$user.$domain.$timestamp.zip" ]]; then
-	echo "$BACKUP/$user.$domain.$timestamp.zip"
-	echo "rm $BACKUP/$user.$domain.$timestamp.zip" | at now + 1 hour
+if [[ -f "$BACKUP/${user}_${domain}_${timestamp}.zip" ]]; then
+	# echo filename for use in the php
+	echo "${user}_${domain}_${timestamp}.zip"
+
+	# echo file location for use in the php
+	echo "$BACKUP/${user}_${domain}_${timestamp}.zip"
+
+	# cleanup
+	echo "rm $BACKUP/${user}_${domain}_${timestamp}.zip" | at now + 1 hour
 fi
 
 #----------------------------------------------------------#

--- a/web/download/database/index.php
+++ b/web/download/database/index.php
@@ -13,6 +13,6 @@ exec(HESTIA_CMD . "v-dump-database " . $user . " " . $database . " file", $outpu
 
 if ($return_var == 0) {
 	header("Content-type: application/sql");
-	header("Content-Disposition: attachment; filename=\"" . $_GET["database"] . ".sql\";");
-	header("X-Accel-Redirect: " . $output[0]);
+	header("Content-Disposition: attachment; filename=" . $output[0]);
+	header("X-Accel-Redirect: " . $output[1]);
 }


### PR DESCRIPTION
Follow up to https://github.com/hestiacp/hestiacp/pull/3808

Realized `.`isn't the best separator for filename fields.