### PR TITLE
Add update-dns-record api permission

### DIFF
--- a/install/common/api/update-dns-records
+++ b/install/common/api/update-dns-records
@@ -1,0 +1,2 @@
+ROLE='user'
+COMMANDS='v-list-dns-records,v-change-dns-record'

--- a/install/upgrade/versions/1.8.3.sh
+++ b/install/upgrade/versions/1.8.3.sh
@@ -22,3 +22,9 @@ upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
+# Add new API key permission
+if [ -f "$HESTIA/data/api/update-dns-records" ]; then
+	rm $HESTIA/data/api/update-dns-records
+fi
+cp $HESTIA/install/common/api/update-dns-records $HESTIA/data/api/update-dns-records


### PR DESCRIPTION
I wanted to be able to use Hestia as a DDNS provider, so I added an API permission for it. I think that's the only thing I need to add? If @jaapmarcus can confirm, that'd be great!