### PR TITLE
Mostly rename web backend to php interpreter

### DIFF
--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -86,9 +86,9 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-# Restart backend server
+# Restart php interpreter
 $BIN/v-restart-web-backend "$restart" "$backend_version"
-check_result $? "Web backend restart failed" > /dev/null
+check_result $? "PHP restart failed" > /dev/null
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Web" "Web domain configuration applied (Domain: $domain, Backend: $WEB_BACKEND)."

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -177,7 +177,7 @@ if [ "$version" != "$backend_version" ]; then
 	$BIN/v-restart-web-backend "$restart" "$backend_version"
 fi
 
-check_result $? "Web backend restart failed" > /dev/null
+check_result $? "PHP restart failed" > /dev/null
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Web" "Backend template applied (Domain: $domain, Template: $template)."

--- a/bin/v-delete-web-domain
+++ b/bin/v-delete-web-domain
@@ -145,16 +145,16 @@ else
 	version=$(multiphp_default_version)
 fi
 # Restarting web server
-$BIN/v-restart-web "$restart" 
+$BIN/v-restart-web "$restart"
 check_result $? "Web restart failed" > /dev/null
 
 # Restarting proxy server
 $BIN/v-restart-proxy "$restart"
 check_result $? "Proxy restart failed" > /dev/null
 
-# Restarting backend server
+# Restarting php interpreter
 $BIN/v-restart-web-backend "$restart" "$version"
-check_result $? "Backend restart failed" > /dev/null
+check_result $? "PHP restart failed" > /dev/null
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Web" "Deleted web domain (Name: $domain)."

--- a/bin/v-delete-web-domain-backend
+++ b/bin/v-delete-web-domain-backend
@@ -84,9 +84,9 @@ if [[ $BACKEND =~ ^.*PHP-([0-9])\_([0-9])$ ]]; then
 else
 	version=$(multiphp_default_version)
 fi
-# Restarting backend server
+# Restarting php interpreter
 $BIN/v-restart-web-backend "$restart" "$version"
-check_result $? "Backend restart failed" > /dev/null
+check_result $? "PHP restart failed" > /dev/null
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Web" "Web domain configuration deleted (Domain: $domain)."

--- a/bin/v-list-sys-config
+++ b/bin/v-list-sys-config
@@ -124,7 +124,7 @@ shell_list() {
 		echo "SSL Support:                      $WEB_SSL:$WEB_SSL_PORT"
 	fi
 	if [ -n "$WEB_BACKEND" ]; then
-		echo "Web Backend:                      $WEB_BACKEND"
+		echo "PHP Intepreter:                   $WEB_BACKEND"
 	fi
 	if [ -n "$PROXY_SYSTEM" ]; then
 		echo "Proxy Server:                     $PROXY_SYSTEM:$PROXY_PORT"

--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -162,14 +162,14 @@ if [ -n "$WEB_SYSTEM" ] && [ "$WEB_SYSTEM" != 'remote' ]; then
 	data="$data MEM='$mem' RTIME='$rtime'"
 fi
 
-# Checking WEB Backend
+# Checking PHP intepreter
 if [ -n "$WEB_BACKEND" ] && [ "$WEB_BACKEND" != 'remote' ]; then
 	php_versions=$(ls /usr/sbin/php*fpm* | cut -d'/' -f4 | sed 's|php-fpm||')
 	for version in $php_versions; do
 		proc_name="php-fpm${version}"
 		service_name="php${version}-fpm"
 		get_srv_state "$proc_name"
-		data="$data\nNAME='$service_name' SYSTEM='backend server' STATE='$state'"
+		data="$data\nNAME='$service_name' SYSTEM='php interpreter' STATE='$state'"
 		data="$data CPU='$cpu' MEM='$mem' RTIME='$rtime'"
 	done
 fi

--- a/bin/v-restart-web-backend
+++ b/bin/v-restart-web-backend
@@ -1,10 +1,10 @@
 #!/bin/bash
-# info: restart backend server
+# info: restart php interpreter
 # options: NONE
 #
 # example: v-restart-web-backend
 #
-# This function reloads backend server configuration.
+# This function reloads php interpreter configuration.
 
 restart=$1
 # For backward compatibility might change in the feature

--- a/web/locale/hestiacp.pot
+++ b/web/locale/hestiacp.pot
@@ -4194,7 +4194,7 @@ msgid "Proxy Server"
 msgstr ""
 
 #: ../../web/templates/pages/edit_server.php:241
-msgid "Backend Server"
+msgid "PHP Interpreter"
 msgstr ""
 
 #: ../../web/templates/pages/edit_server.php:252
@@ -4735,7 +4735,7 @@ msgid "web server"
 msgstr ""
 
 #: ../../bin/v-list-sys-services:172
-msgid "backend server"
+msgid "php interpreter"
 msgstr ""
 
 #: ../../bin/v-list-sys-services:180

--- a/web/templates/pages/edit_server.php
+++ b/web/templates/pages/edit_server.php
@@ -238,7 +238,7 @@
 					<?php } ?>
 					<?php if (!empty($_SESSION["WEB_BACKEND"])) { ?>
 						<p>
-							<?= _("Backend Server") ?>:
+							<?= _("PHP Interpreter") ?>:
 							<span class="u-ml5">
 								<?= $_SESSION["WEB_BACKEND"] ?>
 							</span>


### PR DESCRIPTION
This PR renames most of the string instances of `web backend` to `php interpreter` for better accuracy. I didn't rename variables to prevent potential issues.