### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,14 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"reviewers": ["jaapmarcus"],
+	"extends": [
+		"config:best-practices",
+		":pinAllExceptPeerDependencies",
+		":disableDependencyDashboard",
+		"group:allNonMajor",
+		"schedule:earlyMondays"
+	],
 	"enabledManagers": ["npm", "composer", "github-actions"],
 	"ignorePaths": ["**/node_modules/**", "install/deb/filemanager/filegator/composer.json"],
-	"branchPrefix": "dependencies",
-	"bumpVersion": "patch",
-	"extends": ["config:recommended", "group:allNonMajor", "schedule:earlyMondays"]
+	"reviewers": ["jaapmarcus"],
+	"branchPrefix": "dependencies"
 }


### PR DESCRIPTION
The config is now based on `config:best-practices` so that it pins dependencies, ensuring they don't update without us intending it. It also disables the Dependency Dashboard, since we won't use it. I removed [`bumpVersion`](https://docs.renovatebot.com/configuration-options/#bumpversion) from the config, because it wasn't actually what we thought it was. It's to update the `version` field in `package.json`, not to force it to bump the version of dependencies.