### PR TITLE
fix/Add missing v-restart-mail to v-update-mail-domain-ssl

### DIFF
--- a/bin/v-update-mail-domain-ssl
+++ b/bin/v-update-mail-domain-ssl
@@ -85,6 +85,10 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
+# Restarting mail server
+$BIN/v-restart-mail "$restart"
+check_result $? "Mail restart failed" > /dev/null
+
 # Restarting web server
 $BIN/v-restart-web "$restart"
 check_result $? "Web restart failed" > /dev/null


### PR DESCRIPTION
v-update-mail-domain-ssl command only restarts web and proxy but not mail server.