### PR TITLE
Renovate: Group some dependencies and fix branch prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,22 @@
 		"group:allNonMajor",
 		"schedule:weekdays"
 	],
+	"packageRules": [
+		{
+			"groupName": "Linters",
+			"matchPackagePrefixes": ["@prettier/", "prettier"]
+		},
+		{
+			"groupName": "ESLint",
+			"extends": ["packages:eslint"]
+		},
+		{
+			"groupName": "StyleLint",
+			"extends": ["packages:stylelint"]
+		}
+	],
 	"enabledManagers": ["npm", "composer", "github-actions"],
 	"ignorePaths": ["**/node_modules/**", "install/deb/filemanager/filegator/composer.json"],
 	"reviewers": ["jaapmarcus", "krismkenn"],
-	"branchPrefix": "dependencies"
+	"branchPrefix": "dependencies/"
 }


### PR DESCRIPTION
This PR groups some packages together for better PRs by Renovate and also fixes its branch prefix.

It will now group:
- Prettier and its plugins
- ESLint and its plugins
- StyleLint and its plugins