### PR TITLE
Prevent double logging when return_hash is requested

### DIFF
--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -95,7 +95,9 @@ if [ "$method" = "yescrypt" ]; then
 
 	if [ $? -ne 0 ]; then
 		echo "Error: password missmatch"
-		echo "$date $time $user $ip46 failed to login" >> $HESTIA/log/auth.log
+		if [ -z "$return_hash" ]; then
+			echo "$date $time $user $ip46 failed to login" >> $HESTIA/log/auth.log
+		fi
 		exit 9
 	fi
 else
@@ -104,7 +106,9 @@ else
 	hash=$($BIN/v-generate-password-hash "$method" "$salt" <<< "$password")
 	if [[ -z "$hash" ]]; then
 		echo "Error: password missmatch"
-		echo "$date $time $user $ip46 failed to login" >> $HESTIA/log/auth.log
+		if [ -z "$return_hash" ]; then
+			echo "$date $time $user $ip46 failed to login" >> $HESTIA/log/auth.log
+		fi
 		exit 9
 	fi
 fi
@@ -113,7 +117,9 @@ fi
 result=$(grep "^$user:$hash:" /etc/shadow 2> /dev/null)
 if [[ -z "$result" ]]; then
 	echo "Error: password missmatch"
-	echo "$date $time $user $ip46 failed to login" >> $HESTIA/log/auth.log
+	if [ -z "$return_hash" ]; then
+		echo "$date $time $user $ip46 failed to login" >> $HESTIA/log/auth.log
+	fi
 	exit 9
 fi
 
@@ -123,8 +129,9 @@ fi
 
 if [ -n "$return_hash" ]; then
 	echo $hash
+else
+	# If return_hash is pressent it will log a second time
+	echo "$date $time $user $ip46 successfully logged in" >> $HESTIA/log/auth.log
 fi
-# Logging
-echo "$date $time $user $ip46 successfully logged in" >> $HESTIA/log/auth.log
 
 exit


### PR DESCRIPTION
Both https://github.com/hestiacp/hestiacp/blob/60362d46a983f231a8d8f7d0d4f334a2e1a74e11/web/login/index.php#L161-L171 and

https://github.com/hestiacp/hestiacp/blob/60362d46a983f231a8d8f7d0d4f334a2e1a74e11/web/login/index.php#L187-L192

Used to log failed / successful login if yescrypt is used