### PR TITLE
Nitpicking bin/v-generate-password-hash

### DIFF
--- a/bin/v-generate-password-hash
+++ b/bin/v-generate-password-hash
@@ -36,7 +36,7 @@ if ($crypt == 'md5' ) {
 } elseif ($crypt == 'des' ) {
     $hash = crypt($password, $salt);
 } else {
-    fwrite(STDERR, "Argument #1 (HASH_METHOD) is invalid. It must be one of 'md5', 'sha-512', 'htpasswd', 'des'\n");
+    fwrite(STDERR, "Error: argument #1 (HASH_METHOD) is invalid. It must be one of 'md5', 'sha-512', 'htpasswd', 'des'\n");
     exit(1);
 }
 

--- a/bin/v-generate-password-hash
+++ b/bin/v-generate-password-hash
@@ -10,8 +10,9 @@
 
 // Checking arguments
 if ((empty($argv[1])) || (empty($argv[2]))) {
-    echo "Error: not enought arguments\n";
-    echo "Usage: " . $argv[0] ." HASH_METHOD SALT PASSWORD\n";
+    $errstr = "Error: not enought arguments\n";
+    $errstr .= "Usage: " . $argv[0] ." HASH_METHOD SALT PASSWORD (or the password can be sent in STDIN)\n";
+    fwrite(STDERR, $errstr);
     exit(1);
 }
 
@@ -19,7 +20,7 @@ $crypt = $argv[1];
 $salt = $argv[2];
 if (empty($argv[3])) {
     $password = file_get_contents("php://stdin");
-    $password = str_replace("\n",'',$password);
+    $password = str_replace("\n", '', $password);
 } else {
     $password = $argv[3];
 }
@@ -27,22 +28,16 @@ if (empty($argv[3])) {
 // Generating MD5 hash
 if ($crypt == 'md5' ) {
     $hash = crypt($password,  '$1$'.$salt.'$');
-}
-
-// Generating SHA-512 hash
-if ($crypt == 'sha-512' ) {
+} elseif ($crypt == 'sha-512' ) {
     $hash = crypt($password,  '$6$rounds=5000$'.$salt.'$');
     $hash = str_replace('$rounds=5000','',$hash);
-}
-
-// Generating base64 hash
-if ($crypt == 'htpasswd' ) {
+} elseif ($crypt == 'htpasswd' ) {
     $hash = crypt($password, base64_encode($password));
-}
-
-// Generating DES hash
-if ($crypt == 'des' ) {
+} elseif ($crypt == 'des' ) {
     $hash = crypt($password, $salt);
+} else {
+    fwrite(STDERR, "Argument #1 (HASH_METHOD) is invalid. It must be one of 'md5', 'sha-512', 'htpasswd', 'des'\n");
+    exit(1);
 }
 
 // Printing result


### PR DESCRIPTION
some errors were sent in stdout, this is a problem because in other parts of HestiaCP, for example in v-check-user-password, we just check if it printed anything at all in stdout, like
```
hash=$($BIN/v-generate-password-hash "$method" "$salt" <<< "$password")
	if [[ -z "$hash" ]]; then
		echo "Error: password missmatch"
```


also made sure we print an error message and return exit code 1 (error)  if the HASH_METHOD is invalid