### PR TITLE
Fix removeunnecessary line v-add-web-domain

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -94,8 +94,10 @@ check_hestia_demo_mode
 # Reading user values
 source_conf "$USER_DATA/user.conf"
 
+[[ -L "$HOMEDIR/$user/web/$domain" ]] && check_result "$E_EXISTS" "Web domain folder for $domain should not exist"
+
 # Creating domain directories
-mkdir -p $HOMEDIR/$user/web/$domain
+mkdir $HOMEDIR/$user/web/$domain
 chown $user:$user $HOMEDIR/$user/web/$domain
 $BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/public_html"
 $BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/document_errors"

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -94,8 +94,6 @@ check_hestia_demo_mode
 # Reading user values
 source_conf "$USER_DATA/user.conf"
 
-[[ -e "$HOMEDIR/$user/web/$domain" ]] && check_result "$E_EXISTS" "Web domain folder for $domain should not exist"
-
 # Creating domain directories
 mkdir $HOMEDIR/$user/web/$domain
 chown $user:$user $HOMEDIR/$user/web/$domain

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -95,7 +95,7 @@ check_hestia_demo_mode
 source_conf "$USER_DATA/user.conf"
 
 # Creating domain directories
-mkdir $HOMEDIR/$user/web/$domain
+mkdir -p $HOMEDIR/$user/web/$domain
 chown $user:$user $HOMEDIR/$user/web/$domain
 $BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/public_html"
 $BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/document_errors"


### PR DESCRIPTION
Just a small fix. The line is unnecesary, and isn't correct.
"-e" is a condition for file and not directory (-d), and if it will be true (exists as file) then will be exit with false info.
And the next line will create without condition, therefore I deleted the check.