### PR TITLE
fix/use v-list-sys-sshd-port to check custom ssh port#3921

### DIFF
--- a/bin/v-add-firewall-chain
+++ b/bin/v-add-firewall-chain
@@ -56,8 +56,8 @@ heal_iptables_links
 
 # Checking known chains
 case $chain in
-        SSH) # Get ssh port using v-list-sys-sshd-port.
-                sshport="$($BIN/v-list-sys-sshd-port plain)"
+        SSH) # Get ssh port (or ports) using v-list-sys-sshd-port.
+                sshport="$($BIN/v-list-sys-sshd-port plain | sed ':a;N;$!ba;s/\n/,/g')"
 		if [ -z "$sshport" ]; then
 			sshport=22
 		fi

--- a/bin/v-add-firewall-chain
+++ b/bin/v-add-firewall-chain
@@ -56,8 +56,8 @@ heal_iptables_links
 
 # Checking known chains
 case $chain in
-	SSH) # Get ssh port by reading ssh config file.
-		sshport=$(grep '^Port ' /etc/ssh/sshd_config | head -1 | cut -d ' ' -f 2)
+        SSH) # Get ssh port using v-list-sys-sshd-port.
+                sshport="$($BIN/v-list-sys-sshd-port plain)"
 		if [ -z "$sshport" ]; then
 			sshport=22
 		fi

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -62,8 +62,9 @@ fi
 
 # Checking custom OpenSSH port (or ports)
 sshport="$($BIN/v-list-sys-sshd-port plain | sed ':a;N;$!ba;s/\n/,/g')"
-if echo "$sshport" | grep -E '^[0-9]+(,[0-9]+)*$' &>/dev/null && [[ "$sshport" -ne "22" ]]; then
-	sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
+if echo "$sshport" | grep -E '^[0-9]+(,[0-9]+)*$' &>/dev/null; then
+        sed -i -E "s/(PORT=')[0-9]+(,[0-9]+)*('.*COMMENT='SSH')/\1$sshport\3/" $rules
+        sed -i "/CHAIN='SSH'/c\CHAIN='SSH' PORT='$sshport' PROTOCOL='TCP'" "$HESTIA/data/firewall/chains.conf"
 fi
 
 # Load ipset lists before adding Hestia iptables rules

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -60,8 +60,8 @@ if [ $? -ne 0 ]; then
 	conntrack_ftp='no'
 fi
 
-# Checking custom OpenSSH  port
-sshport=$(grep '^Port ' /etc/ssh/sshd_config | head -1 | cut -d ' ' -f 2)
+# Checking custom OpenSSH port
+sshport="$($BIN/v-list-sys-sshd-port plain)"
 if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22" ]; then
 	sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
 fi

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -60,9 +60,9 @@ if [ $? -ne 0 ]; then
 	conntrack_ftp='no'
 fi
 
-# Checking custom OpenSSH port
-sshport="$($BIN/v-list-sys-sshd-port plain)"
-if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22" ]; then
+# Checking custom OpenSSH port (or ports)
+sshport="$($BIN/v-list-sys-sshd-port plain | sed ':a;N;$!ba;s/\n/,/g')"
+if echo "$sshport" | grep -E '^[0-9]+(,[0-9]+)*$' &>/dev/null && [[ "$sshport" -ne "22" ]]; then
 	sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
 fi
 


### PR DESCRIPTION
Modify `v-add-firewall-chain` and `v-update-firewall` to use `v-list-sys-sshd-port` instead of `grep sshd_config` file to check what is the used ssh port.