### PR TITLE
New override option O in install scripts to skip hestia existence check during the installation

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -81,6 +81,7 @@ help() {
   -p, --password          Set admin password
   -D, --with-debs         Path to Hestia debs
   -f, --force             Force installation
+  -O, --override          Override checks (dangerous!)
   -h, --help              Print this help
 
   Example: bash $0 -e demo@hestiacp.com -p p4ssw0rd --multiphp yes"
@@ -247,6 +248,7 @@ for arg; do
 		--username) args="${args}-u " ;;
 		--password) args="${args}-p " ;;
 		--force) args="${args}-f " ;;
+		--override) args="${args}-O " ;;
 		--with-debs) args="${args}-D " ;;
 		--help) args="${args}-h " ;;
 		*)
@@ -258,7 +260,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fh" Option; do
+while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fOh" Option; do
 	case $Option in
 		a) apache=$OPTARG ;;      # Apache
 		w) phpfpm=$OPTARG ;;      # PHP-FPM
@@ -288,6 +290,7 @@ while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fh" Option;
 		p) vpass=$OPTARG ;;       # Admin password
 		D) withdebs=$OPTARG ;;    # Hestia debs path
 		f) force='yes' ;;         # Force install
+		O) override='yes' ;;      # Override checks
 		h) help ;;                # Help
 		*) help ;;                # Print help (default)
 	esac
@@ -360,7 +363,7 @@ if [ "x$(id -u)" != 'x0' ]; then
 	check_result 1 "Script can be run executed only by root"
 fi
 
-if [ -d "/usr/local/hestia" ]; then
+if [ -d "/usr/local/hestia" -a -z "$override" ]; then
 	check_result 1 "Hestia install detected. Unable to continue"
 fi
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -81,6 +81,7 @@ help() {
   -p, --password          Set admin password
   -D, --with-debs         Path to Hestia debs
   -f, --force             Force installation
+  -O, --override          Override checks (dangerous!)
   -h, --help              Print this help
 
   Example: bash $0 -e demo@hestiacp.com -p p4ssw0rd --multiphp yes"
@@ -247,6 +248,7 @@ for arg; do
 		--username) args="${args}-u " ;;
 		--password) args="${args}-p " ;;
 		--force) args="${args}-f " ;;
+		--override) args="${args}-O " ;;
 		--with-debs) args="${args}-D " ;;
 		--help) args="${args}-h " ;;
 		*)
@@ -258,7 +260,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fh" Option; do
+while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fOh" Option; do
 	case $Option in
 		a) apache=$OPTARG ;;      # Apache
 		w) phpfpm=$OPTARG ;;      # PHP-FPM
@@ -288,6 +290,7 @@ while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fh" Option;
 		p) vpass=$OPTARG ;;       # Admin password
 		D) withdebs=$OPTARG ;;    # Hestia debs path
 		f) force='yes' ;;         # Force install
+		O) override='yes' ;;      # Override checks
 		h) help ;;                # Help
 		*) help ;;                # Print help (default)
 	esac
@@ -353,7 +356,7 @@ if [ "x$(id -u)" != 'x0' ]; then
 	check_result 1 "Script can be run executed only by root"
 fi
 
-if [ -d "/usr/local/hestia" ]; then
+if [ -d "/usr/local/hestia" -a -z "$override" ]; then
 	check_result 1 "Hestia install detected. Unable to continue"
 fi
 


### PR DESCRIPTION
Sometimes it is helpfully to deactivate the hestia existence check for development and debuging purposes. Installation scriptes do not have such option. To override hestia existence check, modification of installation scriptes is required.
The new override option 'O' for installation scripts deactivates hestia existence check without the modification of installation script by the user. The override option is deactivated by default and should be used only at own risk by advanced users.
In future also other overrides (not only hestia existence check) could be implemented by using of the 'O' override option.
