### PR TITLE
Fix: idn2: toAscii: A-label roundtrip failed

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -61,6 +61,13 @@ shell_list_ssl() {
 
 # Additional argument formatting
 format_domain_idn
+if [[ "$email" = *[![:ascii:]]* ]]; then
+	local=$(echo "$email" | cut -f1 -d'@')
+	email_domain=$(echo "$email" | cut -f2 -d'@')
+	email_domain_idn=$(idn2 --quiet $email_domain)
+	email="$local"@"$email_domain_idn"
+fi
+echo $email
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -61,9 +61,6 @@ shell_list_ssl() {
 
 # Additional argument formatting
 format_domain_idn
-if [[ "$email" = *[![:ascii:]]* ]]; then
-	email=$(idn2 --quiet $email)
-fi
 
 #----------------------------------------------------------#
 #                    Verifications                         #

--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -67,7 +67,6 @@ if [[ "$email" = *[![:ascii:]]* ]]; then
 	email_domain_idn=$(idn2 --quiet $email_domain)
 	email="$local"@"$email_domain_idn"
 fi
-echo $email
 
 #----------------------------------------------------------#
 #                    Verifications                         #


### PR DESCRIPTION
v-genereate-ssl-cert uses
```
if [[ "$email" = *[![:ascii:]]* ]]; then
	email=$(idn2 --quiet $email)
fi
```
This is not really needed and causes the listed error
