### PR TITLE
fix/update v-list-sys-services to avoid 0 min uptime on services with multiple pids

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -87,9 +87,9 @@ get_srv_state() {
 
 	# Searching related pids
 	if [ -z $3 ]; then
-		pids=$(pidof $name | tr ' ' '|')
+		pids=$(pidof -d '|' $name)
 	else
-		pids=$(pidof -x $name | tr ' ' '|')
+		pids=$(pidof -d '|' -x $name)
 	fi
 	if [ -z "$pids" ] && [ "$name" != 'nginx' ]; then
 		pids=$(pgrep $name | tr '\n' '|')
@@ -107,7 +107,7 @@ get_srv_state() {
 
 	# Checking pid
 	if [ -n "$pids" ]; then
-		pid=$(echo "$pids" | cut -f 1 -d '|')
+		pid=$(echo "$pids" | awk -F '|' '{print $NF}')
 		pids=${pids%|}
 		pids=$(egrep "$pids" $tmp_file)
 


### PR DESCRIPTION
This cames from this post: https://forum.hestiacp.com/t/php8-1-fpm-always-at-0min-in-uptime/10720/ 

Modify pidof command to use -d option to assign a delimiter so there is no need to use tr to change spaces by pipes.

In services with several pids, the script is taking the first pid in the list, but the first pid is the pid for last started process, not the main process so a lot of times you can see an uptime of 0 mins instead of the actual uptime for the main/master process. So, I've modified v-list-sys-services to get the last pid in the list instead of the first.