### PR TITLE
Update main.sh to raise characters limit in regex used by function is_fw_port_format_valid 

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -1038,8 +1038,8 @@ is_fw_port_format_valid() {
 			check_result "$E_INVALID" "invalid port format :: $1"
 		fi
 	else
-		if ! [[ "$1" =~ ^[0-9][-|,|:|0-9]{0,30}[0-9]$ ]]; then
-			check_result "$E_INVALID" "invalid port format :: $1"
+		if ! [[ "$1" =~ ^[0-9][-|,|:|0-9]{0,76}[0-9]$ ]]; then
+			check_result "$E_INVALID" "invalid port format and/or more than 78 chars used :: $1"
 		fi
 	fi
 }


### PR DESCRIPTION
This comes from this forum thread: https://forum.hestiacp.com/t/invalid-port-format/10749 

There is a limit of **30** characters (really **32** chars) and doesn't seem too much so I've tested it and raised the char limit till it breaks the Web UI table and the limit is **78** characters so I've raised the char limit used in regex by function _is_fw_port_format_valid_  to **76** (1 _number + 76 characters + 1 number_) so it takes **78** as the limit and doesn't break the web ui.

I've also changed the error message to say also that error could be because of the port list has more than 78 chars.  

