### PR TITLE
Update web/api/index.php to allow 13 arguments instead of 9

### DIFF
--- a/web/api/index.php
+++ b/web/api/index.php
@@ -51,7 +51,7 @@ function api_error($exit_code, $message, $hst_return, bool $add_log = false, $us
 /**
  * Legacy connection format using hash or user and password.
  *
- * @param array{user: string?, pass: string?, hash?: string, cmd: string, arg1?: string, arg2?: string, arg3?: string, arg4?: string, arg5?: string, arg6?: string, arg7?: string, arg8?: string, arg9?: string, returncode?: string} $request_data
+ * @param array{user: string?, pass: string?, hash?: string, cmd: string, arg1?: string, arg2?: string, arg3?: string, arg4?: string, arg5?: string, arg6?: string, arg7?: string, arg8?: string, arg9?: string, arg10?: string, arg11?: string, arg12?: string, arg13?: string, returncode?: string} $request_data
  * @return void
  * @return void
  */
@@ -164,7 +164,7 @@ function api_legacy(array $request_data) {
 
 	$hst_cmd = trim($request_data["cmd"] ?? "");
 	$hst_cmd_args = [];
-	for ($i = 1; $i <= 9; $i++) {
+	for ($i = 1; $i <= 13; $i++) {
 		if (isset($request_data["arg{$i}"])) {
 			$hst_cmd_args["arg{$i}"] = trim($request_data["arg{$i}"]);
 		}
@@ -212,7 +212,7 @@ function api_legacy(array $request_data) {
 /**
  * Connection using access key.
  *
- * @param array{access_key: string, secret_key: string, cmd: string, arg1?: string, arg2?: string, arg3?: string, arg4?: string, arg5?: string, arg6?: string, arg7?: string, arg8?: string, arg9?: string, returncode?: string} $request_data
+ * @param array{access_key: string, secret_key: string, cmd: string, arg1?: string, arg2?: string, arg3?: string, arg4?: string, arg5?: string, arg6?: string, arg7?: string, arg8?: string, arg9?: string, arg10?: string, arg11?: string, arg12?: string, arg13?: string, returncode?: string} $request_data
  * @return void
  */
 function api_connection(array $request_data) {
@@ -247,7 +247,7 @@ function api_connection(array $request_data) {
 	$hst_secret_access_key = trim($request_data["secret_key"] ?? "");
 	$hst_cmd = trim($request_data["cmd"] ?? "");
 	$hst_cmd_args = [];
-	for ($i = 1; $i <= 9; $i++) {
+	for ($i = 1; $i <= 13; $i++) {
 		if (isset($request_data["arg{$i}"])) {
 			$hst_cmd_args["arg{$i}"] = trim($request_data["arg{$i}"]);
 		}


### PR DESCRIPTION
Checking the max arguments an hestia command could use, I saw it is 12 (actually 13, see below).

```
$ grep -h '^# options: ' /usr/local/hestia/bin/* | sed 's/# options: //' | while read line;do echo "$line"| wc -w ;done | sort -n | tail -n1
12
```

And the winner is... `v-add-dns-domain`

`# options: USER DOMAIN IP [NS1] [NS2] [NS3] [NS4] [NS5] [NS6] [NS7] [NS8] [RESTART]`

But those options aren't all the options this command allows:

```
# Argument definition
user=$1
domain=$2
ip=$3
ns1=$4
ns2=$5
ns3=$6
ns4=$7
ns5=$8
ns6=$9
ns7=${10}
ns8=${11}
restart=${12}
dnssec=${13}
```
The options missed the last argument `[DNSSEC]`  so the actual arguments are **13**.

As web api only allows 9 arguments, I've raised it to 13.