### PR TITLE
Fix/v-add-sys-quota and v-delete-sys-quota

### DIFF
--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -82,11 +82,7 @@ if [ -n "$(quotaon -pa | grep " $mnt " | grep 'user\|group' | grep 'is off')" ];
 fi
 
 # Updating hestia.conf value
-if [ -z "$(grep DISK_QUOTA $HESTIA/conf/hestia.conf)" ]; then
-	echo "DISK_QUOTA='yes'" >> $HESTIA/conf/hestia.conf
-else
-	$BIN/v-change-sys-config-value "DISK_QUOTA" "yes"
-fi
+$BIN/v-change-sys-config-value "DISK_QUOTA" "yes"
 
 # Rebuilding user quota
 for user in $("$BIN/v-list-users" list); do

--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -22,8 +22,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 # Ensure that quota kernel modules are installed
-kernel_module_check=$(find /lib/modules/$(uname -r) -type f -name '*quota_v*.ko*' | egrep '.*' && [ $? -eq 0 ])
-if [ -z "$kernel_module_check" ]; then
+if ! find "/lib/modules/$(uname -r)" -type f -name '*quota_v*.ko*' | grep -q '.*'; then
 	# Install kernel modules for quota support.
 	# Requires reboot to activate updated kernel.
 	echo "Installing required kernel modules for quota support..."
@@ -33,8 +32,7 @@ if [ -z "$kernel_module_check" ]; then
 fi
 
 # Checking quota package
-quota=$(which --skip-alias --skip-functions quota 2> /dev/null)
-if [ $? -ne 0 ]; then
+if ! type -P quota &>/dev/null; then
 	if [ -f "/etc/redhat-release" ]; then
 		dnf -y install quota > /dev/null 2>&1
 	else
@@ -56,7 +54,7 @@ mnt=$(df -P /home | awk '{print $6}' | tail -n1)
 lnr=$(cat -n /etc/fstab | grep -v "#" | awk '{print $1,$3}' | grep "$mnt$" | cut -f 1 -d ' ')
 opt=$(sed -n ${lnr}p /etc/fstab | awk '{print $4}')
 fnd='usrquota\|grpquota\|usrjquota=aquota.user\|grpjquota=aquota.group\|jqfmt=vfsv0'
-if [ $(echo $opt | tr ',' '\n' | grep -x $fnd | wc -l) -ne 5 ]; then
+if [ "$(echo "$opt" | tr ',' '\n' | grep -c -x $fnd)" -eq 5 ]; then
 	old=$(echo $(echo $opt | tr ',' '\n' | grep -v 'usrquota\|grpquota\|usrjquota=\|grpjquota=\|jqfmt=') | tr ' ' ',')
 	new='usrquota,grpquota,usrjquota=aquota.user,grpjquota=aquota.group,jqfmt=vfsv0'
 	sed -i "$lnr s/$opt/$old,$new/" /etc/fstab

--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -54,7 +54,7 @@ mnt=$(df -P /home | awk '{print $6}' | tail -n1)
 lnr=$(cat -n /etc/fstab | grep -v "#" | awk '{print $1,$3}' | grep "$mnt$" | cut -f 1 -d ' ')
 opt=$(sed -n ${lnr}p /etc/fstab | awk '{print $4}')
 fnd='usrquota\|grpquota\|usrjquota=aquota.user\|grpjquota=aquota.group\|jqfmt=vfsv0'
-if [ "$(echo "$opt" | tr ',' '\n' | grep -c -x $fnd)" -eq 5 ]; then
+if [ "$(echo "$opt" | tr ',' '\n' | grep -c -x $fnd)" -ne 5 ]; then
 	old=$(echo $(echo $opt | tr ',' '\n' | grep -v 'usrquota\|grpquota\|usrjquota=\|grpjquota=\|jqfmt=') | tr ' ' ',')
 	new='usrquota,grpquota,usrjquota=aquota.user,grpjquota=aquota.group,jqfmt=vfsv0'
 	sed -i "$lnr s/$opt/$old,$new/" /etc/fstab

--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -58,6 +58,7 @@ if [ "$(echo "$opt" | tr ',' '\n' | grep -c -x $fnd)" -ne 5 ]; then
 	old=$(echo $(echo $opt | tr ',' '\n' | grep -v 'usrquota\|grpquota\|usrjquota=\|grpjquota=\|jqfmt=') | tr ' ' ',')
 	new='usrquota,grpquota,usrjquota=aquota.user,grpjquota=aquota.group,jqfmt=vfsv0'
 	sed -i "$lnr s/$opt/$old,$new/" /etc/fstab
+	systemctl daemon-reload
 	mount -o remount "$mnt"
 fi
 
@@ -84,7 +85,7 @@ fi
 if [ -z "$(grep DISK_QUOTA $HESTIA/conf/hestia.conf)" ]; then
 	echo "DISK_QUOTA='yes'" >> $HESTIA/conf/hestia.conf
 else
-	sed -i "s/DISK_QUOTA=.*/DISK_QUOTA='yes'/g" $HESTIA/conf/hestia.conf
+	$BIN/v-change-sys-config-value "DISK_QUOTA" "yes"
 fi
 
 # Rebuilding user quota

--- a/bin/v-delete-sys-quota
+++ b/bin/v-delete-sys-quota
@@ -37,6 +37,7 @@ fnd='usrquota\|grpquota\|usrjquota=\|grpjquota=\|jqfmt='
 if [ -n "$(echo $opt | grep $fnd)" ]; then
 	rep=$(echo $(echo $opt | tr ',' '\n' | grep -v $fnd) | tr ' ' ',')
 	sed -i "$lnr s/$opt/$rep/" /etc/fstab
+	systemctl daemon-reload
 	mount -o remount "$mnt"
 fi
 
@@ -64,7 +65,7 @@ fi
 if ! grep -q DISK_QUOTA "$HESTIA/conf/hestia.conf"; then
 	echo "DISK_QUOTA='no'" >> "$HESTIA/conf/hestia.conf"
 else
-	sed -i "s/DISK_QUOTA=.*/DISK_QUOTA='no'/g" "$HESTIA/conf/hestia.conf"
+	$BIN/v-change-sys-config-value "DISK_QUOTA" "no"
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-delete-sys-quota
+++ b/bin/v-delete-sys-quota
@@ -31,7 +31,7 @@ check_hestia_demo_mode
 
 # Deleting group and user quota on /home partition
 mnt=$(df -P /home | awk '{print $6}' | tail -n1)
-lnr=$(cat -n /etc/fstab | awk '{print $1,$3}' | grep "$mnt$" | cut -f 1 -d ' ')
+lnr=$(cat -n /etc/fstab | grep -v "#" | awk '{print $1,$3}' | grep "$mnt$" | cut -f 1 -d ' ')
 opt=$(sed -n ${lnr}p /etc/fstab | awk '{print $4}')
 fnd='usrquota\|grpquota\|usrjquota=\|grpjquota=\|jqfmt='
 if [ -n "$(echo $opt | grep $fnd)" ]; then
@@ -41,15 +41,14 @@ if [ -n "$(echo $opt | grep $fnd)" ]; then
 fi
 
 # Disabling group and user quota
-quotaoff=$(which --skip-alias --skip-functions quotaoff 2> /dev/null)
-if [ $? -eq 0 ]; then
-	if [ -n "$(quotaon -pa | grep " $mnt " | grep 'user\|group' | grep 'is on')" ]; then
-		$quotaoff $mnt
+f quotaon="$(type -P quotaon 2>/dev/null)" && quotaoff="$(type -P quotaoff 2>/dev/null)"; then
+        if "${quotaon}" -pa | grep " $mnt " | grep 'user\|group' | grep -q 'is on' &>/dev/null; then
+		"$quotaoff" "$mnt"
 	fi
 fi
 
 # Deleting v1 + v2 group and user quota index
-for idx in $(echo 'quota.user quota.group aquota.user aquota.group'); do
+for idx in quota.user quota.group aquota.user aquota.group; do
 	[ -e "$mnt/$idx" ] && rm -f "$mnt/$idx"
 done
 
@@ -57,10 +56,10 @@ done
 rm -f /etc/cron.daily/quotacheck
 
 # Updating hestia.conf value
-if [ -z "$(grep DISK_QUOTA $HESTIA/conf/hestia.conf)" ]; then
-	echo "DISK_QUOTA='no'" >> $HESTIA/conf/hestia.conf
+if ! grep -q DISK_QUOTA "$HESTIA/conf/hestia.conf"; then
+	echo "DISK_QUOTA='no'" >> "$HESTIA/conf/hestia.conf"
 else
-	sed -i "s/DISK_QUOTA=.*/DISK_QUOTA='no'/g" $HESTIA/conf/hestia.conf
+	sed -i "s/DISK_QUOTA=.*/DISK_QUOTA='no'/g" "$HESTIA/conf/hestia.conf"
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-delete-sys-quota
+++ b/bin/v-delete-sys-quota
@@ -41,7 +41,7 @@ if [ -n "$(echo $opt | grep $fnd)" ]; then
 fi
 
 # Disabling group and user quota
-f quotaon="$(type -P quotaon 2>/dev/null)" && quotaoff="$(type -P quotaoff 2>/dev/null)"; then
+if quotaon="$(type -P quotaon 2>/dev/null)" && quotaoff="$(type -P quotaoff 2>/dev/null)"; then
         if "${quotaon}" -pa | grep " $mnt " | grep 'user\|group' | grep -q 'is on' &>/dev/null; then
 		"$quotaoff" "$mnt"
 	fi
@@ -52,8 +52,13 @@ for idx in quota.user quota.group aquota.user aquota.group; do
 	[ -e "$mnt/$idx" ] && rm -f "$mnt/$idx"
 done
 
-# Deleting cron job
-rm -f /etc/cron.daily/quotacheck
+# Deleting cron job and forcequotacheck
+if [[ -f "/etc/cron.daily/quotacheck" ]]; then
+        rm -f "/etc/cron.daily/quotacheck"
+fi
+if [[ -f "/forcequotacheck" ]]; then
+        rm -f "/forcequotacheck"
+fi
 
 # Updating hestia.conf value
 if ! grep -q DISK_QUOTA "$HESTIA/conf/hestia.conf"; then

--- a/bin/v-delete-sys-quota
+++ b/bin/v-delete-sys-quota
@@ -62,11 +62,7 @@ if [[ -f "/forcequotacheck" ]]; then
 fi
 
 # Updating hestia.conf value
-if ! grep -q DISK_QUOTA "$HESTIA/conf/hestia.conf"; then
-	echo "DISK_QUOTA='no'" >> "$HESTIA/conf/hestia.conf"
-else
-	$BIN/v-change-sys-config-value "DISK_QUOTA" "no"
-fi
+$BIN/v-change-sys-config-value "DISK_QUOTA" "no"
 
 #----------------------------------------------------------#
 #                       Hestia                             #


### PR DESCRIPTION
This PR comes from this post https://forum.hestiacp.com/t/disk-quota-exceeded/10620

I completely forgot this issue so here we go to try to fix it ;)

`v-add-sys-quota`:

**1.-** It uses command `which --skip-alias --skip-functions quota` and those `--skip` options are not available in regular `which` command installed neither in Debian nor Ubuntu so I replaced it with `type -P quota`

`v-delete-sys-quota`:

**1.-** If a fstab file contains something like this:
```
# / was on /dev/sda1 during installation
UUID=example-aaaa-bbbb-cccc-dddddddddddd /               ext4    errors=remount-ro 0
```

The script will match both lines even if the first one is a comment. `v-add-sys-quota` manages it correctly so I fixed `v-delete-sys-quota` script.

**2.-** It uses command `which --skip-alias --skip-functions quotaoff` and those `--skip` options are not available in regular `which` command installed neither in Debian nor Ubuntu so I replaced it with `type -P quotaoff`

I've also made other minimal changes, like remove `/forcequotacheck` when using `v-delete-sys-quota` script and also I've changed some `ìf` to avoid the use of a variable and then check the return code.