### PR TITLE
Fix/v-delete-sys-api-ip

### DIFF
--- a/bin/v-delete-sys-api-ip
+++ b/bin/v-delete-sys-api-ip
@@ -36,7 +36,7 @@ check_hestia_demo_mode
 
 new_list=''
 set -f # avoid globbing (expansion of *).
-array=("${API_ALLOWED_IP//,/ }")
+array=(${API_ALLOWED_IP//,/ })
 for i in "${!array[@]}"; do
 	if [ "${array[i]}" != "$ip46" ]; then
 		if [ "$new_list" = '' ]; then


### PR DESCRIPTION
I have two ips in `API_ALLOWED_IP`:

```
# v-list-sys-config json | jq -r '.[].API_ALLOWED_IP'
127.0.0.1,203.0.113.1
```
I've tried to remove the ip `203.0.113.1` using command `v-delete-sys-api-ip` and the only thing that the command did was to replace the comma by a space.

```
# v-list-sys-config json | jq -r '.[].API_ALLOWED_IP'
127.0.0.1 203.0.113.1
``` 

Checking the script, I saw the array:

`array=("${API_ALLOWED_IP//,/ }")`

And those quotes are wrong. The quotes doesn't allow to split the ips in different lines so the array only has one element `127.0.0.1 203.0.113.1` instead of two
```
127.0.0.1
203.0.113.1
```

And that is the reason the command doesn't work as expected.

I've removed the quotes and the command `v-delete-sys-api-ip` works fine now.

`array=(${API_ALLOWED_IP//,/ })`