### PR TITLE
Fix/change default value true to yes for three POLICY_USER directives

### DIFF
--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -403,7 +403,7 @@ function syshealth_repair_system_config() {
 	# Theme editor
 	if [[ -z $(check_key_exists 'POLICY_USER_CHANGE_THEME') ]]; then
 		echo "[ ! ] Adding missing variable to hestia.conf: POLICY_USER_CHANGE_THEME ('yes')"
-		$BIN/v-change-sys-config-value "POLICY_USER_CHANGE_THEME" "true"
+		$BIN/v-change-sys-config-value "POLICY_USER_CHANGE_THEME" "yes"
 	fi
 	# Protect admin user
 	if [[ -z $(check_key_exists 'POLICY_SYSTEM_PROTECTED_ADMIN') ]]; then
@@ -428,12 +428,12 @@ function syshealth_repair_system_config() {
 	# Allow users to edit web templates
 	if [[ -z $(check_key_exists 'POLICY_USER_EDIT_WEB_TEMPLATES') ]]; then
 		echo "[ ! ] Adding missing variable to hestia.conf: POLICY_USER_EDIT_WEB_TEMPLATES ('yes')"
-		$BIN/v-change-sys-config-value "POLICY_USER_EDIT_WEB_TEMPLATES" "true"
+		$BIN/v-change-sys-config-value "POLICY_USER_EDIT_WEB_TEMPLATES" "yes"
 	fi
 	# View user logs
 	if [[ -z $(check_key_exists 'POLICY_USER_VIEW_LOGS') ]]; then
 		echo "[ ! ] Adding missing variable to hestia.conf: POLICY_USER_VIEW_LOGS ('yes')"
-		$BIN/v-change-sys-config-value "POLICY_USER_VIEW_LOGS" "true"
+		$BIN/v-change-sys-config-value "POLICY_USER_VIEW_LOGS" "yes"
 	fi
 	# Allow users to login (read only) when suspended
 	if [[ -z $(check_key_exists 'POLICY_USER_VIEW_SUSPENDED') ]]; then

--- a/install/upgrade/versions/1.8.8.sh
+++ b/install/upgrade/versions/1.8.8.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.8.8
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### upgrade_config_set_value only accepts true or false.                    #######
+#######                                                                         #######
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
+# Modify existing POLICY_USER directives (POLICY_USER_CHANGE_THEME, POLICY_USER_EDIT_WEB_TEMPLATES
+# and POLICY_USER_VIEW_LOGS) that are using value 'true' instead of the correct value 'yes'
+
+hestia_conf="$HESTIA/conf/hestia.conf"
+hestia_defaults_conf="$HESTIA/conf/defaults/hestia.conf"
+
+for i in POLICY_USER_CHANGE_THEME POLICY_USER_EDIT_WEB_TEMPLATES POLICY_USER_VIEW_LOGS; do
+        if [[ -f "$hestia_conf" ]]; then
+                if grep "$i" "$hestia_conf" | grep -q 'true'; then
+                        if "$BIN/v-change-sys-config-value" "$i" 'yes'; then
+                                echo "[ * ] Success: ${i} value changed from true to yes in hestia.conf"
+                        else
+                                echo "[ ! ] Error: Couldn't change ${i} value from true to yes in hestia.conf"
+                        fi
+                fi
+        fi
+        if [[ -f "$hestia_defaults_conf" ]]; then
+                if grep "$i" "$hestia_defaults_conf" | grep -q 'true'; then
+                        if sed -i "s/${i}='true'/${i}='yes'/" "$hestia_defaults_conf"; then
+                                echo "[ * ] Success: ${i} value changed from true to yes in defaults/hestia.conf"
+                        else
+                                echo "[ ! ] Error: Couldn't change ${i} value from true to yes in defaults/hestia.conf"
+                        fi
+                fi
+        fi
+done


### PR DESCRIPTION
This comes from this [post ](https://forum.hestiacp.com/t/change-theme-no-apply/10946)

There are three `POLICY_USER` directives using `true` as default value when it should be `yes`.

```
POLICY_USER_CHANGE_THEME
POLICY_USER_EDIT_WEB_TEMPLATES
POLICY_USER_VIEW_LOGS
```

I've modified `func/syshealth.sh` file and added script `install/upgrade/versions/1.8.8.sh` so incorrect values in `conf/hestia.conf` and `conf/defaults/hestia.conf` are modified during the upgrade. 