### PR TITLE
Fix v-add-user-wp-cli

### DIFF
--- a/bin/v-add-user-wp-cli
+++ b/bin/v-add-user-wp-cli
@@ -56,7 +56,7 @@ chown $user:$user "$WPCLI_DIR"
 
 user_exec wget --tries=3 --timeout=15 --read-timeout=15 --waitretry=3 --no-dns-cache --quiet -O "$WPCLI_BIN" https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 user_exec chmod +x "$WPCLI_BIN"
-user_exec echo -e "#add wp-cli alias for user\nalias wp='php $WPCLI_BIN'" >> ~/.bashrc
+echo "alias wp=/home/"$user"/.wp-cli/wp" >> /home/$user/.bash_aliases
 
 #----------------------------------------------------------#
 #                       Hestia                             #


### PR DESCRIPTION
Bug, currently does NOT write to user folder. Fixed to alias wp using user's protected .bash_aliases. This is how Hestia does composer (which does work). Also removes php prefix, as "wp" is already an executable. See HesitaCP forum for discussion. 

https://forum.hestiacp.com/t/10983