### PR TITLE
Fix: Prevent the script v-add-sys-roundcube from freezing during Roundcube upgrade

### DIFF
--- a/bin/v-add-sys-roundcube
+++ b/bin/v-add-sys-roundcube
@@ -187,7 +187,9 @@ else
 
 	# Run Roundcube upgrade script
 	$RC_INSTALL_DIR/$RC_EXTRACT/bin/installto.sh -y $RC_INSTALL_DIR > /dev/null 2>&1
-	$RC_INSTALL_DIR/bin/update.sh --version "$version" > /dev/null 2>&1
+	# Use COMPOSER_ALLOW_SUPERUSER=1 to prevent update.sh script from freezing trying
+	# to execute composer as root to update roundcube dependencies
+	COMPOSER_ALLOW_SUPERUSER=1 $RC_INSTALL_DIR/bin/update.sh --version "$version" > /dev/null 2>&1
 	$RC_INSTALL_DIR/bin/indexcontacts.sh > /dev/null 2>&1
 	chown -R root:www-data $RC_INSTALL_DIR
 


### PR DESCRIPTION
Fix for [#4017](https://github.com/hestiacp/hestiacp/issues/4017)

Use `COMPOSER_ALLOW_SUPERUSER=1` to prevent roundcube's `update.sh` script from freezing trying to execute composer as root to update roundcube dependencies