### PR TITLE
fix for v-list-sys-services, pidof command in Debian Buster doesn't support option -d

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -87,9 +87,9 @@ get_srv_state() {
 
 	# Searching related pids
 	if [ -z $3 ]; then
-		pids=$(pidof -d '|' $name)
+		pids=$(pidof $name | tr ' ' '|')
 	else
-		pids=$(pidof -d '|' -x $name)
+		pids=$(pidof -x $name | tr ' ' '|')
 	fi
 	if [ -z "$pids" ] && [ "$name" != 'nginx' ]; then
 		pids=$(pgrep $name | tr '\n' '|')


### PR DESCRIPTION
This comes from this [post](https://forum.hestiacp.com/t/nginx-is-stopped-in-server-settings-but-running/11093)

`pidof` command in Debian Buster doesn't support option `-d` so I had to change again the script `v-list-sys-services`

https://manpages.debian.org/buster/sysvinit-utils/pidof.8.en.html