### PR TITLE
account.md: 2FA: Add Vaultwarden (optionally with Bitwarden clients)

### DIFF
--- a/docs/docs/user-guide/account.md
+++ b/docs/docs/user-guide/account.md
@@ -33,6 +33,7 @@ If you do not have an authenticator app, here are a couple of recommendations.
 - [Authy](https://authy.com/) – Free, has a cloud sync feature
 - [1Password](https://1password.com/) – Paid password manager
 - [Bitwarden](https://bitwarden.com/) – Password manager. 2FA in premium plan only
+- [Vaultwarden](https://docs.cloudron.io/apps/vaultwarden) (AGPL, [self-hosted](https://hub.docker.com/r/vaultwarden/server)), optionally with [Bitwarden](https://linuxiac.com/how-to-install-vaultwarden-password-manager-with-docker) clients
 
 :::
 


### PR DESCRIPTION
Add Vaultwarden to the list of 2FA password managers (which can be used with Bitwarden clients).