### PR TITLE
Fix --mysql8 option in getting-started.md file

### DIFF
--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -88,7 +88,7 @@ To choose what software gets installed, you can provide flags to the installatio
 -j, --proftpd Install ProFTPD [yes | no] default: no
 -k, --named Install Bind [yes | no] default: yes
 -m, --mysql Install MariaDB [yes | no] default: yes
--M, --mysql-classic Install Mysql8 [yes | no] default: no
+-M, --mysql8 Install Mysql8 [yes | no] default: no
 -g, --postgresql Install PostgreSQL [yes | no] default: no
 -x, --exim Install Exim [yes | no] default: yes
 -z, --dovecot Install Dovecot [yes | no] default: yes


### PR DESCRIPTION
Installer uses --mysql8 and getting-started.html were outdated displaying -mysql-classic.