### PR TITLE
Fix install script generator copy to clipboard issue

### DIFF
--- a/docs/.vitepress/theme/components/CopyToClipboardInput.vue
+++ b/docs/.vitepress/theme/components/CopyToClipboardInput.vue
@@ -13,8 +13,6 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
-
 defineProps({
 	value: {
 		type: String,

--- a/docs/.vitepress/theme/components/CopyToClipboardInput.vue
+++ b/docs/.vitepress/theme/components/CopyToClipboardInput.vue
@@ -15,7 +15,7 @@
 <script setup>
 import { ref } from "vue";
 
-const { value } = defineProps({
+defineProps({
 	value: {
 		type: String,
 		required: true,
@@ -23,7 +23,8 @@ const { value } = defineProps({
 });
 
 const copyToClipboard = (event) => {
-	navigator.clipboard.writeText(value).then(
+	const inputValue = event.target.previousSibling.value;
+	navigator.clipboard.writeText(inputValue).then(
 		() => {
 			event.target.textContent = "Copied!";
 			setTimeout(() => {


### PR DESCRIPTION
The "Copy" buttons in the [new install script generator](https://main.hestiacp.pages.dev/install.html) work to copy the initial value to the clipboard.

But after modifying the install command using the checkboxes, while the updated command displays in the input, only the initial "bash hst-install.sh" value is copied to the clipboard.

This is because we were using the "value" prop directly in the copyToClipboard() function, and it looks like with Vue we can't depend on the prop value to be reactive in this case.

The input value does get updated correctly though, so now we use that value in copyToClipboard() instead which fixes the issue.