### PR TITLE
Add check if group / user exists + Allow user to select php versions

### DIFF
--- a/func/upgrade.sh
+++ b/func/upgrade.sh
@@ -246,7 +246,7 @@ upgrade_send_notification_to_email() {
 
 upgrade_send_log_to_email() {
 	if [ "$UPGRADE_SEND_EMAIL_LOG" = "true" ]; then
-		admin_email=$($BIN/v-list-user admin json | grep "CONTACT" | cut -d'"' -f4)
+		admin_email=$($BIN/v-list-user $ROOT_USER json | grep "CONTACT" | cut -d'"' -f4)
 		send_mail="$HESTIA/web/inc/mail-wrapper.php"
 		cat $LOG | $send_mail -s "Update Installation Log - v${new_version}" $admin_email
 	fi

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -318,8 +318,8 @@ if [ -n "$multiphp" ]; then
 	if [ "$multiphp" != 'no' ] && [ "$multiphp" != 'yes' ]; then
 		php_versions=$(echo $multiphp | tr ',' "\n")
 		multiphp_version=()
-		for php_version in ${php_versions[@]}; do
-			if [[ $(echo ${multiphp_v[@]} | fgrep -w "$php_version") ]]; then
+		for php_version in "${php_versions[@]}"; do
+			if [[ $(echo "${multiphp_v[@]}" | fgrep -w "$php_version") ]]; then
 				multiphp_version=(${multiphp_version[@]} "$php_version")
 			else
 				echo "$php_version is not supported"
@@ -327,7 +327,7 @@ if [ -n "$multiphp" ]; then
 			fi
 		done
 		multiphp_v=()
-		for version in ${multiphp_version[@]}; do
+		for version in "${multiphp_version[@]}"; do
 			multiphp_v=(${multiphp_v[@]} $version)
 		done
 		fpm_old=$fpm_v
@@ -606,7 +606,7 @@ fi
 if [ "$multiphp" = 'yes' ]; then
 	phpfpm='yes'
 	echo -n '   - Multi-PHP Environment: Version'
-	for version in ${multiphp_v[@]}; do
+	for version in "${multiphp_v[@]}"; do
 		echo -n " php$version"
 	done
 	echo ''

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -32,9 +32,13 @@ VERBOSE='no'
 
 # Define software versions
 HESTIA_INSTALL_VER='1.9.0~alpha'
-# Dependencies
+# Supported PHP versions
 multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2")
+# One of the following PHP versions is required for Roundcube / phpmyadmin
+multiphp_required=("7.3" "7.4" "8.0" "8.1" "8.2")
+# Default PHP version if none supplied
 fpm_v="8.2"
+# MariaDB version
 mariadb_v="10.11"
 
 # Defining software pack for all distros
@@ -178,10 +182,14 @@ sort_config_file() {
 
 # todo add check for usernames that are blocked
 validate_username() {
-	if [[ "$username" =~ ^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$ ]]; then
-		# Username valid
-		return 1
+	if [[ "$username" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+		if [ -n "$(grep ^$username: /etc/passwd /etc/group)" ]; then
+			echo -e "\nUsername or Group allready exists please select a new user name or delete the user and / or group."
+		else
+			return 1
+		fi
 	else
+		echo -e "\nPlease use a valid username (ex. user)."
 		return 0
 	fi
 }
@@ -306,6 +314,43 @@ while getopts "a:w:v:j:k:m:M:g:d:x:z:Z:c:t:i:b:r:o:q:l:y:s:u:e:p:W:D:fh" Option;
 	esac
 done
 
+if [ -n "$multiphp" ]; then
+	if [ "$multiphp" != 'no' ] && [ "$multiphp" != 'yes' ]; then
+		php_versions=$(echo $multiphp | tr ',' "\n")
+		multiphp_version=()
+		for php_version in ${php_versions[@]}; do
+			if [[ $(echo ${multiphp_v[@]} | fgrep -w "$php_version") ]]; then
+				multiphp_version=(${multiphp_version[@]} "$php_version")
+			else
+				echo "$php_version is not supported"
+				exit 1
+			fi
+		done
+		multiphp_v=()
+		for version in ${multiphp_version[@]}; do
+			multiphp_v=(${multiphp_v[@]} $version)
+		done
+		fpm_old=$fpm_v
+		multiphp="yes"
+		fpm_v=$(printf "%s\n" "${multiphp_version[@]}" | sort -V | tail -n1)
+		fpm_last=$(printf "%s\n" "${multiphp_required[@]}" | sort -V | tail -n1)
+		# Allow Maintainer to set minimum fpm version to make sure phpmyadmin and roundcube keep working
+		if [[ -z $(echo "${multiphp_required[@]}" | fgrep -w $fpm_v) ]]; then
+			if version_ge $fpm_v $fpm_last; then
+				multiphp_version=(${multiphp_version[@]} $fpm_last)
+				fpm_v=$fpm_last
+			else
+				# Roundcube and PHPmyadmin doesn't support the version selected.
+				echo "Selected PHP versions are not supported any more by Dependencies..."
+				exit 1
+			fi
+		fi
+
+		software=$(echo "$software" | sed -e "s/php$fpm_old/php$fpm_v/g")
+
+	fi
+fi
+
 # Defining default software stack
 set_default_value 'nginx' 'yes'
 set_default_value 'apache' 'yes'
@@ -357,6 +402,7 @@ fi
 if [ "$apache" = 'no' ]; then
 	phpfpm='yes'
 fi
+
 if [ "$mysql" = 'yes' ] && [ "$mysql8" = 'yes' ]; then
 	mysql='no'
 fi
@@ -372,14 +418,6 @@ fi
 
 if [ -d "/usr/local/hestia" ]; then
 	check_result 1 "Hestia install detected. Unable to continue"
-fi
-
-# Checking $username user account
-if [ -n "$(grep ^$username: /etc/passwd /etc/group)" ] && [ -z "$force" ]; then
-	echo "Please remove $username user account before proceeding."
-	echo 'If you want to do it automatically run installer with -f option:'
-	echo -e "Example: bash $0 --force\n"
-	check_result 1 "User $username exists"
 fi
 
 # Clear the screen once launch permissions have been verified
@@ -567,7 +605,11 @@ if [ "$phpfpm" = 'yes' ] && [ "$multiphp" = 'no' ]; then
 fi
 if [ "$multiphp" = 'yes' ]; then
 	phpfpm='yes'
-	echo '   - Multi-PHP Environment'
+	echo -n '   - Multi-PHP Environment: Version'
+	for version in ${multiphp_v[@]}; do
+		echo -n " php$version"
+	done
+	echo ''
 fi
 
 # DNS stack
@@ -645,15 +687,12 @@ if [ "$interactive" = 'yes' ]; then
 fi
 
 #Validate Username / Password / Email / Hostname even when interactive = no
-# Asking for contact email
 if [ -z "$username" ]; then
 	while validate_username; do
-		echo -e "\nPlease use a valid username (ex. user)."
 		read -p 'Please enter administrator username: ' username
 	done
 else
 	if validate_username; then
-		echo "Please use a valid username (ex. user)."
 		exit 1
 	fi
 fi
@@ -707,6 +746,7 @@ else
 	fi
 fi
 
+exit
 # Generating admin password if it wasn't set
 displaypass="The password you chose during installation."
 if [ -z "$vpass" ]; then

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -746,7 +746,6 @@ else
 	fi
 fi
 
-exit
 # Generating admin password if it wasn't set
 displaypass="The password you chose during installation."
 if [ -z "$vpass" ]; then

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -686,6 +686,18 @@ else
 	fi
 fi
 
+#Ask for the password
+if [ -z "$vpass" ]; then
+	while validate_password; do
+		read -p 'Please enter administrator password: ' vpass
+	done
+else
+	if validate_password; then
+		echo "Please use a valid password"
+		exit 1
+	fi
+fi
+
 # Asking for contact email
 if [ -z "$email" ]; then
 	while validate_email; do

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -319,8 +319,8 @@ if [ -n "$multiphp" ]; then
 	if [ "$multiphp" != 'no' ] && [ "$multiphp" != 'yes' ]; then
 		php_versions=$(echo $multiphp | tr ',' "\n")
 		multiphp_version=()
-		for php_version in ${php_versions[@]}; do
-			if [[ $(echo ${multiphp_v[@]} | fgrep -w "$php_version") ]]; then
+		for php_version in "${php_versions[@]}"; do
+			if [[ $(echo "${multiphp_v[@]}" | fgrep -w "$php_version") ]]; then
 				multiphp_version=(${multiphp_version[@]} "$php_version")
 			else
 				echo "$php_version is not supported"
@@ -328,7 +328,7 @@ if [ -n "$multiphp" ]; then
 			fi
 		done
 		multiphp_v=()
-		for version in ${multiphp_version[@]}; do
+		for version in "${multiphp_version[@]}"; do
 			multiphp_v=(${multiphp_v[@]} $version)
 		done
 		fpm_old=$fpm_v
@@ -595,7 +595,7 @@ fi
 if [ "$multiphp" = 'yes' ]; then
 	phpfpm='yes'
 	echo -n '   - Multi-PHP Environment: Version'
-	for version in ${multiphp_v[@]}; do
+	for version in "${multiphp_v[@]}"; do
 		echo -n " php$version"
 	done
 	echo ''

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -299,6 +299,7 @@ if [ "$dontinstalldeps" != 'true' ]; then
 			echo "Requires NodeJS 18.x or higher"
 			exit 1
 		fi
+
 		# Fix for Debian PHP Envroiment
 		if [ $BUILD_ARCH == "amd64" ]; then
 			if [ ! -L /usr/local/include/curl ]; then

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -293,8 +293,7 @@ if [ "$dontinstalldeps" != 'true' ]; then
 		apt -qq install -y nodejs > /dev/null 2>&1
 
 		nodejs_version=$(/usr/bin/node -v | cut -f1 -d'.' | sed 's/v//g')
-		echo /usr/bin/node -v
-		echo $nodejs_version
+
 		if [ "$nodejs_version" -lt 18 ]; then
 			echo "Requires NodeJS 18.x or higher"
 			exit 1


### PR DESCRIPTION
Usage 

bash hst-install-debian.sh -D /root/ -o 8.2,8.1,8.0 

Will install php8.0 to php8.2 

A few exceptions:
- If user wants to install a non existing version it will create an error and exit it self 
- If Versions installer are  lower then 7.3  it will do the same as our dependencies require it (roundcube)
- If PHP version > current supported it will include php8.2 in this case to the supported list. This is mainly for 8.3 and new and or 9.0 versions


<img width="570" alt="Screenshot 2023-10-15 at 22 23 32" src="https://github.com/hestiacp/hestiacp/assets/9754650/eab148ca-55fb-4f79-86af-00fc2ed44701">

Not tested with Ubuntu 


