### PR TITLE
Fixed issue when getting pids from pgrep and then using awk to get the main pid

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -91,8 +91,10 @@ get_srv_state() {
 	else
 		pids=$(pidof -x $name | tr ' ' '|')
 	fi
+	used_pgrep=0
 	if [ -z "$pids" ] && [ "$name" != 'nginx' ]; then
 		pids=$(pgrep $name | tr '\n' '|')
+		used_pgrep=1
 	fi
 
 	# Correctly handle hestia-web-terminal service
@@ -107,7 +109,11 @@ get_srv_state() {
 
 	# Checking pid
 	if [ -n "$pids" ]; then
-		pid=$(echo "$pids" | awk -F '|' '{print $NF}')
+		if [[ "$used_pgrep" -eq 1 ]]; then
+			pid=$(echo "$pids" | awk -F '|' '{print $1}')
+		else
+			pid=$(echo "$pids" | awk -F '|' '{print $NF}')
+		fi
 		pids=${pids%|}
 		pids=$(egrep "$pids" $tmp_file)
 


### PR DESCRIPTION
In previous pull request #3962, I modified  `pid=$(echo "$pids" | awk -F '|' '{print $1}')` by `pid=$(echo "$pids" | awk -F '|' '{print $NF}')` because main pid using pidof is the last one but today checking it to try to fix an issue posted in forum, I realized that my ssh service said it has been started for 8 days but I restarted it yesterday (less than 24 hours) so I checked it and pgrep shows the main pid the first so I've modified the script to take it into account.