### PR TITLE
Auto merge linting dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,16 +9,9 @@
 	],
 	"packageRules": [
 		{
-			"groupName": "Linters",
-			"matchPackagePrefixes": ["@prettier/", "prettier"]
-		},
-		{
-			"groupName": "ESLint",
-			"extends": ["packages:eslint"]
-		},
-		{
-			"groupName": "StyleLint",
-			"extends": ["packages:stylelint"]
+			"matchDepTypes": ["devDependencies"],
+			"matchPackagePatterns": ["lint", "prettier"],
+			"automerge": true
 		}
 	],
 	"enabledManagers": ["npm", "composer", "github-actions"],


### PR DESCRIPTION
Renovate opens PRs for linting dependencies. These changes are "tested" straight away as linting runs on new PRs.

If such PRs are green, there's no reason not to merge them. So we may as well get Renovate to do this automatically?

This also removes the different "groups" that resulted in Prettier, ESLint and Stylelint always being in different PRs.

The new matching should "group" all the linting-related packages together including Prettier, ESLint and Stylelint.

NOTE: This is untested.