### PR TITLE
Simplify Renovate linter auto-merging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
 	],
 	"packageRules": [
 		{
-			"matchDepTypes": ["devDependencies"],
-			"matchPackagePatterns": ["lint", "prettier"],
+			"extends": ["packages:linters"],
 			"automerge": true
 		}
 	],

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,8 @@
 		":pinAllExceptPeerDependencies",
 		":disableDependencyDashboard",
 		"group:allNonMajor",
-		"schedule:weekdays"
-	],
-	"packageRules": [
-		{
-			"extends": ["packages:linters"],
-			"automerge": true
-		}
+		"schedule:weekdays",
+		":automergeLinters"
 	],
 	"enabledManagers": ["npm", "composer", "github-actions"],
 	"ignorePaths": ["**/node_modules/**", "install/deb/filemanager/filegator/composer.json"],


### PR DESCRIPTION
Looks like there's a simpler built-in way of auto-merging linting deps.

https://docs.renovatebot.com/presets-default/#automergelinters