### PR TITLE
Correct formatting of user dir

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -637,7 +637,7 @@ fi
 
 # User Directories
 if [ "$USER" != '*' ]; then
-	echo -e "\n-- USER DIR --" | tee -a $BACKUP/$user.log
+	echo -e "\n-- USER DIRECTORIES --" | tee -a $BACKUP/$user.log
 	mkdir $tmpdir/user_dir
 	cd $HOMEDIR/$user
 

--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -637,7 +637,7 @@ fi
 
 # User Directories
 if [ "$USER" != '*' ]; then
-	echo -e "\n-- User Dir --" | tee -a $BACKUP/$user.log
+	echo -e "\n-- USER DIR --" | tee -a $BACKUP/$user.log
 	mkdir $tmpdir/user_dir
 	cd $HOMEDIR/$user
 


### PR DESCRIPTION
Hi,

This is my first pull request so if I did something wrong I'm terribly sorry!

The goal is to fix the formatting of "User Dir" in the mail sent to a user after running v-backup-user
All other headlines are in caps, so I thought this one ought to be too.

Thank you