### PR TITLE
Allow for optional domain directory write permissions

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -126,7 +126,12 @@ chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
 user_exec chmod 751 $HOMEDIR/$user/web/$domain/*
 user_exec chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
 user_exec chmod 644 $HOMEDIR/$user/web/$domain/public_*html/*
-user_exec chmod 551 $HOMEDIR/$user/web/$domain
+
+# domain folder permissions: DOMAINDIR_WRITABLE: optional hestia.conf key=value
+DOMAINDIR_MODE=551
+if [ "$DOMAINDIR_WRITABLE" = 'yes' ]; then DOMAINDIR_MODE=751; fi
+
+user_exec chmod $DOMAINDIR_MODE $HOMEDIR/$user/web/$domain
 chown --no-dereference $user:www-data $HOMEDIR/$user/web/$domain/public_*html
 
 # Adding PHP-FPM backend

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -127,7 +127,7 @@ user_exec chmod 751 $HOMEDIR/$user/web/$domain/*
 user_exec chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
 user_exec chmod 644 $HOMEDIR/$user/web/$domain/public_*html/*
 
-# domain folder permissions: DOMAINDIR_WRITABLE: optional hestia.conf key=value
+# domain folder permissions: DOMAINDIR_WRITABLE: default-val:no source:hestia.conf
 DOMAINDIR_MODE=551
 if [ "$DOMAINDIR_WRITABLE" = 'yes' ]; then DOMAINDIR_MODE=751; fi
 

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -459,9 +459,13 @@ rebuild_web_domain_conf() {
 		chgrp $user $htpasswd $htaccess
 	done
 
+	# domain folder permissions: DOMAINDIR_WRITABLE: optional hestia.conf key=value
+ 	DOMAINDIR_MODE=551
+	if [ "$DOMAINDIR_WRITABLE" = 'yes' ]; then DOMAINDIR_MODE=751; fi
+
 	# Set folder permissions
-	no_symlink_chmod 551 $HOMEDIR/$user/web/$domain \
-		$HOMEDIR/$user/web/$domain/stats \
+	no_symlink_chmod $DOMAINDIR_MODE $HOMEDIR/$user/web/$domain
+	no_symlink_chmod 551 $HOMEDIR/$user/web/$domain/stats \
 		$HOMEDIR/$user/web/$domain/logs
 	no_symlink_chmod 751 $HOMEDIR/$user/web/$domain/private \
 		$HOMEDIR/$user/web/$domain/cgi-bin \

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -459,7 +459,7 @@ rebuild_web_domain_conf() {
 		chgrp $user $htpasswd $htaccess
 	done
 
-	# domain folder permissions: DOMAINDIR_WRITABLE: optional hestia.conf key=value
+	# domain folder permissions: DOMAINDIR_WRITABLE: default-val:no source:hestia.conf
  	DOMAINDIR_MODE=551
 	if [ "$DOMAINDIR_WRITABLE" = 'yes' ]; then DOMAINDIR_MODE=751; fi
 

--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -538,6 +538,10 @@ function syshealth_repair_system_config() {
 		echo "[ ! ] Adding missing variable to hestia.conf: ROOT_USER ('admin')"
 		$BIN/v-change-sys-config-value "ROOT_USER" "admin"
 	fi
+ 	if [[ -z $(check_key_exists 'DOMAINDIR_WRITABLE') ]]; then
+		echo "[ ! ] Adding missing variable to hestia.conf: DOMAINDIR_WRITABLE ('no')"
+		$BIN/v-change-sys-config-value "DOMAINDIR_WRITABLE" "no"
+	fi
 
 	touch $HESTIA/conf/hestia.conf.new
 	while IFS='= ' read -r lhs rhs; do


### PR DESCRIPTION
For security reasons, my applications require writeable storage at /home/user/web/domain.tld/. I've been hacking hestia on install/upgrade to achieve this. I'd like to see it integrated. 

/home/user/web/domain.tld/ writability will only occur when the user adds optional: `DOMAINDIR_WRITABLE='yes'` to `/usr/local/hestia/conf/hestia.conf`. Additionally, the user will have to modify their open_basedir in their php templates.

The way I've changed the hestia code does not impact default functionality of non-writable /home/user/web/domain.tld/ at all and does not require a new hestia.conf key=value to maintain this default functionality.

Allowing a writable /home/user/web/domain.tld/ is common for panels and providers. While I understand hestia allows for a sub directory under public_html and setting that directory to docroot, this is unnecessary hassle with negligible security benefits.

