### PR TITLE
Small fix for small screens in the logs header

### DIFF
--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -460,7 +460,7 @@ rebuild_web_domain_conf() {
 	done
 
 	# domain folder permissions: DOMAINDIR_WRITABLE: default-val:no source:hestia.conf
- 	DOMAINDIR_MODE=551
+	DOMAINDIR_MODE=551
 	if [ "$DOMAINDIR_WRITABLE" = 'yes' ]; then DOMAINDIR_MODE=751; fi
 
 	# Set folder permissions

--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -538,7 +538,7 @@ function syshealth_repair_system_config() {
 		echo "[ ! ] Adding missing variable to hestia.conf: ROOT_USER ('admin')"
 		$BIN/v-change-sys-config-value "ROOT_USER" "admin"
 	fi
- 	if [[ -z $(check_key_exists 'DOMAINDIR_WRITABLE') ]]; then
+	if [[ -z $(check_key_exists 'DOMAINDIR_WRITABLE') ]]; then
 		echo "[ ! ] Adding missing variable to hestia.conf: DOMAINDIR_WRITABLE ('no')"
 		$BIN/v-change-sys-config-value "DOMAINDIR_WRITABLE" "no"
 	fi

--- a/install/common/firewall/ipset/blacklist.sh
+++ b/install/common/firewall/ipset/blacklist.sh
@@ -5,16 +5,16 @@
 #
 
 BLACKLISTS=(
-	"https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1"                                # Project Honey Pot Directory of Dictionary Attacker IPs
-	"https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"                       # TOR Exit Nodes
-	"https://www.maxmind.com/en/high-risk-ip-sample-list"                                      # MaxMind GeoIP Anonymous Proxies
-	"https://danger.rulez.sk/projects/bruteforceblocker/blist.php"                             # BruteForceBlocker IP List
-	"https://www.spamhaus.org/drop/drop.lasso"                                                 # Spamhaus Don't Route Or Peer List (DROP)
-	"https://cinsscore.com/list/ci-badguys.txt"                                                # C.I. Army Malicious IP List
-	"https://lists.blocklist.de/lists/all.txt"                                                 # blocklist.de attackers
-	"https://blocklist.greensnow.co/greensnow.txt"                                             # GreenSnow
-	"https://iplists.firehol.org/files/firehol_level1.netset"  # Firehol Level 1
-	"https://iplists.firehol.org/files/stopforumspam_7d.ipset" # Stopforumspam via Firehol
+	"https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1"          # Project Honey Pot Directory of Dictionary Attacker IPs
+	"https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1" # TOR Exit Nodes
+	"https://www.maxmind.com/en/high-risk-ip-sample-list"                # MaxMind GeoIP Anonymous Proxies
+	"https://danger.rulez.sk/projects/bruteforceblocker/blist.php"       # BruteForceBlocker IP List
+	"https://www.spamhaus.org/drop/drop.lasso"                           # Spamhaus Don't Route Or Peer List (DROP)
+	"https://cinsscore.com/list/ci-badguys.txt"                          # C.I. Army Malicious IP List
+	"https://lists.blocklist.de/lists/all.txt"                           # blocklist.de attackers
+	"https://blocklist.greensnow.co/greensnow.txt"                       # GreenSnow
+	"https://iplists.firehol.org/files/firehol_level1.netset"            # Firehol Level 1
+	"https://iplists.firehol.org/files/stopforumspam_7d.ipset"           # Stopforumspam via Firehol
 )
 
 IP_BLACKLIST_TMP=$(mktemp)

--- a/install/upgrade/versions/1.8.8.sh
+++ b/install/upgrade/versions/1.8.8.sh
@@ -30,22 +30,22 @@ hestia_conf="$HESTIA/conf/hestia.conf"
 hestia_defaults_conf="$HESTIA/conf/defaults/hestia.conf"
 
 for i in POLICY_USER_CHANGE_THEME POLICY_USER_EDIT_WEB_TEMPLATES POLICY_USER_VIEW_LOGS; do
-        if [[ -f "$hestia_conf" ]]; then
-                if grep "$i" "$hestia_conf" | grep -q 'true'; then
-                        if "$BIN/v-change-sys-config-value" "$i" 'yes'; then
-                                echo "[ * ] Success: ${i} value changed from true to yes in hestia.conf"
-                        else
-                                echo "[ ! ] Error: Couldn't change ${i} value from true to yes in hestia.conf"
-                        fi
-                fi
-        fi
-        if [[ -f "$hestia_defaults_conf" ]]; then
-                if grep "$i" "$hestia_defaults_conf" | grep -q 'true'; then
-                        if sed -i "s/${i}='true'/${i}='yes'/" "$hestia_defaults_conf"; then
-                                echo "[ * ] Success: ${i} value changed from true to yes in defaults/hestia.conf"
-                        else
-                                echo "[ ! ] Error: Couldn't change ${i} value from true to yes in defaults/hestia.conf"
-                        fi
-                fi
-        fi
+	if [[ -f "$hestia_conf" ]]; then
+		if grep "$i" "$hestia_conf" | grep -q 'true'; then
+			if "$BIN/v-change-sys-config-value" "$i" 'yes'; then
+				echo "[ * ] Success: ${i} value changed from true to yes in hestia.conf"
+			else
+				echo "[ ! ] Error: Couldn't change ${i} value from true to yes in hestia.conf"
+			fi
+		fi
+	fi
+	if [[ -f "$hestia_defaults_conf" ]]; then
+		if grep "$i" "$hestia_defaults_conf" | grep -q 'true'; then
+			if sed -i "s/${i}='true'/${i}='yes'/" "$hestia_defaults_conf"; then
+				echo "[ * ] Success: ${i} value changed from true to yes in defaults/hestia.conf"
+			else
+				echo "[ ! ] Error: Couldn't change ${i} value from true to yes in defaults/hestia.conf"
+			fi
+		fi
+	fi
 done

--- a/web/css/src/themes/default.css
+++ b/web/css/src/themes/default.css
@@ -2221,6 +2221,10 @@
 	font-size: 0.92rem;
 	line-height: 1.15;
 	padding-bottom: 20px;
+	overflow-x: scroll;
+	@media (--viewport-medium) {
+		overflow-x: initial;
+	}
 }
 
 /* Icon component

--- a/web/css/src/themes/default.css
+++ b/web/css/src/themes/default.css
@@ -2222,6 +2222,7 @@
 	line-height: 1.15;
 	padding-bottom: 20px;
 	overflow-x: scroll;
+
 	@media (--viewport-medium) {
 		overflow-x: initial;
 	}

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -354,7 +354,7 @@ function humanize_usage_size($usage, $round = 2) {
 	}
 	if ($usage < 1) {
 		$usage = "0";
-	}	
+	}
 	$display_usage = $usage;
 	if ($usage > 1024) {
 		$usage = $usage / 1024;


### PR DESCRIPTION
Adding overflow-x:scroll; to the logs on smaller screens to fix the header, which goes out of the screen currently on mobile devices.
From this:
![bug](https://github.com/hestiacp/hestiacp/assets/801036/8ba881e1-8d93-4d3e-b677-54fcaf40c95e)
To this:
![fixed](https://github.com/hestiacp/hestiacp/assets/801036/e51f0109-d844-4dc5-b328-b8acd3e76d52)
