### PR TITLE
Fix QuickInstall App Input type text value

### DIFF
--- a/web/templates/pages/setup_webapp.php
+++ b/web/templates/pages/setup_webapp.php
@@ -113,6 +113,7 @@
 									name="<?= $field_name ?>"
 									id="<?= $field_name ?>"
 									placeholder="<?= $field_placeholder ?>"
+									value="<?= $field_value ?>"
 								>
 							<?php endif; ?>
 						<?php endif; ?>


### PR DESCRIPTION
When you create a new _**QuickInstall app**_ in `Hestia\WebApp\Installers\Xxx\XxxSetup` -> `$config['form']` you can set the value of the form field, but when the field type is **text** the value is not displayed.