### PR TITLE
Fix: #4181 Checks for usernames starting with a alphabetic character.

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -21,6 +21,9 @@ name=$5
 if [ -n "$6" ]; then
 	name="$name $6"
 fi
+
+FROM_V_ADD_USER=true
+
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf

--- a/func/main.sh
+++ b/func/main.sh
@@ -748,8 +748,12 @@ is_user_format_valid() {
 	if [ "$1" != "${1//[^[:ascii:]]/}" ]; then
 		check_result "$E_INVALID" "invalid $2 format :: $1"
 	fi
-	if ! [[ "$1" =~ ^[a-zA-Z]+ ]]; then
-		check_result "$E_INVALID" "invalid $2 format :: $1"
+
+	# Only for new users
+	if [[ "$FROM_V_ADD_USER" == "true" ]]; then
+		if ! [[ "$1" =~ ^[a-zA-Z][-|.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+			check_result "$E_INVALID" "invalid $2 format :: $1"
+		fi
 	fi
 }
 

--- a/func/main.sh
+++ b/func/main.sh
@@ -704,7 +704,30 @@ sync_cron_jobs() {
 	chmod 600 $crontab
 }
 
-# User format validator
+# Validates Local part email and mail alias
+is_localpart_format_valid() {
+	if [ ${#1} -eq 1 ]; then
+		if ! [[ "$1" =~ ^^[[:alnum:]]$ ]]; then
+			check_result "$E_INVALID" "invalid $2 format :: $1"
+		fi
+	else
+		if [ -n "$3" ]; then
+			maxlenght=$(($3 - 2))
+			if ! [[ "$1" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,$maxlenght}[[:alnum:]]$ ]]; then
+				check_result "$E_INVALID" "invalid $2 format :: $1"
+			fi
+		else
+			if ! [[ "$1" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+				check_result "$E_INVALID" "invalid $2 format :: $1"
+			fi
+		fi
+	fi
+	if [ "$1" != "${1//[^[:ascii:]]/}" ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Username / ftp username format validator
 is_user_format_valid() {
 	if [ ${#1} -eq 1 ]; then
 		if ! [[ "$1" =~ ^^[[:alnum:]]$ ]]; then
@@ -1188,7 +1211,7 @@ is_format_valid() {
 		if [ -n "$arg" ]; then
 			case $arg_name in
 				access_key_id) is_access_key_id_format_valid "$arg" "$arg_name" ;;
-				account) is_user_format_valid "$arg" "$arg_name" '64' ;;
+				account) is_localpart_format_valid "$arg" "$arg_name" '64' ;;
 				action) is_fw_action_format_valid "$arg" ;;
 				active) is_boolean_format_valid "$arg" 'active' ;;
 				aliases) is_alias_format_valid "$arg" ;;
@@ -1229,7 +1252,7 @@ is_format_valid() {
 				ip_status) is_ip_status_format_valid "$arg" ;;
 				job) is_int_format_valid "$arg" 'job' ;;
 				key) is_common_format_valid "$arg" "$arg_name" ;;
-				malias) is_user_format_valid "$arg" "$arg_name" '64' ;;
+				malias) is_localpart_format_valid "$arg" "$arg_name" '64' ;;
 				max_db) is_int_format_valid "$arg" 'max db' ;;
 				min) is_cron_format_valid "$arg" $arg_name ;;
 				month) is_cron_format_valid "$arg" $arg_name ;;

--- a/func/main.sh
+++ b/func/main.sh
@@ -725,6 +725,9 @@ is_user_format_valid() {
 	if [ "$1" != "${1//[^[:ascii:]]/}" ]; then
 		check_result "$E_INVALID" "invalid $2 format :: $1"
 	fi
+	if ! [[ "$1" =~ ^[a-zA-Z]+ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
 }
 
 # Domain format validator

--- a/test/test.bats
+++ b/test/test.bats
@@ -1887,11 +1887,11 @@ function check_ip_not_banned(){
 }
 
 @test "MYSQL: Add database 2" {
-		run v-add-database $user database 01 1234 mysql
+		run v-add-database $user 01 01 1234 mysql
 		assert_success
 		refute_output
 		# validate_database mysql database_name database_user password
-		validate_database mysql $database 'database_01' 1234
+		validate_database mysql "$user_01" "$user_01" 1234
 }
 
 @test "MYSQL: Add Database (Duplicate)" {

--- a/test/test.bats
+++ b/test/test.bats
@@ -1886,15 +1886,6 @@ function check_ip_not_banned(){
     validate_database mysql $database $dbuser 1234
 }
 
-@test "MYSQL: Add database 2" {
-		run v-add-database $user 01 01 1234 mysql
-		assert_success
-		refute_output
-		# validate_database mysql database_name database_user password
-		$test_db = "${$user}_01"
-		validate_database mysql $test_db" "test_db" 1234
-}
-
 @test "MYSQL: Add Database (Duplicate)" {
     run v-add-database $user database dbuser 1234 mysql
     assert_failure $E_EXISTS

--- a/test/test.bats
+++ b/test/test.bats
@@ -390,6 +390,12 @@ function check_ip_not_banned(){
 	assert_output --partial 'Error: invalid user format'
 }
 
+@test "User: Add new user Failed 5" {
+	run v-add-user '1aap'  $user $user@hestiacp2.com default "Super Test"
+	assert_failure $E_INVALID
+	assert_output --partial 'Error: invalid user format'
+}
+
 @test "User: Add new user Success 1" {
 	run v-add-user 'jaap01'  $user $user@hestiacp2.com default "Super Test"
 	assert_success

--- a/test/test.bats
+++ b/test/test.bats
@@ -1622,14 +1622,14 @@ function check_ip_not_banned(){
 		refute_output
 }
 
-@test "MAIL: Add account" {
+@test "MAIL: Add account 3" {
 		run v-add-mail-account $user $domain 0AA "$userpass2"
 		assert_success
 		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
 		refute_output
 }
 
-@test "MAIL: Add account" {
+@test "MAIL: Add account 4" {
 		run v-add-mail-account $user $domain A1234 "$userpass2"
 		assert_success
 		assert_file_contains /etc/exim4/domains/$domain/limits "A1234@$domain"

--- a/test/test.bats
+++ b/test/test.bats
@@ -1670,7 +1670,7 @@ function check_ip_not_banned(){
 }
 
 @test "MAIL: Add account 6" {
-		run v-add-mail-account $user $domain 0AA "$userpass2"
+		run v-add-mail-account $user $domain "0AA" "$userpass2"
 		assert_success
 		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
 		refute_output
@@ -1891,7 +1891,8 @@ function check_ip_not_banned(){
 		assert_success
 		refute_output
 		# validate_database mysql database_name database_user password
-		validate_database mysql "$user_01" "$user_01" 1234
+		$test_db = "${$user}_01"
+		validate_database mysql $test_db" "test_db" 1234
 }
 
 @test "MYSQL: Add Database (Duplicate)" {

--- a/test/test.bats
+++ b/test/test.bats
@@ -1672,7 +1672,7 @@ function check_ip_not_banned(){
 @test "MAIL: Add account 6" {
 		run v-add-mail-account $user $domain "0AA" "$userpass2"
 		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
+		assert_file_contains /etc/exim4/domains/$domain/limits "0AA"
 		refute_output
 }
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -1670,9 +1670,9 @@ function check_ip_not_banned(){
 }
 
 @test "MAIL: Add account 6" {
-		run v-add-mail-account $user $domain "0AA" "$userpass2"
+		run v-add-mail-account $user $domain "0aa" "$userpass2"
 		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "0AA"
+		assert_file_contains /etc/exim4/domains/$domain/limits "0aa@$domain"
 		refute_output
 }
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -1615,27 +1615,6 @@ function check_ip_not_banned(){
     refute_output
 }
 
-@test "MAIL: Add account 2" {
-		run v-add-mail-account $user $domain 01 "$userpass2"
-		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "01@$domain"
-		refute_output
-}
-
-@test "MAIL: Add account 3" {
-		run v-add-mail-account $user $domain 0AA "$userpass2"
-		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
-		refute_output
-}
-
-@test "MAIL: Add account 4" {
-		run v-add-mail-account $user $domain A1234 "$userpass2"
-		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "A1234@$domain"
-		refute_output
-}
-
 @test "MAIL: Add account (duplicate)" {
 	run v-add-mail-account $user $domain test "$userpass2"
 	assert_failure $E_EXISTS
@@ -1646,6 +1625,27 @@ function check_ip_not_banned(){
 	assert_success
 	assert_file_contains  /etc/exim4/domains/$domain/limits "random@$domain"
 	refute_output
+}
+
+@test "MAIL: Add account 3" {
+		run v-add-mail-account $user $domain 01 "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "01@$domain"
+		refute_output
+}
+
+@test "MAIL: Add account 4" {
+		run v-add-mail-account $user $domain 0AA "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
+		refute_output
+}
+
+@test "MAIL: Add account 5" {
+		run v-add-mail-account $user $domain A1234 "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "A1234@$domain"
+		refute_output
 }
 
 @test "MAIL: Add account alias" {

--- a/test/test.bats
+++ b/test/test.bats
@@ -384,6 +384,24 @@ function check_ip_not_banned(){
 	assert_output --partial 'Error: invalid user format'
 }
 
+@test "User: Add new user Failed 4" {
+	run v-add-user '1234'  $user $user@hestiacp2.com default "Super Test"
+	assert_failure $E_INVALID
+	assert_output --partial 'Error: invalid user format'
+}
+
+@test "User: Add new user Success 1" {
+	run v-add-user 'jaap01'  $user $user@hestiacp2.com default "Super Test"
+	assert_success
+	refute_output
+}
+
+@test "User: Add new user Success 1 Delete" {
+	run v-delete-user jaap01
+	assert_success
+	refute_output
+}
+
 @test "User: Change user password" {
     run v-change-user-password "$user" "$userpass2"
     assert_success
@@ -1597,6 +1615,27 @@ function check_ip_not_banned(){
     refute_output
 }
 
+@test "MAIL: Add account 2" {
+		run v-add-mail-account $user $domain 01 "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "01@$domain"
+		refute_output
+}
+
+@test "MAIL: Add account" {
+		run v-add-mail-account $user $domain 0AA "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
+		refute_output
+}
+
+@test "MAIL: Add account" {
+		run v-add-mail-account $user $domain A1234 "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "A1234@$domain"
+		refute_output
+}
+
 @test "MAIL: Add account (duplicate)" {
 	run v-add-mail-account $user $domain test "$userpass2"
 	assert_failure $E_EXISTS
@@ -1854,6 +1893,15 @@ function check_ip_not_banned(){
     # validate_database mysql database_name database_user password
     validate_database mysql $database $dbuser 1234
 }
+
+@test "MYSQL: Add database" {
+		run v-add-database $user database 01 1234 mysql
+		assert_success
+		refute_output
+		# validate_database mysql database_name database_user password
+		validate_database mysql $database 'database_01' 1234
+}
+
 @test "MYSQL: Add Database (Duplicate)" {
     run v-add-database $user database dbuser 1234 mysql
     assert_failure $E_EXISTS

--- a/test/test.bats
+++ b/test/test.bats
@@ -1886,7 +1886,7 @@ function check_ip_not_banned(){
     validate_database mysql $database $dbuser 1234
 }
 
-@test "MYSQL: Add database" {
+@test "MYSQL: Add database 2" {
 		run v-add-database $user database 01 1234 mysql
 		assert_success
 		refute_output

--- a/test/test.bats
+++ b/test/test.bats
@@ -1627,27 +1627,6 @@ function check_ip_not_banned(){
 	refute_output
 }
 
-@test "MAIL: Add account 3" {
-		run v-add-mail-account $user $domain 01 "$userpass2"
-		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "01@$domain"
-		refute_output
-}
-
-@test "MAIL: Add account 4" {
-		run v-add-mail-account $user $domain 0AA "$userpass2"
-		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
-		refute_output
-}
-
-@test "MAIL: Add account 5" {
-		run v-add-mail-account $user $domain A1234 "$userpass2"
-		assert_success
-		assert_file_contains /etc/exim4/domains/$domain/limits "A1234@$domain"
-		refute_output
-}
-
 @test "MAIL: Add account alias" {
 	run v-add-mail-account-alias $user $domain test hestiacprocks
 	assert_success
@@ -1683,6 +1662,19 @@ function check_ip_not_banned(){
 	refute_output
 }
 
+@test "MAIL: Add account 5" {
+		run v-add-mail-account $user $domain 01 "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "01@$domain"
+		refute_output
+}
+
+@test "MAIL: Add account 6" {
+		run v-add-mail-account $user $domain 0AA "$userpass2"
+		assert_success
+		assert_file_contains /etc/exim4/domains/$domain/limits "0AA@$domain"
+		refute_output
+}
 
 @test "MAIL: Add account alias Invalid length" {
 	run v-add-mail-account-alias $user $domain test 'hestiacp-realy-rocks-but-i-want-to-have-feature-xyz-and-i-want-it-now'


### PR DESCRIPTION
Added an "username starting with a alphabetic character" check to function `is_user_format_valid()`

Testing results:
```bash
root@hestia:~# bash v-add-user asdas123 test "me@xxxxxxxxx.nu"
root@hestia:~# bash v-add-user asdadaaa test "me@xxxxxxxxx.nu"
root@hestia:~# bash v-add-user 12345 test "me@xxxxxxxxx.nu"
Error: invalid user format :: 12345
root@hestia:~# bash v-add-user 12345asdasd test "me@xxxxxxxxx.nu"
Error: invalid user format :: 12345asdasd
root@hestia:~# bash v-add-user 12asdad123 test "me@xxxxxxxxx.nu"
Error: invalid user format :: 12asdad123
root@hestia:~# bash v-add-user 12asdad123aaa test "me@xxxxxxxxx.nu"
Error: invalid user format :: 12asdad123aaa
```

Closes #4181 