### PR TITLE
Email docs: added examples

### DIFF
--- a/docs/docs/server-administration/email.md
+++ b/docs/docs/server-administration/email.md
@@ -10,6 +10,14 @@ Execute the following script and follow the instructions:
 bash /usr/local/hestia/install/upgrade/manual/configure-server-smtp.sh
 ```
 
+The script will ask you for the following SMTP parameters:
+- Host (e.g. `smtp.example.com`)
+- Port (e.g. `25`, `465` or `587`)
+- Security (e.g. `STARTTLS`)
+- Username
+- Password
+- Email Address (i.e. the sender address).
+
 ## I am unable to send email
 
 First, check that port 25 is open for outgoing traffic. A lot of providers block port 25 by default to combat spam.

--- a/docs/docs/server-administration/email.md
+++ b/docs/docs/server-administration/email.md
@@ -11,6 +11,7 @@ bash /usr/local/hestia/install/upgrade/manual/configure-server-smtp.sh
 ```
 
 The script will ask you for the following SMTP parameters:
+
 - Host (e.g. `smtp.example.com`)
 - Port (e.g. `25`, `465` or `587`)
 - Security (e.g. `STARTTLS`)


### PR DESCRIPTION
I added some examples in the docs about setting up an external SMTP.

I spent some time trying to understand what should I put when asked for "SMTP security" (it was `STARTTLS` in my case) so I hope this will be useful to somebody else.