### PR TITLE
Tweak Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,9 @@
 		"config:best-practices",
 		":pinAllExceptPeerDependencies",
 		":disableDependencyDashboard",
+		":automergeLinters",
 		"group:allNonMajor",
-		"schedule:weekdays",
-		":automergeLinters"
+		"schedule:weekly"
 	],
 	"enabledManagers": ["npm", "composer", "github-actions"],
 	"ignorePaths": ["**/node_modules/**", "install/deb/filemanager/filegator/composer.json"],


### PR DESCRIPTION
- Switch to running weekly (Monday) instead of week days. Doesn't feel like this project needs daily dependency updates
- Move `:automergeLinters` before the `group:allNonMajor` maybe that will fix linting deps not being grouped and merged automatically 🤷 