### PR TITLE
Run lint CI on LTS Node

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
-          node-version: 16
+          node-version: "lts/*"
 
       - name: Install Node packages
         run: npm ci --ignore-scripts
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
-          node-version: 16
+          node-version: "lts/*"
 
       - name: Install Node packages
         run: npm ci --ignore-scripts
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
-          node-version: 16
+          node-version: "lts/*"
 
       - name: Install Node packages
         run: npm ci --ignore-scripts


### PR DESCRIPTION
No need to run our linting CI scripts on an old Node version.