### PR TITLE
Add mjs as a file to serve statically

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -194,7 +194,7 @@ if [ -n "$PROXY_SYSTEM" ]; then
 	PROXY_EXT="$proxy_ext"
 	if [ -z "$proxy_ext" ]; then
 		# Code
-		PROXY_EXT="css,htm,html,js,json,xml"
+		PROXY_EXT="css,htm,html,js,mjs,json,xml"
 		# Image (from https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types)
 		PROXY_EXT="$PROXY_EXT,apng,avif,bmp,cur,gif,ico,jfif,jpg,jpeg,pjp,pjpeg,png,svg,tif,tiff,webp"
 		# Audio from (https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Audio_codecs)


### PR DESCRIPTION
.mjs is used to denote a ES Module Javascript file, separating it from .js which typically contains a CommonJS, AMD or direct browser code. .mjs is increasingly being used to deliver ESM files over the web, not just for package builders, through the use of import maps.

I think it makes sense to add .mjs files to those which nginx should serve statically.