### PR TITLE
Don't run v-add-user-jail for every user during rebuild

### DIFF
--- a/bin/v-add-user-ssh-jail
+++ b/bin/v-add-user-ssh-jail
@@ -51,6 +51,7 @@ if [ -d "/home/$user" ]; then
 	chown root:root /home/$user
 fi
 
+# Prevent from enabling for users hen rssh or nologin is enabled
 user_str=$(grep "^$user:" /etc/passwd | egrep "rssh|nologin")
 if [ -n "$user_str" ]; then
 	exit

--- a/bin/v-add-user-ssh-jail
+++ b/bin/v-add-user-ssh-jail
@@ -58,29 +58,29 @@ if [ -n "$user_str" ]; then
 fi
 
 if [ ! -d "$chroot" ]; then
-add_chroot_jail "$user"
+	add_chroot_jail "$user"
 
-# Add user to the ssh-jailed group to allow jailed ssh
-# This needs to be done first to make sure these groups are made available in the jail
-usermod -a -G ssh-jailed "$user"
+	# Add user to the ssh-jailed group to allow jailed ssh
+	# This needs to be done first to make sure these groups are made available in the jail
+	usermod -a -G ssh-jailed "$user"
 
-# Installing shell files into the user chroot directory
-# - IMPORTANT - MODIFY THE FOLLOWING LINES AND THE FILE jk_init.ini ACCORDING TO YOUR SYSTEM AND YOUR PREFERENCES
-/sbin/jk_init -f -j "$chroot" extendedshell netutils ssh sftp scp git php php5_6 php7_0 php7_1 php7_2 php7_3 php7_4 php8_0 php8_1 php8_2 > /dev/null 2>&1
-/sbin/jk_cp -f -j "$chroot" /bin/id > /dev/null 2>&1
+	# Installing shell files into the user chroot directory
+	# - IMPORTANT - MODIFY THE FOLLOWING LINES AND THE FILE jk_init.ini ACCORDING TO YOUR SYSTEM AND YOUR PREFERENCES
+	/sbin/jk_init -f -j "$chroot" extendedshell netutils ssh sftp scp git php php5_6 php7_0 php7_1 php7_2 php7_3 php7_4 php8_0 php8_1 php8_2 > /dev/null 2>&1
+	/sbin/jk_cp -f -j "$chroot" /bin/id > /dev/null 2>&1
 
-# Jailing user to make sure passwd and groups are set correctly within the jail.
-# This command also does a little too much by changing the users homedir and
-# shell in /etc/passwd. The next commands reverts those changes for compatibility
-# with hestia.
-/sbin/jk_jailuser -n -s "$shell_path" -j "$chroot" "$user"
+	# Jailing user to make sure passwd and groups are set correctly within the jail.
+	# This command also does a little too much by changing the users homedir and
+	# shell in /etc/passwd. The next commands reverts those changes for compatibility
+	# with hestia.
+	/sbin/jk_jailuser -n -s "$shell_path" -j "$chroot" "$user"
 
-# Reset home directory and shell again for hestiacp because jailkit changes these.
-# Normally these are needed to redirect the ssh user to it's chroot but because we
-# use a custom sshd_config to redirect the user to it's chroot we don't need it to be
-# changed in /etc/passwd for the user.
-usermod -d "/home/$user" "$user" > /dev/null 2>&1
-usermod -s "$shell_path" "$user" > /dev/null 2>&1
+	# Reset home directory and shell again for hestiacp because jailkit changes these.
+	# Normally these are needed to redirect the ssh user to it's chroot but because we
+	# use a custom sshd_config to redirect the user to it's chroot we don't need it to be
+	# changed in /etc/passwd for the user.
+	usermod -d "/home/$user" "$user" > /dev/null 2>&1
+	usermod -s "$shell_path" "$user" > /dev/null 2>&1
 
 else
 	/sbin/jk_update -f -j "$chroot" > /dev/null 2>&1

--- a/bin/v-add-user-ssh-jail
+++ b/bin/v-add-user-ssh-jail
@@ -57,29 +57,36 @@ if [ -n "$user_str" ]; then
 	exit
 fi
 
+if [ ! -d "$chroot" ]; then
 add_chroot_jail "$user"
 
 # Add user to the ssh-jailed group to allow jailed ssh
 # This needs to be done first to make sure these groups are made available in the jail
-usermod -a -G ssh-jailed $user
+usermod -a -G ssh-jailed "$user"
 
 # Installing shell files into the user chroot directory
 # - IMPORTANT - MODIFY THE FOLLOWING LINES AND THE FILE jk_init.ini ACCORDING TO YOUR SYSTEM AND YOUR PREFERENCES
-/sbin/jk_init -f -j $chroot extendedshell netutils ssh sftp scp git php php5_6 php7_0 php7_1 php7_2 php7_3 php7_4 php8_0 php8_1 php8_2 > /dev/null 2>&1
-/sbin/jk_cp -f -j $chroot /bin/id > /dev/null 2>&1
+/sbin/jk_init -f -j "$chroot" extendedshell netutils ssh sftp scp git php php5_6 php7_0 php7_1 php7_2 php7_3 php7_4 php8_0 php8_1 php8_2 > /dev/null 2>&1
+/sbin/jk_cp -f -j "$chroot" /bin/id > /dev/null 2>&1
 
 # Jailing user to make sure passwd and groups are set correctly within the jail.
 # This command also does a little too much by changing the users homedir and
 # shell in /etc/passwd. The next commands reverts those changes for compatibility
 # with hestia.
-/sbin/jk_jailuser -n -s $shell_path -j $chroot $user
+/sbin/jk_jailuser -n -s "$shell_path" -j "$chroot" "$user"
 
 # Reset home directory and shell again for hestiacp because jailkit changes these.
 # Normally these are needed to redirect the ssh user to it's chroot but because we
 # use a custom sshd_config to redirect the user to it's chroot we don't need it to be
 # changed in /etc/passwd for the user.
-usermod -d /home/$user $user
-usermod -s $shell_path $user
+usermod -d "/home/$user" "$user" > /dev/null 2>&1
+usermod -s "$shell_path" "$user" > /dev/null 2>&1
+
+else
+	/sbin/jk_update -f -j "$chroot" > /dev/null 2>&1
+	usermod -d "/home/$user" "$user" > /dev/null 2>&1
+	usermod -s "$shell_path" "$user" > /dev/null 2>&1
+fi
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-add-user-ssh-jail
+++ b/bin/v-add-user-ssh-jail
@@ -51,6 +51,11 @@ if [ -d "/home/$user" ]; then
 	chown root:root /home/$user
 fi
 
+user_str=$(grep "^$user:" /etc/passwd | egrep "rssh|nologin")
+if [ -n "$user_str" ]; then
+	exit
+fi
+
 add_chroot_jail "$user"
 
 # Add user to the ssh-jailed group to allow jailed ssh

--- a/bin/v-change-user-shell
+++ b/bin/v-change-user-shell
@@ -32,7 +32,7 @@ is_format_valid 'user' 'shell shell_jail_enabled'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
 
-if [[ "$shell" =~ nologin ]] || [[ "$shell" =~ rssh ]] &&  [[ "$shell_jail_enabled" =~ yes ]]; then
+if [[ "$shell" =~ nologin ]] || [[ "$shell" =~ rssh ]] && [[ "$shell_jail_enabled" =~ yes ]]; then
 	check_result "$E_INVALID" "nologin and rssh can't be jailed"
 fi
 

--- a/bin/v-change-user-shell
+++ b/bin/v-change-user-shell
@@ -27,7 +27,7 @@ source $HESTIA/conf/hestia.conf
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '3' "$#" 'USER SHELL SHELL_JAIL_ENABLED'
+check_args '2' "$#" 'USER SHELL SHELL_JAIL_ENABLED'
 is_format_valid 'user' 'shell shell_jail_enabled'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"

--- a/bin/v-change-user-shell
+++ b/bin/v-change-user-shell
@@ -32,6 +32,10 @@ is_format_valid 'user' 'shell shell_jail_enabled'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
 
+if [[ "$shell" =~ nologin ]] || [[ "$shell" =~ rssh ]] &&  [[ "$shell_jail_enabled" =~ yes ]]; then
+	check_result "$E_INVALID" "nologin and rssh can't be jailed"
+fi
+
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
 

--- a/bin/v-delete-user-ssh-jail
+++ b/bin/v-delete-user-ssh-jail
@@ -45,15 +45,15 @@ user_shell_rssh_nologin=$(grep "^$user:" /etc/passwd | egrep "rssh|nologin")
 if [ -z "$user_shell_rssh_nologin" ]; then
 	# chown permissions back to user:user
 	if [ -d "/home/$user" ]; then
-		chown $user:$user /home/$user
+		chown "$user":"$user" "/home/$user"
 	fi
 
 	# Deleting chroot jail for SSH
-	delete_chroot_jail $user
+	delete_chroot_jail "$user"
 fi
 
 # Deleting user from groups
-gpasswd -d $user ssh-jailed > /dev/null 2>&1
+gpasswd -d "$user" ssh-jailed > /dev/null 2>&1
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -126,6 +126,7 @@ rebuild_user_conf() {
 	chown root:root $HOMEDIR/$user/conf
 
 	$BIN/v-add-user-sftp-jail "$user"
+	# Check if SHELL_JAIL_ENABLED
 	if [ "$SHELL_JAIL_ENABLED" == "yes" ]; then
 		$BIN/v-add-user-ssh-jail "$user"
 	fi

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -126,8 +126,9 @@ rebuild_user_conf() {
 	chown root:root $HOMEDIR/$user/conf
 
 	$BIN/v-add-user-sftp-jail "$user"
-
-	$BIN/v-add-user-ssh-jail "$user"
+	if [ "$SHELL_JAIL_ENABLED" == "yes" ]; then
+		$BIN/v-add-user-ssh-jail "$user"
+	fi
 
 	# Update disk pipe
 	sed -i "/ $user$/d" $HESTIA/data/queue/disk.pipe


### PR DESCRIPTION
When v-rebuild-user ran all accounts would enable it on default.   