### PR TITLE
Auto fix PRs that fail Prettier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,8 +48,20 @@ jobs:
       - name: Install Node packages
         run: npm ci --ignore-scripts
 
-      - name: Run Prettier
+      - name: Check formatting
         run: npx prettier --check .
+
+      - name: Apply formatting
+        if: github.event_name == 'pull_request'
+        run: npm run format
+
+      - name: Commit formatting changes
+        if: github.event_name == 'pull_request'
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: Apply Prettier formatting
+          add: "."
 
   eslint:
     name: ESLint


### PR DESCRIPTION
## Current problem

We use Prettier to format our code. This works great for core maintainers and others who have the project [setup for local development](https://hestiacp.com/docs/contributing/development.html) where development tools are installed and Prettier auto-formats on commit.

It doesn't work so well for other contributors who just want to e.g. fix a couple lines of code, which seem the majority of PRs. They understandably don't want to setup the project locally, and instead make the changes from the GitHub UI.

This results in a PR that fails the Prettier check we have in CI, unless they are very careful with the formatting. Usually Jaap then adds a commit to fix the issue before merging.

## Proposed solution

If it's a PR then run "npm run format" and commit if any changes.

This should be the same end result as the commit Jaap makes, but automatic.