### PR TITLE
bugfix: v-backup-user >>> fix for missing dotfile backup

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -390,9 +390,9 @@ if [ -n "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
 
 		# Backup files
 		if [ "$BACKUP_MODE" = 'zstd' ]; then
-			tar "${fargs[@]}" -cpf- * | pzstd -"$BACKUP_GZIP" - > $tmpdir/web/$domain/domain_data.tar.zst
+			tar "${fargs[@]}" -cpf- . | pzstd -"$BACKUP_GZIP" - > $tmpdir/web/$domain/domain_data.tar.zst
 		else
-			tar "${fargs[@]}" -cpf- * | gzip -"$BACKUP_GZIP" - > $tmpdir/web/$domain/domain_data.tar.gz
+			tar "${fargs[@]}" -cpf- . | gzip -"$BACKUP_GZIP" - > $tmpdir/web/$domain/domain_data.tar.gz
 		fi
 	done
 


### PR DESCRIPTION
bugfix for: Allow for optional domain directory write permissions https://github.com/hestiacp/hestiacp/pull/4109

`*` was causing dotfiles to be excluded. replaced with `.` lines 393 & 395