### PR TITLE
Tweak Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,9 @@
 	"extends": [
 		"config:best-practices",
 		":pinAllExceptPeerDependencies",
-		":disableDependencyDashboard",
 		":automergeLinters",
 		"group:allNonMajor",
-		"schedule:weekly"
+		"schedule:weekdays"
 	],
 	"enabledManagers": ["npm", "composer", "github-actions"],
 	"ignorePaths": ["**/node_modules/**", "install/deb/filemanager/filegator/composer.json"],


### PR DESCRIPTION
It looks like #4235 stopped Renovate creating PRs, not sure why.

This PR enables the dependency dashboard (temporarily) to get more insight into why this is happening.

It also changes the schedule from weekly to week days (temporarily, until this is running smoothly).