### PR TITLE
Add group:linters to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
 		":pinAllExceptPeerDependencies",
 		":automergeLinters",
 		"group:allNonMajor",
+		"group:linters",
 		"schedule:weekdays"
 	],
 	"enabledManagers": ["npm", "composer", "github-actions"],


### PR DESCRIPTION
Our Renovate config has "group:allNonMajor" preset which groups all non-major upgrades together in one PR. It also has ":automergeLinters" preset, which allows a PR containing only linting dependencies to merge automatically.

The problem is, non-major linting dependencies get included in "group:allNonMajor" PRs ([example](https://github.com/hestiacp/hestiacp/pull/4271)). Because these PRs usually also contain other non-linting dependencies, the PR cannot automerge.

To fix this I have added "group:linters" to explicitly group linting dependencies together. This should separate the dependencies into two different PRs, one that automerges, one that doesn't.

<details>
<summary>More information</summary>

We could ditch the presets and manually define two groups using `packageRules`. But it would be nice to keep the Renovate config as simple as possible to keep maintenance overhead to a minimum. `group:linters` for example may not accurately match every linting dependency we use, but it's better than having to define and maintain the different package names in this Renovate config imo.

</details>