### PR TITLE
Remove PHP code, and fix installer warning

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -35,11 +35,10 @@ source_conf "$HESTIA/conf/hestia.conf"
 is_user_free() {
 	# these names may cause issues with MariaDB/MySQL database names and should be reserved:
 	# sudo has been added due to Privilege escalation as sudo group has always sudo permission
-	check_sysuser=$(php -r '$reserved_names=array("aria", "aria_log", "mysql", "mysql_upgrade", "ib", "ib_buffer",
- "ddl", "ddl_recovery", "performance", "sudo"); if(in_array(strtolower($argv[1]), $reserved_names, true)){echo implode(", ", $reserved_names);}' "$user")
-	if [ -n "$check_sysuser" ]; then
-		check_result "$E_INVALID" "The user name '$user' is reserved and cannot be used. List of reserved names: $check_sysuser"
-		return
+	reserved_names=("aria" "aria_log" "mysql" "mysql_upgrade" "ib" "ib_buffer" "ddl" "ddl_recovery" "performance" "sudo")
+	if [[ "${reserved_names[@],,}" =~ "${user,,}" ]]; then
+        	check_result "$E_INVALID" "The user name '$user' is reserved and cannot be used. List of reserved names: ${reserved_names[*]}"
+        	return
 	fi
 	check_sysuser=$(cut -f 1 -d : /etc/passwd | grep "^$user$")
 	if [ -n "$check_sysuser" ] || [ -e "$USER_DATA" ]; then

--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -36,12 +36,11 @@ is_user_free() {
 	# these names may cause issues with MariaDB/MySQL database names and should be reserved:
 	# sudo has been added due to Privilege escalation as sudo group has always sudo permission
 	reserved_names=("aria" "aria_log" "mysql" "mysql_upgrade" "ib" "ib_buffer" "ddl" "ddl_recovery" "performance" "sudo")
-	for value in "${reserved_names[@]}"
-	do
-	if [ "${user,,}" = "$value" ]; then
-        	check_result "$E_INVALID" "The user name '$user' is reserved and cannot be used. List of reserved names: ${reserved_names[*]}"
-        	return
-	fi
+	for value in "${reserved_names[@]}"; do
+		if [ "${user,,}" = "$value" ]; then
+			check_result "$E_INVALID" "The user name '$user' is reserved and cannot be used. List of reserved names: ${reserved_names[*]}"
+			return
+		fi
 	done
 
 	check_sysuser=$(cut -f 1 -d : /etc/passwd | grep "^$user$")

--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -36,10 +36,14 @@ is_user_free() {
 	# these names may cause issues with MariaDB/MySQL database names and should be reserved:
 	# sudo has been added due to Privilege escalation as sudo group has always sudo permission
 	reserved_names=("aria" "aria_log" "mysql" "mysql_upgrade" "ib" "ib_buffer" "ddl" "ddl_recovery" "performance" "sudo")
-	if [[ "${reserved_names[@],,}" =~ "${user,,}" ]]; then
+	for value in "${reserved_names[@]}"
+	do
+	if [ "${user,,}" = "$value" ]; then
         	check_result "$E_INVALID" "The user name '$user' is reserved and cannot be used. List of reserved names: ${reserved_names[*]}"
         	return
 	fi
+	done
+
 	check_sysuser=$(cut -f 1 -d : /etc/passwd | grep "^$user$")
 	if [ -n "$check_sysuser" ] || [ -e "$USER_DATA" ]; then
 		check_result "$E_EXISTS" "user $user exists"

--- a/test/test.bats
+++ b/test/test.bats
@@ -396,6 +396,12 @@ function check_ip_not_banned(){
 	assert_output --partial 'Error: invalid user format'
 }
 
+@test "User: Add new user Failed 6" {
+	run v-add-user 'ib_Buffer'  $user $user@hestiacp2.com default "Super Test"
+	assert_failure $E_INVALID
+	assert_output --partial 'Error: invalid user format'
+}
+
 @test "User: Add new user Success 1" {
 	run v-add-user 'jaap01'  $user $user@hestiacp2.com default "Super Test"
 	assert_success
@@ -404,6 +410,18 @@ function check_ip_not_banned(){
 
 @test "User: Add new user Success 1 Delete" {
 	run v-delete-user jaap01
+	assert_success
+	refute_output
+}
+
+@test "User: Add new user Success 2" {
+	run v-add-user 'buffer'  $user $user@hestiacp2.com default "Super Test"
+	assert_success
+	refute_output
+}
+
+@test "User: Add new user Success 2 Delete" {
+	run v-delete-user buffer
 	assert_success
 	refute_output
 }

--- a/test/test.bats
+++ b/test/test.bats
@@ -399,7 +399,7 @@ function check_ip_not_banned(){
 @test "User: Add new user Failed 6" {
 	run v-add-user 'ib_Buffer'  $user $user@hestiacp2.com default "Super Test"
 	assert_failure $E_INVALID
-	assert_output --partial 'Error: invalid user format'
+	assert_output --partial 'Error: The user name'
 }
 
 @test "User: Add new user Success 1" {


### PR DESCRIPTION
When install hestia, 

Installer first add user and then install PHP, so this php code return a warning 

/usr/local/hestia/bin/v-add-user: line 36: php: command not found

So why add php code to pure bash script :/