### PR TITLE
fix/minor-ui-fix-corrected-shadow-position-on-spinner

### DIFF
--- a/web/css/src/themes/default.css
+++ b/web/css/src/themes/default.css
@@ -2308,7 +2308,7 @@
 
 	& .fas {
 		border-radius: 50%;
-		box-shadow: 0 8px 40px 0 rgb(0 0 0 / 35%);
+		box-shadow: 0 0px 40px 0 rgb(0 0 0 / 35%);
 	}
 }
 


### PR DESCRIPTION
Spinner shadow offset in combination with rotating made it seem like the light was coming from a different direction, while in reality the spinner itself is moving.