### PR TITLE
Fix to the Localpart Mail validator so it can accept aliases starting and ending with -

### DIFF
--- a/bin/v-delete-mail-account-alias
+++ b/bin/v-delete-mail-account-alias
@@ -42,7 +42,7 @@ is_object_valid 'user' 'USER' "$user"
 is_object_valid 'mail' 'DOMAIN' "$domain"
 is_object_valid "mail/$domain" 'ACCOUNT' "$account"
 aliases=$(get_object_value "mail/$domain" 'ACCOUNT' "$account" '$ALIAS')
-if [ -z "$(echo $aliases | grep -w $malias)" ]; then
+if [ -z "$(echo $aliases | grep -w -e $malias)" ]; then
 	echo "Error: alias $malias doesn't exist"
 	log_event "$E_NOTEXIST $ARGUMENTS"
 	exit "$E_NOTEXIST"

--- a/func/main.sh
+++ b/func/main.sh
@@ -707,17 +707,19 @@ sync_cron_jobs() {
 # Validates Local part email and mail alias
 is_localpart_format_valid() {
 	if [ ${#1} -eq 1 ]; then
-		if ! [[ "$1" =~ ^^[[:alnum:]]$ ]]; then
+		if ! [[ "$1" =~ ^[[:alnum:]]$ ]]; then
 			check_result "$E_INVALID" "invalid $2 format :: $1"
 		fi
 	else
 		if [ -n "$3" ]; then
 			maxlenght=$(($3 - 2))
-			if ! [[ "$1" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,$maxlenght}[[:alnum:]]$ ]]; then
+			# Allow leading and trailing special characters by adjusting the regex
+			if ! [[ "$1" =~ ^[[:alnum:]_.-][[:alnum:]_.-]{0,$maxlenght}[[:alnum:]_.-]$ ]]; then
 				check_result "$E_INVALID" "invalid $2 format :: $1"
 			fi
 		else
-			if ! [[ "$1" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+			# Allow leading and trailing special characters by adjusting the regex
+			if ! [[ "$1" =~ ^[[:alnum:]_.-][[:alnum:]_.-]{0,28}[[:alnum:]_.-]$ ]]; then
 				check_result "$E_INVALID" "invalid $2 format :: $1"
 			fi
 		fi

--- a/test/test.bats
+++ b/test/test.bats
@@ -1701,12 +1701,20 @@ function check_ip_not_banned(){
 }
 
 @test "MAIL: Add account alias Invalid length" {
-	run v-add-mail-account-alias $user $domain test 'hestiacp-realy-rocks-but-i-want-to-have-feature-xyz-and-i-want-it-now'
+	run v-add-mail-account-alias $user $domain test 'hestiacp-really-rocks-but-i-want-to-have-feature-xyz-and-i-want-it-now'
 	assert_failure $E_INVALID
 }
 @test "MAIL: Add account alias Invalid" {
-	run v-add-mail-account-alias $user $domain test '-test'
+	run v-add-mail-account-alias $user $domain test 'test+123'
 	assert_failure $E_INVALID
+}
+@test "MAIL: Add account alias starting with -" {
+	run v-add-mail-account-alias $user $domain test '-test'
+	assert_success
+}
+@test "MAIL: Add account alias ending with -" {
+	run v-add-mail-account-alias $user $domain test 'test-'
+	assert_success
 }
 @test "MAIL: Add account alias Invalid 2" {
 	run v-add-mail-account-alias $user $domain test 'hestia@test'


### PR DESCRIPTION
Following my reading of issue #3818 - and checking if the error still happened, I found that some changes were necessary so that #3818 can be closed completely. With this change, E-Mail Aliases and local parts beginning and ending with "-" can be used.