### PR TITLE
Fix v-add-dns-record when adding TLSA records

### DIFF
--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -71,7 +71,7 @@ fi
 if [ "$rtype" != "CAA" ]; then
 	dvalue=${dvalue//\"/}
 	# Add support for DS key
-	if [ "$rtype" != "DNSKEY" ] && [ "$rtype" != "DS" ]; then
+	if [ "$rtype" != "DNSKEY" ] && [ "$rtype" != "DS" ] && [ "$rtype" != "TLSA" ]; then
 		if [ "$rtype" != 'SRV' ] && [[ "$dvalue" =~ [\;[:space:]] ]]; then
 			dvalue='"'"$dvalue"'"'
 		fi


### PR DESCRIPTION
Hestia encloses value of TLSA records with double quotes and Bind doesn't allow it, giving a SERVFAIL when trying to query any type of record of that zone.