### PR TITLE
Fix roundcube permissions

### DIFF
--- a/bin/v-add-sys-roundcube
+++ b/bin/v-add-sys-roundcube
@@ -116,9 +116,9 @@ if [ "$UPDATE" == "no" ]; then
 	ln -s $RC_CONFIG_DIR/plugins/zipdownload/config.inc.php ./plugins/zipdownload/config.inc.php
 
 	# Set up correct permissions roundcube
-	chown -R root:hestiamail $RC_CONFIG_DIR/
+	chown -R hestiamail:www-data $RC_CONFIG_DIR/
 	chmod 751 -R $RC_CONFIG_DIR
-	chmod 644 $RC_CONFIG_DIR/config.inc.php
+	chmod 640 $RC_CONFIG_DIR/config.inc.php
 	chmod 644 $RC_CONFIG_DIR/plugins/password/config.inc.php
 	chmod 644 $RC_CONFIG_DIR/plugins/newmail_notifier/config.inc.php
 	chmod 644 $RC_CONFIG_DIR/plugins/zipdownload/config.inc.php
@@ -127,13 +127,13 @@ if [ "$UPDATE" == "no" ]; then
 	echo "User-agent: *" > /var/lib/roundcube/robots.txt
 	echo "Disallow: /" >> /var/lib/roundcube/robots.txt
 
-	chown -R root:hestiamail $RC_INSTALL_DIR
+	chown -R hestiamail:www-data $RC_INSTALL_DIR
 
 	# Log file
 	if [ ! -d $RC_LOG ]; then
 		mkdir $RC_LOG
 	fi
-	chown hestiamail:hestiamail $RC_LOG
+	chown hestiamail:www-data $RC_LOG
 	chmod 751 $RC_LOG
 
 	if [ ! -z "$(echo "$DB_SYSTEM" | grep -E 'mysql|pgsql')" ]; then
@@ -192,7 +192,7 @@ else
 	export COMPOSER_ALLOW_SUPERUSER=1
 	$RC_INSTALL_DIR/bin/update.sh --version "$version" > /dev/null 2>&1
 	$RC_INSTALL_DIR/bin/indexcontacts.sh > /dev/null 2>&1
-	chown -R root:hestiamail $RC_INSTALL_DIR
+	chown -R hestiamail:www-data $RC_INSTALL_DIR
 
 	#clean up the mess
 	if [ -d "$RC_INSTALL_DIR/installer" ]; then

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -2190,11 +2190,12 @@ if [ "$sieve" = 'yes' ]; then
 		mkdir -p $RC_CONFIG_DIR/plugins/managesieve
 		cp -f $HESTIA_COMMON_DIR/roundcube/plugins/config_managesieve.inc.php $RC_CONFIG_DIR/plugins/managesieve/config.inc.php
 		ln -s $RC_CONFIG_DIR/plugins/managesieve/config.inc.php $RC_INSTALL_DIR/plugins/managesieve/config.inc.php
-		chown -R root:hestiamail $RC_CONFIG_DIR/
+		chown -R hestiamail:www-data $RC_CONFIG_DIR/
 		chmod 751 -R $RC_CONFIG_DIR
 		chmod 644 $RC_CONFIG_DIR/*.php
 		chmod 644 $RC_CONFIG_DIR/plugins/managesieve/config.inc.php
 		sed -i "s/\"archive\"/\"archive\", \"managesieve\"/g" $RC_CONFIG_DIR/config.inc.php
+		chmod 640 $RC_CONFIG_DIR/config.inc.php
 	fi
 
 	# Restart Dovecot and exim4

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -2165,11 +2165,12 @@ if [ "$sieve" = 'yes' ]; then
 		mkdir -p $RC_CONFIG_DIR/plugins/managesieve
 		cp -f $HESTIA_COMMON_DIR/roundcube/plugins/config_managesieve.inc.php $RC_CONFIG_DIR/plugins/managesieve/config.inc.php
 		ln -s $RC_CONFIG_DIR/plugins/managesieve/config.inc.php $RC_INSTALL_DIR/plugins/managesieve/config.inc.php
-		chown -R root:hestiamail $RC_CONFIG_DIR/
+		chown -R hestiamail:www-data $RC_CONFIG_DIR/
 		chmod 751 -R $RC_CONFIG_DIR
 		chmod 644 $RC_CONFIG_DIR/*.php
 		chmod 644 $RC_CONFIG_DIR/plugins/managesieve/config.inc.php
 		sed -i "s/\"archive\"/\"archive\", \"managesieve\"/g" $RC_CONFIG_DIR/config.inc.php
+		chmod 640 $RC_CONFIG_DIR/config.inc.php
 	fi
 
 	# Restart Dovecot and exim4

--- a/install/upgrade/versions/1.8.12.sh
+++ b/install/upgrade/versions/1.8.12.sh
@@ -33,4 +33,22 @@ if [ -d "/var/lib/snappymail" ]; then
 	chown hestiamail:hestiamail /etc/snappymail
 fi
 
+#Roundube folder paths
+RC_INSTALL_DIR="/var/lib/roundcube"
+RC_CONFIG_DIR="/etc/roundcube"
+RC_LOG="/var/log/roundcube"
+
+if [ -d "$RC_INSTALL_DIR" ]; then
+	chown -R hestiamail:www-data "$RC_INSTALL_DIR"
+fi
+if [ -d "$RC_CONFIG_DIR" ]; then
+	chown -R hestiamail:www-data "$RC_CONFIG_DIR"
+fi
+if [ -f "$RC_CONFIG_DIR/config.inc.php" ]; then
+	chmod 640 "$RC_CONFIG_DIR/config.inc.php"
+fi
+if [ -d "$RC_LOG" ]; then
+	chown -R hestiamail:www-data "$RC_LOG"
+fi
+
 sed -i "s/disable_functions =.*/disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority/g" /etc/php/*/cli/php.ini


### PR DESCRIPTION
This patch basically changes the user group root:hestiamail to hestiamail:www-data for roundcube directories.

Also changes the permissions from 644 to 640 to the file /etc/roundcube/config.inc.php so that it cannot be read by others as it contains the roundcube user's password for the database.