### PR TITLE
Fix SMTP Relay routing issue

### DIFF
--- a/bin/v-add-mail-domain-smtp-relay
+++ b/bin/v-add-mail-domain-smtp-relay
@@ -54,6 +54,7 @@ port:$port
 user:$username
 pass:$password
 EOL
+rm $HOMEDIR/$user/conf/mail/$domain/ip
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -635,7 +635,7 @@ rebuild_mail_domain_conf() {
 		touch $HOMEDIR/$user/conf/mail/$domain/limits
 
 		# Setting outgoing ip address
-		if [ -n "$local_ip" ]; then
+		if [ -n "$local_ip" ] && [ "$U_SMTP_RELAY" != 'true' ]; then
 			echo "$local_ip" > $HOMEDIR/$user/conf/mail/$domain/ip
 		fi
 


### PR DESCRIPTION
When using SMTP Relay, specifying interface(OUTGOING_IP) in exim4 with force routing out from specified interface(ip), this can cause some network routing issue when multiple interface exist on the host. By remove OUTGOING_IP when SMTP relay enabled, will allow server to route based on routing table instead of FORCE routing and likely become not routable