### PR TITLE
Adds ~/.wp-cli (https://wp-cli.org/)

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -140,7 +140,8 @@ mkdir $HOMEDIR/$user/.config \
 	$HOMEDIR/$user/.composer \
 	$HOMEDIR/$user/.vscode-server \
 	$HOMEDIR/$user/.ssh \
-	$HOMEDIR/$user/.npm
+	$HOMEDIR/$user/.npm \
+	$HOMEDIR/$user/.wp-cli
 
 chown $user:$user \
 	$HOMEDIR/$user/.config \
@@ -149,7 +150,8 @@ chown $user:$user \
 	$HOMEDIR/$user/.composer \
 	$HOMEDIR/$user/.vscode-server \
 	$HOMEDIR/$user/.ssh \
-	$HOMEDIR/$user/.npm
+	$HOMEDIR/$user/.npm \
+	$HOMEDIR/$user/.wp-cli
 
 # Set permissions
 chmod a+x $HOMEDIR/$user

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -111,7 +111,8 @@ rebuild_user_conf() {
 		$HOMEDIR/$user/.composer \
 		$HOMEDIR/$user/.vscode-server \
 		$HOMEDIR/$user/.ssh \
-		$HOMEDIR/$user/.npm
+		$HOMEDIR/$user/.npm \
+		$HOMEDIR/$user/.wp-cli
 	chmod a+x $HOMEDIR/$user
 	chmod a+x $HOMEDIR/$user/conf
 	chown --no-dereference $user:$user \
@@ -122,7 +123,8 @@ rebuild_user_conf() {
 		$HOMEDIR/$user/.composer \
 		$HOMEDIR/$user/.vscode-server \
 		$HOMEDIR/$user/.ssh \
-		$HOMEDIR/$user/.npm
+		$HOMEDIR/$user/.npm \
+		$HOMEDIR/$user/.wp-cli
 	chown root:root $HOMEDIR/$user/conf
 
 	$BIN/v-add-user-sftp-jail "$user"


### PR DESCRIPTION
Adds this folder where wp-cli stores some cache files. WP is used to perform some WordPress operations on the terminal.