### PR TITLE
Redhat derivatives are not currently supported

### DIFF
--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -10,7 +10,6 @@
 #
 # Debian 10, 11, 12
 # Ubuntu 20.04, 22.04
-# AlmaLinux, EuroLinux, Red Hat EnterPrise Linux, Rocky Linux 8, 9
 #
 # ======================================================== #
 


### PR DESCRIPTION
saw a post on the forum about this.  Saw other mentions of RH.  Maybe it was supported or going to be supported at one time