### PR TITLE
Password options

### DIFF
--- a/web/css/src/utilities.css
+++ b/web/css/src/utilities.css
@@ -200,3 +200,7 @@
 		display: none !important;
 	}
 }
+
+.js-password-length {
+	max-width: 3.8rem;
+}

--- a/web/css/src/utilities.css
+++ b/web/css/src/utilities.css
@@ -200,7 +200,3 @@
 		display: none !important;
 	}
 }
-
-.js-password-length {
-	max-width: 3.8rem;
-}

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -216,6 +216,20 @@ function render_page($user, $TAB, $page) {
 	include $__template_dir . "footer.php";
 }
 
+/**
+ * Renders a php fragment inside another page.
+ * The base directory is /usr/local/hestia/web
+ * Fragment must starts with / and must be relative to the base directory
+ */
+function render_fragment($fragment) {
+	$file = dirname(__DIR__) . $fragment;
+	if (file_exists($file)) {
+		include_once $file;
+	} else {
+		return "Fragment does not exists";
+	}
+}
+
 // Match $_SESSION['token'] against $_GET['token'] or $_POST['token']
 // Usage: verify_csrf($_POST) or verify_csrf($_GET); Use verify_csrf($_POST,true) to return on failure instead of redirect
 function verify_csrf($method, $return = false) {

--- a/web/js/src/helpers.js
+++ b/web/js/src/helpers.js
@@ -1,12 +1,22 @@
 import { customAlphabet } from 'nanoid';
 
 // Generates a random password that always passes password requirements
-export function randomPassword(length = 16) {
+export function randomPassword(length = 16, options = null, _symbols = null) {
 	const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 	const lowercase = 'abcdefghijklmnopqrstuvwxyz';
 	const numbers = '0123456789';
-	const symbols = '!@#$%^&*()_+-=[]{}|;:/?';
-	const allCharacters = uppercase + lowercase + numbers + symbols;
+	const symbols = _symbols ?? '!@#$%^&*()_+-=[]{}|;:/?';
+	let allCharacters;
+	switch (options) {
+		case 'numbers':
+			allCharacters = uppercase + lowercase + numbers;
+			break;
+		case 'both':
+		default:
+			allCharacters = uppercase + lowercase + numbers + symbols;
+			break;
+	}
+
 	const generate = customAlphabet(allCharacters, length);
 
 	let password;

--- a/web/js/src/passwordInput.js
+++ b/web/js/src/passwordInput.js
@@ -16,9 +16,41 @@ export default function handlePasswordInput() {
 		generatePasswordButton.addEventListener('click', () => {
 			const passwordInput =
 				generatePasswordButton.parentNode.nextElementSibling.querySelector('.js-password-input');
+			const passwordLength =
+				document.getElementById('v_password_length') &&
+				document.getElementById('v_password_length').value
+					? document.getElementById('v_password_length').value
+					: 16;
+			const passwordOptions = document.querySelector(
+				'input.password_options_radios[type=radio]:checked',
+			)
+				? document.querySelector('input.password_options_radios[type=radio]:checked').value
+				: null;
+			const passwordSymbols = document.getElementById('v_password_options_symbols')
+				? document.getElementById('v_password_options_symbols').value
+				: null;
 			if (passwordInput) {
-				passwordInput.value = randomPassword();
+				passwordInput.value = randomPassword(+passwordLength, passwordOptions, passwordSymbols);
 				passwordInput.dispatchEvent(new Event('input'));
+			}
+		});
+	});
+
+	// Listen for clicks on toggle password options
+	document.querySelectorAll('.js-toggle-generate-password').forEach((toggleBtn) => {
+		toggleBtn.addEventListener('click', () => {
+			const caret = toggleBtn.querySelector('i.fas');
+			const panel = document.querySelector('div.password-options');
+			if (panel.classList.contains('u-hidden')) {
+				panel.classList.add('animate__animated', 'animate__fadeIn');
+				panel.classList.remove('u-hidden');
+				caret.classList.remove('fa-caret-down');
+				caret.classList.add('fa-caret-up');
+			} else {
+				panel.classList.remove('animate__animated', 'animate__fadeIn');
+				panel.classList.add('u-hidden');
+				caret.classList.add('fa-caret-down');
+				caret.classList.remove('fa-caret-up');
 			}
 		});
 	});

--- a/web/templates/includes/password-options.php
+++ b/web/templates/includes/password-options.php
@@ -1,0 +1,31 @@
+<button type="button" title="<?= _("Toggle password options") ?>" class="u-unstyled-button u-ml5 js-toggle-generate-password">
+    <i class="fas fa-caret-down icon-green"></i>
+</button>
+<div class="u-pos-relative u-mb10 u-mt10 password-options u-hidden panel">
+    <div class="u-mb20"><?= _("Select the length and characters to use when generating a password:") ?></div>
+    <div class="u-mb20">
+        <label for="v_password_length" class="form-label">
+            <?= _("Length") ?>
+        </label>
+        <input type="number" class="form-control js-password-length" name="v_password_length" id="v_password_length" min="8" value="16">
+    </div>
+    <div class="u-mb20">
+        <label for="v_password_options_symbols" class="form-label">
+            <?= _("Symbols the password may include") ?>
+        </label>
+        <input type="text" class="form-control" name="v_password_options_symbols" id="v_password_options_symbols" value="!@#$%^&*()_+-=[]{}|;:/?">
+    </div>
+    <h2 class="u-text-H3 u-mb10">
+        <?= _("Numbers and Symbols") ?>
+    </h2>
+    <div class="u-mb10">
+        <label for="v_password_options_both" class="form-label">
+            <input type="radio" class="password_options_radios" name="v_password_options_numbers_symbols" id="v_password_options_both" checked value="both"> <?= _("Both (1@3$)") ?>
+        </label>
+    </div>
+    <div class="u-mb20">
+        <label for="v_password_options_numbers" class="form-label">
+            <input type="radio" class="password_options_radios" name="v_password_options_numbers_symbols" id="v_password_options_numbers" value="numbers"> <?= _("Numbers (123)") ?>
+        </label>
+    </div>
+</div>

--- a/web/templates/includes/password-options.php
+++ b/web/templates/includes/password-options.php
@@ -7,7 +7,7 @@
         <label for="v_password_length" class="form-label">
             <?= _("Length") ?>
         </label>
-        <input type="number" class="form-control js-password-length" name="v_password_length" id="v_password_length" min="8" value="16">
+        <input type="number" class="form-control" name="v_password_length" id="v_password_length" min="8" value="16" style="max-width: 3.8rem">
     </div>
     <div class="u-mb20">
         <label for="v_password_options_symbols" class="form-label">

--- a/web/templates/pages/add_db.php
+++ b/web/templates/pages/add_db.php
@@ -80,6 +80,7 @@
 						<button type="button" title="<?= _("Generate") ?>" class="u-unstyled-button u-ml5 js-generate-password">
 							<i class="fas fa-arrows-rotate icon-green"></i>
 						</button>
+						<?= render_fragment("/templates/includes/password-options.php") ?>
 					</label>
 					<div class="u-pos-relative u-mb10">
 						<input type="text" class="form-control js-password-input" name="v_password" id="v_password">

--- a/web/templates/pages/add_mail_acc.php
+++ b/web/templates/pages/add_mail_acc.php
@@ -48,6 +48,7 @@
 							<button type="button" title="<?= _("Generate") ?>" class="u-unstyled-button u-ml5 js-generate-password">
 								<i class="fas fa-arrows-rotate icon-green"></i>
 							</button>
+							<?= render_fragment("/templates/includes/password-options.php") ?>
 						</label>
 						<div class="u-pos-relative u-mb10">
 							<input type="text" class="form-control js-password-input" name="v_password" id="v_password" required>

--- a/web/templates/pages/add_user.php
+++ b/web/templates/pages/add_user.php
@@ -49,6 +49,7 @@
 					<button type="button" title="<?= _("Generate") ?>" class="u-unstyled-button u-ml5 js-generate-password">
 						<i class="fas fa-arrows-rotate icon-green"></i>
 					</button>
+					<?= render_fragment("/templates/includes/password-options.php") ?>
 				</label>
 				<div class="u-pos-relative u-mb10">
 					<input type="text" class="form-control js-password-input" name="v_password" id="v_password" value="<?= htmlentities(trim($v_password, "'")) ?>" tabindex="4" required>

--- a/web/templates/pages/edit_db.php
+++ b/web/templates/pages/edit_db.php
@@ -43,6 +43,7 @@
 					<button type="button" title="<?= _("Generate") ?>" class="u-unstyled-button u-ml5 js-generate-password">
 						<i class="fas fa-arrows-rotate icon-green"></i>
 					</button>
+					<?= render_fragment("/templates/includes/password-options.php") ?>
 				</label>
 				<div class="u-pos-relative u-mb10">
 					<input type="text" class="form-control js-password-input" name="v_password" id="v_password" value="<?= htmlentities(trim($v_password, "'")) ?>">

--- a/web/templates/pages/edit_mail_acc.php
+++ b/web/templates/pages/edit_mail_acc.php
@@ -46,6 +46,7 @@
 							<button type="button" title="<?= _("Generate") ?>" class="u-unstyled-button u-ml5 js-generate-password">
 								<i class="fas fa-arrows-rotate icon-green"></i>
 							</button>
+							<?= render_fragment("/templates/includes/password-options.php") ?>
 						</label>
 						<div class="u-pos-relative u-mb10">
 							<input type="text" class="form-control js-password-input" name="v_password" id="v_password" value="<?= htmlentities(trim($v_password, "'")) ?>">

--- a/web/templates/pages/edit_user.php
+++ b/web/templates/pages/edit_user.php
@@ -85,6 +85,7 @@
 					<button type="button" title="<?= _("Generate") ?>" class="u-unstyled-button u-ml5 js-generate-password">
 						<i class="fas fa-arrows-rotate icon-green"></i>
 					</button>
+					<?= render_fragment("/templates/includes/password-options.php") ?>
 				</label>
 				<div class="u-pos-relative u-mb10">
 					<input type="text" class="form-control js-password-input" name="v_password" id="v_password" value="<?= htmlentities(trim($v_password, "'")) ?>">


### PR DESCRIPTION
Adds a toggle button alongside the generate password button where the user can customize the generated password

This allows the user to set the password length by minimum of 8 characters and allows to include or not symbols, also can customize which symbols wants to use.

To render the code on pages that has the Generate password button, I create a render_fragment function so renders the fragment inside the current page.