### PR TITLE
Simplify pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged


### PR DESCRIPTION
Since [husky 9.1](https://github.com/typicode/husky/releases) merged in #4464, `npx` prefix is no longer required in commit hooks.

It'a also slightly faster without `npx`.