### PR TITLE
Fix integer overflow in disk size calculation for S3 storage

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -178,7 +178,7 @@ email=$(grep CONTACT "$HESTIA/data/users/$ROOT_USER/user.conf" | cut -f 2 -d \')
 
 # Validate available disk space (take usage * 2, due to the backup handling)
 let u_disk=$(($(get_user_disk_usage) * 2))
-let v_disk=$(($(stat -f --format="%a*%S" $BACKUP)))/1024/1024
+let v_disk=$(echo "$(stat -f --format='%a*%S' $BACKUP) / 1024 / 1024" | bc)
 
 if [ "$u_disk" -gt "$v_disk" ]; then
 	let u_disk_original=$(get_user_disk_usage)


### PR DESCRIPTION
Resolved an issue with calculating available disk space when mounting a backup filesystem on S3 storage, which caused integer overflow due to values exceeding the 32-bit integer limit.

This change addresses the problem of receiving a negative value (-16MB) due to integer overflow when handling large available space values from S3 storage. The use of bc ensures accurate calculations for large numbers, preventing overflow issues.