### PR TITLE
Fix error in variable name for web-template in docs

### DIFF
--- a/docs/docs/server-administration/web-templates.md
+++ b/docs/docs/server-administration/web-templates.md
@@ -45,7 +45,7 @@ After modifying an existing template, you need to rebuild the user configuration
 | -------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | `%ip%`               | IP Address of Server                                  | `123.123.123.123`                          |
 | `%proxy_port%`       | Port of Proxy                                         | `80`                                       |
-| `%proxy_port_ssl%`   | Port of Proxy (SSL)                                   | `443`                                      |
+| `%proxy_ssl_port%`   | Port of Proxy (SSL)                                   | `443`                                      |
 | `%web_port%`         | Port of Webserver                                     | `8080`                                     |
 | `%web_ssl_port%`     | Port of Webserver (SSL)                               | `8443`                                     |
 | `%domain%`           | Domain                                                | `domain.tld`                               |


### PR DESCRIPTION
https://hestiacp.com/docs/server-administration/web-templates.html#available-variables In table "Available variables" there is an incorrect variable:

%proxy_port_ssl%
it must be %proxy_ssl_port%