### PR TITLE
issue4401

### DIFF
--- a/install/deb/exim/system.filter
+++ b/install/deb/exim/system.filter
@@ -1,4 +1,4 @@
-if $h_X-Spam-Status: matches ^Yes\$
+if $h_X-Spam-Status: matches ^[Yy]es
 then
     headers add "Old-Subject: $h_subject"
     headers remove "Subject"

--- a/install/deb/exim/system.filter
+++ b/install/deb/exim/system.filter
@@ -1,4 +1,4 @@
-if $h_X-Spam-Status: contains "Yes"
+if $h_X-Spam-Status: matches ^Yes\$
 then
     headers add "Old-Subject: $h_subject"
     headers remove "Subject"


### PR DESCRIPTION
 [Bug] If outgoing mail servers checks for spam and uses BAYES then hestia marks all incoming email as spam even if spamassassin is disabled #4401 