### PR TITLE
Add database host selection for app quick install

### DIFF
--- a/web/src/app/System/HestiaApp.php
+++ b/web/src/app/System/HestiaApp.php
@@ -200,6 +200,7 @@ class HestiaApp {
 		string $dbuser,
 		string $dbpass,
 		string $dbtype = "mysql",
+		string $dbhost = "localhost",
 		string $charset = "utf8mb4",
 	) {
 		$v_password = tempnam("/tmp", "hst");
@@ -211,7 +212,7 @@ class HestiaApp {
 			$dbuser,
 			$v_password,
 			$dbtype,
-			"localhost",
+			$dbhost,
 			$charset,
 		]);
 		if (!$status) {

--- a/web/src/app/WebApp/AppWizard.php
+++ b/web/src/app/WebApp/AppWizard.php
@@ -14,6 +14,7 @@ class AppWizard {
 
 	private $database_config = [
 		"database_create" => ["type" => "boolean", "value" => true],
+		"database_host" => ["type" => "select"],
 		"database_name" => ["type" => "text", "placeholder" => "auto"],
 		"database_user" => ["type" => "text", "placeholder" => "auto"],
 		"database_password" => ["type" => "password", "placeholder" => "auto"],
@@ -72,6 +73,18 @@ class AppWizard {
 		]);
 
 		if ($this->appsetup->withDatabase()) {
+			exec(HESTIA_CMD . "v-list-database-hosts json", $output, $return_var);
+			$db_hosts_tmp1 = json_decode(implode("", $output), true);
+			$db_hosts_tmp2 = array_map(function ($host) {
+				return $host["HOST"];
+			}, $db_hosts_tmp1);
+			$db_hosts = array_values(array_unique($db_hosts_tmp2));
+			unset($output);
+			unset($db_hosts_tmp1);
+			unset($db_hosts_tmp2);
+
+			$this->database_config["database_host"]["options"] = $db_hosts;
+
 			$options = array_merge($options, $this->database_config);
 		}
 		return $options;
@@ -119,6 +132,8 @@ class AppWizard {
 					$options["database_name"],
 					$options["database_user"],
 					$options["database_password"],
+					"mysql",
+					$options["database_host"],
 				)
 			) {
 				$this->errors[] = "Error adding database";

--- a/web/src/app/WebApp/Installers/Drupal/DrupalSetup.php
+++ b/web/src/app/WebApp/Installers/Drupal/DrupalSetup.php
@@ -70,7 +70,9 @@ class DrupalSetup extends BaseSetup {
 				$options["database_user"] .
 				":" .
 				$options["database_password"] .
-				"@localhost:3306/" .
+				"@" .
+				$options["database_host"] .
+				":3306/" .
 				$this->appcontext->user() .
 				"_" .
 				$options["database_name"] .

--- a/web/src/app/WebApp/Installers/Flarum/FlarumSetup.php
+++ b/web/src/app/WebApp/Installers/Flarum/FlarumSetup.php
@@ -157,7 +157,7 @@ class FlarumSetup extends BaseSetup {
 		$webDomain = ($sslEnabled ? "https://" : "http://") . $this->domain;
 		$webPort = $sslEnabled ? "443" : "80";
 
-		$mysql_host = "localhost";
+		$mysql_host = $options["database_host"];
 		$mysql_database = addcslashes(
 			$this->appcontext->user() . "_" . $options["database_name"],
 			"\\'",

--- a/web/src/app/WebApp/Installers/Joomla/JoomlaSetup.php
+++ b/web/src/app/WebApp/Installers/Joomla/JoomlaSetup.php
@@ -71,6 +71,7 @@ class JoomlaSetup extends BaseSetup {
 		}
 
 		// Database credentials
+		$dbHost = $options["database_host"];
 		$dbName = $this->appcontext->user() . "_" . $options["database_name"];
 		$dbUser = $this->appcontext->user() . "_" . $options["database_user"];
 		$dbPass = $options["database_password"];
@@ -95,7 +96,7 @@ class JoomlaSetup extends BaseSetup {
 			"--db-pass=" . $dbPass,
 			"--db-name=" . $dbName,
 			"--db-prefix=" . Util::generate_string(5, false) . "_",
-			"--db-host=localhost",
+			"--db-host=" . $dbHost,
 			"--db-type=mysqli",
 		];
 

--- a/web/src/app/WebApp/Installers/MediaWiki/MediaWikiSetup.php
+++ b/web/src/app/WebApp/Installers/MediaWiki/MediaWikiSetup.php
@@ -69,7 +69,7 @@ class MediaWikiSetup extends BaseSetup {
 			[
 				"/usr/bin/php" . $options["php_version"],
 				$this->getDocRoot("maintenance/install.php"),
-				"--dbserver=localhost",
+				"--dbserver=" . $options["database_host"],
 				"--dbname=" . $this->appcontext->user() . "_" . $options["database_name"],
 				"--installdbuser=" . $this->appcontext->user() . "_" . $options["database_user"],
 				"--installdbpass=" . $options["database_password"],

--- a/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
+++ b/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
@@ -51,6 +51,7 @@ class NextcloudSetup extends BaseSetup {
 				"maintenance:install",
 				"--database mysql",
 				"--database-name " . $this->appcontext->user() . "_" . $options["database_name"],
+				"--database-host " . $options["database_host"],
 				"--database-user " . $this->appcontext->user() . "_" . $options["database_user"],
 				"--database-pass " . $options["database_password"],
 				"--admin-user " . $options["username"],

--- a/web/src/app/WebApp/Installers/Opencart/OpencartSetup.php
+++ b/web/src/app/WebApp/Installers/Opencart/OpencartSetup.php
@@ -82,6 +82,7 @@ class OpencartSetup extends BaseSetup {
 				"/usr/bin/php" . $options["php_version"],
 				$this->getDocRoot("/install/cli_install.php"),
 				"install",
+				"--db_hostname " . $options["database_host"],
 				"--db_username " . $this->appcontext->user() . "_" . $options["database_user"],
 				"--db_password " . $options["database_password"],
 				"--db_database " . $this->appcontext->user() . "_" . $options["database_name"],

--- a/web/src/app/WebApp/Installers/Prestashop/PrestashopSetup.php
+++ b/web/src/app/WebApp/Installers/Prestashop/PrestashopSetup.php
@@ -72,6 +72,7 @@ class PrestashopSetup extends BaseSetup {
 			[
 				"/usr/bin/php" . $options["php_version"],
 				$this->getDocRoot("/install/index_cli.php"),
+				"--db_server=" . $options["database_host"],
 				"--db_user=" . $this->appcontext->user() . "_" . $options["database_user"],
 				"--db_password=" . $options["database_password"],
 				"--db_name=" . $this->appcontext->user() . "_" . $options["database_name"],

--- a/web/src/app/WebApp/Installers/WordPress/WordPressSetup.php
+++ b/web/src/app/WebApp/Installers/WordPress/WordPressSetup.php
@@ -135,7 +135,7 @@ class WordpressSetup extends BaseSetup {
 						"'," .
 						$padding .
 						"'" .
-						addcslashes("localhost", "\\'") .
+						addcslashes($options["database_host"], "\\'") .
 						"' );";
 					break;
 				case "DB_CHARSET":


### PR DESCRIPTION
This lets you select database host when quick installing web apps, instead of being hardcoded to localhost, which may not even be a valid target.

![bild](https://github.com/user-attachments/assets/43a6a4e4-5afa-44e3-9069-b0096c1b1a71)

All available installers have been updated to accomodate this option.

`AppWizard::execute` may need to be updated to allow `v-quick-install-app` to use a valid default database host. Not sure of the best way to do that.