### PR TITLE
micromatch 4.0.8 fix CVE-2024-4067

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5520,11 +5520,10 @@
 			}
 		},
 		"node_modules/lint-staged/node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
@@ -7651,11 +7650,10 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"


### PR DESCRIPTION
micromatch 4.0.7 has a ReDoS vulnerability called CVE-2024-4067 , see https://github.com/advisories/GHSA-952p-6rrq-rcjv

I believe the impact on HestiaCP is low, but the fix is easy.

    $ npm audit # npm audit report

    micromatch <4.0.8
    Severity: moderate
    Regular Expression Denial of Service (ReDoS) in micromatch - GHSA-952p-6rrq-rcjv fix available via npm audit fix --force
    Will install markdownlint-cli2@0.3.2, which is a breaking change node_modules/lint-staged/node_modules/micromatch
    node_modules/micromatch
    node_modules/stylelint/node_modules/micromatch
    markdownlint-cli2 >=0.4.0
    Depends on vulnerable versions of micromatch
    node_modules/markdownlint-cli2

    2 moderate severity vulnerabilities

Have notified upstream markdownlint-cli2: https://github.com/DavidAnson/markdownlint-cli2/pull/398