### PR TITLE
quote strings

### DIFF
--- a/docs/.vitepress/theme/components/InstallBuilder.test.js
+++ b/docs/.vitepress/theme/components/InstallBuilder.test.js
@@ -66,7 +66,7 @@ describe('InstallBuilder', () => {
 		const textInput = screen.getByLabelText(options[1].description);
 		await fireEvent.update(textInput, 'custom-value');
 
-		expect(screen.getByDisplayValue(/bash hst-install.sh --option2 custom-value/)).toBeTruthy();
+		expect(screen.getByDisplayValue(/bash hst-install.sh --option2 'custom-value'/)).toBeTruthy();
 	});
 
 	it('updates the installation command when option select input changes', async () => {

--- a/docs/.vitepress/theme/components/InstallBuilder.vue
+++ b/docs/.vitepress/theme/components/InstallBuilder.vue
@@ -107,7 +107,7 @@ const toggleOption = (option) => {
 const installCommand = ref("bash hst-install.sh");
 watchEffect(() => {
 	let cmd = "bash hst-install.sh";
-	let quoteshellarg = function(str){
+	let quoteshellarg = function (str) {
 		return "'" + str.replace(/'/g, "'\\''") + "'";
 	};
 	for (const [key, { enabled, value }] of Object.entries(selectedOptions.value)) {

--- a/docs/.vitepress/theme/components/InstallBuilder.vue
+++ b/docs/.vitepress/theme/components/InstallBuilder.vue
@@ -108,6 +108,7 @@ const installCommand = ref("bash hst-install.sh");
 watchEffect(() => {
 	let cmd = "bash hst-install.sh";
 	let quoteshellarg = function (str) {
+		if (!str) return "''";
 		return "'" + str.replace(/'/g, "'\\''") + "'";
 	};
 	for (const [key, { enabled, value }] of Object.entries(selectedOptions.value)) {

--- a/docs/.vitepress/theme/components/InstallBuilder.vue
+++ b/docs/.vitepress/theme/components/InstallBuilder.vue
@@ -107,6 +107,9 @@ const toggleOption = (option) => {
 const installCommand = ref("bash hst-install.sh");
 watchEffect(() => {
 	let cmd = "bash hst-install.sh";
+	let quoteshellarg = function(str){
+		return return "'" + str.replace(/'/g, "'\\''") + "'";
+	};
 	for (const [key, { enabled, value }] of Object.entries(selectedOptions.value)) {
 		const opt = options.find((o) => o.flag === key);
 		if (opt.flag == "force" && enabled) {
@@ -116,7 +119,8 @@ watchEffect(() => {
 				cmd += ` --${key} ${enabled ? "yes" : "no"}`;
 			}
 		} else if (enabled && value !== opt.default) {
-			cmd += ` --${key} ${value}`;
+			let value_quoted = quoteshellarg(value);
+			cmd += ` --${key} ${value_quoted}`;
 		}
 	}
 	installCommand.value = cmd;

--- a/docs/.vitepress/theme/components/InstallBuilder.vue
+++ b/docs/.vitepress/theme/components/InstallBuilder.vue
@@ -108,7 +108,7 @@ const installCommand = ref("bash hst-install.sh");
 watchEffect(() => {
 	let cmd = "bash hst-install.sh";
 	let quoteshellarg = function(str){
-		return return "'" + str.replace(/'/g, "'\\''") + "'";
+		return "'" + str.replace(/'/g, "'\\''") + "'";
 	};
 	for (const [key, { enabled, value }] of Object.entries(selectedOptions.value)) {
 		const opt = options.find((o) => o.flag === key);


### PR DESCRIPTION
Previously if a password contained whitespace like `pass word`  or shell-metacharacters like `pass&word` or `pass'word` , it would generate an invalid install command.

The code is basically just https://github.com/hestiacp/phpquoteshellarg ported to javascript.

Warning: the code is *untested* , i don't have an easy way to test the Vue thing locally :( should work in theory