### PR TITLE
Fix bug when no ipv6 is availble with hestia-nginx install or upgrade 

### DIFF
--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -614,23 +614,17 @@ function syshealth_adapt_hestia_nginx_listen_ports() {
 	done
 
 	# Adapt port listing in nginx.conf depended on availability of IPV4 and IPV6 network interface
-	NGINX_BCONF_CHANGED=""
-	NGINX_BCONF="/usr/local/hestia/nginx/conf/nginx.conf"
-	NGINX_BCONF_TEMP="/tmp/nginx.conf"
-	cp "$NGINX_BCONF" "$NGINX_BCONF_TEMP"
+	NGINX_CONF="/usr/local/hestia/nginx/conf/nginx.conf"
 	if [ -z "$ipv4_scope_global" ]; then
-		sed -i 's/^\([ \t]*listen[ \t]*[0-9]\{1,5\}.*\)/#\1/' "$NGINX_BCONF"
+		sed -i 's/^\([ \t]*listen[ \t]*[0-9]\{1,5\}.*\)/#\1/' "$NGINX_CONF"
 	else
-		sed -i 's/#\([ \t]*listen[ \t]*[0-9]\{1,5\}.*\)/\1/' "$NGINX_BCONF"
+		sed -i 's/#\([ \t]*listen[ \t]*[0-9]\{1,5\}.*\)/\1/' "$NGINX_CONF"
 	fi
 	if [ -z "$ipv6_scope_global" ]; then
-		sed -i 's/^\([ \t]*listen[ \t]*\[\:\:\]\:[0-9]\{1,5\}.*\)/#\1/' "$NGINX_BCONF"
+		sed -i 's/^\([ \t]*listen[ \t]*\[\:\:\]\:[0-9]\{1,5\}.*\)/#\1/' "$NGINX_CONF"
 	else
-		sed -i 's/#\([ \t]*listen[ \t]*\[\:\:\]\:[0-9]\{1,5\}.*\)/\1/' "$NGINX_BCONF"
+		sed -i 's/#\([ \t]*listen[ \t]*\[\:\:\]\:[0-9]\{1,5\}.*\)/\1/' "$NGINX_CONF"
 	fi
-	cmp --silent "$NGINX_BCONF" "$NGINX_BCONF_TEMP"
-	[ $? -ne 0 ] && NGINX_BCONF_CHANGED="yes"
-	rm -f "$NGINX_BCONF_TEMP" > /dev/null 2>&1
 }
 
 syshealth_adapt_nginx_resolver() {

--- a/src/deb/nginx/preinst
+++ b/src/deb/nginx/preinst
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run triggers only on updates
+if [ ! -e "/usr/local/hestia/data/users/admin" ]; then
+	exit
+fi
+
+# Create a new Backup folder
+HESTIA_BACKUP="/root/hst_nginx_backups/$(date +%d%m%Y%H%M)"
+mkdir -p HESTIA_BACKUP
+
+# Create a backup of the current configuration
+cp -r /usr/local/hestia/nginx/conf/nginx.conf $HESTIA_BACKUP/nginx.conf
+
+exit


### PR DESCRIPTION
In favor of:
https://github.com/hestiacp/hestiacp/pull/4539

- I don't know why we create backup of the config after the config has all ready been replaced
- CMP only removed the file afterwards after changes have been made 
- /tmp/ is cleared on reboot 

Now creates a backup on update before config file is replaced.. 