### PR TITLE
owncloud templates: refactor rewrite rules for carddav and caldav endpoints

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/owncloud.stpl
@@ -56,8 +56,8 @@ server {
 		# The following 2 rules are only needed with webfinger
 		rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
 		rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-		rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-		rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
+		rewrite ^/.well-known/carddav /remote.php/dav redirect;
+		rewrite ^/.well-known/caldav /remote.php/dav redirect;
 		rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 
 		try_files $uri $uri/ /index.php;

--- a/install/deb/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/owncloud.tpl
@@ -47,8 +47,8 @@ server {
 		# The following 2 rules are only needed with webfinger
 		rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
 		rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-		rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-		rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
+		rewrite ^/.well-known/carddav /remote.php/dav redirect;
+		rewrite ^/.well-known/caldav /remote.php/dav redirect;
 		rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 
 		try_files $uri $uri/ /index.php;

--- a/install/rpm/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/rpm/templates/web/nginx/php-fpm/owncloud.stpl
@@ -56,8 +56,8 @@ server {
 		# The following 2 rules are only needed with webfinger
 		rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
 		rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-		rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-		rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
+		rewrite ^/.well-known/carddav /remote.php/dav redirect;
+		rewrite ^/.well-known/caldav /remote.php/dav redirect;
 		rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 
 		try_files $uri $uri/ /index.php;

--- a/install/rpm/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/rpm/templates/web/nginx/php-fpm/owncloud.tpl
@@ -47,8 +47,8 @@ server {
 		# The following 2 rules are only needed with webfinger
 		rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
 		rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-		rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-		rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
+		rewrite ^/.well-known/carddav /remote.php/dav redirect;
+		rewrite ^/.well-known/caldav /remote.php/dav redirect;
 		rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 
 		try_files $uri $uri/ /index.php;


### PR DESCRIPTION
Fix the owncloud/nextcloud service discovery redirects as per documentation:

https://doc.owncloud.com/server/next/admin_manual/troubleshooting/general_troubleshooting.html#service-discovery