### PR TITLE
Update dns.md documentation to correct error in guide to converting master-master to master-slave

### DIFF
--- a/docs/docs/server-administration/dns.md
+++ b/docs/docs/server-administration/dns.md
@@ -122,7 +122,7 @@ Preparing your **Master** server:
 ### Converting an existing DNS cluster to Master -> Slave
 
 1. In `/usr/local/hestia/conf/hestia.conf`, change `DNS_CLUSTER_SYSTEM='hestia'` to `DNS_CLUSTER_SYSTEM='hestia-zone'`.
-2. On the master server, open `/etc/bind/named.options`, do the following changes, then restart bind9 with `systemctl restart bind9`.
+2. On the master server, open `/etc/bind/named.conf.options`, do the following changes, then restart bind9 with `systemctl restart bind9`.
 
    ```bash
    # Change this line

--- a/docs/docs/server-administration/dns.md
+++ b/docs/docs/server-administration/dns.md
@@ -135,7 +135,7 @@ Preparing your **Master** server:
    also-notify { second.slave.ip.address; };
    ```
 
-3. On the slave server, open `/etc/bind/named.options`, do the following changes, then restart bind9 with `systemctl restart bind9`:
+3. On the slave server, open `/etc/bind/named.conf.options`, do the following changes, then restart bind9 with `systemctl restart bind9`:
 
    ```bash
    # Change this line


### PR DESCRIPTION
Documentation referenced editing a non-existing file. Upon doing a little review of the text above, I found that the file should have been this instead