### PR TITLE
Update phpmyadmin.inc

### DIFF
--- a/install/deb/nginx/phpmyadmin.inc
+++ b/install/deb/nginx/phpmyadmin.inc
@@ -20,7 +20,8 @@ location /%pma_alias% {
 		fastcgi_pass  127.0.0.1:9000;
 	}
 
+	# Serve static files like CSS and JS
 	location /%pma_alias%/(.+\.(jpg|jpeg|gif|css|png|webp|js|ico|html|xml|txt))$ {
-		root /usr/share/phpmyadmin/;
+		alias /usr/share/phpmyadmin/;
 	}
 }

--- a/install/rpm/nginx/phpmyadmin.inc
+++ b/install/rpm/nginx/phpmyadmin.inc
@@ -19,9 +19,9 @@ location /%pma_alias% {
 		fastcgi_param SCRIPT_FILENAME $request_filename;
 		fastcgi_pass  127.0.0.1:9000;
 	}
-	
+
 	# Serve static files like CSS and JS
-    	location ~ ^/%pma_alias%/(.*\.(jpg|jpeg|gif|css|png|webp|js|ico|html|xml|txt))$ {
-       	 	alias /usr/share/phpmyadmin/$1;  # Corrected from root to alias
-    }
+	location ~ ^/%pma_alias%/(.*\.(jpg|jpeg|gif|css|png|webp|js|ico|html|xml|txt))$ {
+		alias /usr/share/phpmyadmin/$1; # Corrected from root to alias
+	}
 }

--- a/install/rpm/nginx/phpmyadmin.inc
+++ b/install/rpm/nginx/phpmyadmin.inc
@@ -19,8 +19,9 @@ location /%pma_alias% {
 		fastcgi_param SCRIPT_FILENAME $request_filename;
 		fastcgi_pass  127.0.0.1:9000;
 	}
-
-	location /%pma_alias%/(.+\.(jpg|jpeg|gif|css|png|webp|js|ico|html|xml|txt))$ {
-		root /usr/share/phpmyadmin/;
-	}
+	
+	# Serve static files like CSS and JS
+    	location ~ ^/%pma_alias%/(.*\.(jpg|jpeg|gif|css|png|webp|js|ico|html|xml|txt))$ {
+       	 	alias /usr/share/phpmyadmin/$1;  # Corrected from root to alias
+    }
 }


### PR DESCRIPTION
The issue with the CSS and JS files not loading may stem from the configuration of the alias directive and how Nginx resolves file paths in a custom template. I changed `root` to `alias` in the CSS and JS location block, as the alias directive is essential for accurately mapping the request URI to the filesystem path.