### PR TITLE
Introducing Hestia Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 	<a href="https://github.com/hestiacp/hestiacp/actions/workflows/lint.yml">
 		<img src="https://github.com/hestiacp/hestiacp/actions/workflows/lint.yml/badge.svg" alt="Lint Status"/>
 	</a>
+	<a href="https://gurubase.io/g/hestia">
+		<img src="https://img.shields.io/badge/Gurubase-Ask%20Hestia%20Guru-006BFF" alt="Gurubase"/>
+	</a>
 </p>
 
 ## **Welcome!**


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Hestia Guru](https://gurubase.io/g/hestia) to Gurubase. Hestia Guru uses the data from this repo and data from the [docs](https://docs.hestiacp.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Hestia Guru", which highlights that Hestia now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Hestia Guru in Gurubase, just let me know that's totally fine.
