### PR TITLE
/usr/share/zoneinfo/postfix has been dropped

### DIFF
--- a/bin/v-get-sys-timezones
+++ b/bin/v-get-sys-timezones
@@ -45,7 +45,7 @@ plain_list() {
 	done
 }
 
-zones=$(cd /usr/share/zoneinfo/posix && find -L * -type f -or -type l | sort)
+zones=$(cd /usr/share/zoneinfo/ && find -L * -type f -or -type l | sort)
 
 # Listing data
 case $format in


### PR DESCRIPTION
in favor of /usr/share/zoneinfo/

Doesn't break older versions
