### PR TITLE
Update exim.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file.
 - Improve Owncloud templates (#4572)
 - Improve security Quick Install Apps (#457 #4569 #4568 #4567 #4566 #4565 #4564 #4563)
 - Add hestia-mail to hestia-users group and create hestia-users group on new install #4540 #4531
+- Hide orgin ip of clients when sending email #4662
 
 ### Depencies
 

--- a/install/deb/exim/exim4.conf.4.94.template
+++ b/install/deb/exim/exim4.conf.4.94.template
@@ -385,6 +385,7 @@ remote_smtp:
   dkim_strict = 0
   hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
+	headers_remove = Received : X-Originating-IP
 
 procmail:
   driver = pipe

--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -407,6 +407,7 @@ remote_smtp:
   dkim_strict = 0
   hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
+  headers_remove = Received : X-Originating-IP
 
 remote_forwarded_smtp:
   driver = smtp

--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -420,6 +420,7 @@ remote_forwarded_smtp:
   hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
   # modify the envelope from, for mails that we forward
+	headers_remove = Received : X-Originating-IP
   max_rcpt = 1
   return_path = ${srs_encode {SRS_SECRET} {$return_path} {$original_domain}}
 

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -387,6 +387,7 @@ remote_smtp:
   dkim_strict = 0
   hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
+  headers_remove = Received : X-Originating-IP
 
 procmail:
   driver = pipe

--- a/install/rpm/exim/exim.conf
+++ b/install/rpm/exim/exim.conf
@@ -335,6 +335,7 @@ remote_smtp:
   dkim_canon = relaxed
   dkim_strict = 0
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
+  headers_remove = Received : X-Originating-IP
 
 procmail:
   driver = pipe


### PR DESCRIPTION
Hide the sender's IP address when working via smtp for security purposes. The server's IP address will be substituted.