### PR TITLE
Update exim4.conf.template

### DIFF
--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -387,6 +387,7 @@ remote_smtp:
   dkim_strict = 0
   hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
+  headers_remove = Received : X-Originating-IP
 
 procmail:
   driver = pipe


### PR DESCRIPTION
Hide the sender's IP address when working via smtp for security purposes. The server's IP address will be substituted.