### PR TITLE
Update exim4.conf.4.95.template

### DIFF
--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -407,6 +407,7 @@ remote_smtp:
   dkim_strict = 0
   hosts_try_fastopen = !*.l.google.com
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
+  headers_remove = Received : X-Originating-IP
 
 remote_forwarded_smtp:
   driver = smtp


### PR DESCRIPTION
Hide the sender's IP address when working via smtp for security purposes. The server's IP address will be substituted.