### PR TITLE
Revert "Fix Apache IDN PHP scripts (#4583)"

### DIFF
--- a/install/deb/templates/web/apache2/php-fpm/default.stpl
+++ b/install/deb/templates/web/apache2/php-fpm/default.stpl
@@ -31,8 +31,9 @@
     SSLCertificateKeyFile %ssl_key%
     %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
-    ProxyPassMatch ^/(.*\.php)(?:$|\?) "%backend_lsnr%|fcgi://localhost%sdocroot%/$1" nocanon
-    
+    <FilesMatch \.php$>
+        SetHandler "proxy:%backend_lsnr%|fcgi://localhost"
+    </FilesMatch>
     SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 
     IncludeOptional %home%/%user%/conf/web/%domain%/%web_system%.ssl.conf_*

--- a/install/deb/templates/web/apache2/php-fpm/default.tpl
+++ b/install/deb/templates/web/apache2/php-fpm/default.tpl
@@ -28,7 +28,9 @@
         Options +Includes -Indexes +ExecCGI
     </Directory>
 
-    ProxyPassMatch ^/(.*\.php)(?:$|\?) "%backend_lsnr%|fcgi://localhost%docroot%/$1" nocanon
+    <FilesMatch \.php$>
+        SetHandler "proxy:%backend_lsnr%|fcgi://localhost"
+    </FilesMatch>
     SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 
     IncludeOptional %home%/%user%/conf/web/%domain%/%web_system%.conf_*

--- a/install/rpm/templates/web/httpd/php-fpm/default.stpl
+++ b/install/rpm/templates/web/httpd/php-fpm/default.stpl
@@ -25,7 +25,9 @@
     SSLCertificateKeyFile %ssl_key%
     %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
-    ProxyPassMatch ^/(.*\.php)(?:$|\?) "%backend_lsnr%|fcgi://localhost%sdocroot%/$1" nocanon
+    <FilesMatch \.php$>
+        SetHandler "proxy:%backend_lsnr%|fcgi://localhost"
+    </FilesMatch>
     SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 
     IncludeOptional %home%/%user%/conf/web/%domain%/%web_system%.ssl.conf_*

--- a/install/rpm/templates/web/httpd/php-fpm/default.tpl
+++ b/install/rpm/templates/web/httpd/php-fpm/default.tpl
@@ -22,8 +22,9 @@
         Options +Includes -Indexes +ExecCGI
     </Directory>
 
-    ProxyPassMatch ^/(.*\.php)(?:$|\?) "%backend_lsnr%|fcgi://localhost%docroot%/$1" nocanon
-
+    <FilesMatch \.php$>
+        SetHandler "proxy:%backend_lsnr%|fcgi://localhost"
+    </FilesMatch>
     SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 
     IncludeOptional %home%/%user%/conf/web/%domain%/%web_system%.conf_*


### PR DESCRIPTION
This reverts commit 51360180246c806065824e71a38b9b115967ca67.

This makes us go back to using SetHandler instead of ProxyPassMatch

The SetHandler unicode problems appears to have been fixed in upstream apache httpd 2.4.59 ,
so the solution to running domains with unicode/cyrillic characters should just be to update to apache>=2.4.59

ref https://github.com/php/php-src/pull/17083#issuecomment-2544090943

The ProxyPassMatch solution added new problems with OpenCart like https://forum.hestiacp.com/t/php-file-not-found-but-it-exists/16694/4
```
AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon

 [proxy:error] [pid 204010:tid 204023] (111)Connection refused: AH00957: FCGI: attempt to connect to 127.0.0.1:8000 (localhost:8000) failed
```