### PR TITLE
documentation quote password

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -2,7 +2,7 @@
 # info: add backup host
 # options: TYPE HOST USERNAME PASSWORD [PATH] [PORT]
 #
-# example: v-add-backup-host sftp backup.acme.com admin p4$$w@Rd
+# example: v-add-backup-host sftp backup.acme.com admin 'P4$$w@rD'
 #          v-add-backup-host b2 bucketName keyID applicationKey
 #
 # Add a new remote backup location. Currently SFTP, FTP and Backblaze are supported

--- a/bin/v-add-backup-host-restic
+++ b/bin/v-add-backup-host-restic
@@ -2,7 +2,7 @@
 # info: add backup host
 # options: TYPE HOST USERNAME PASSWORD [PATH] [PORT]
 #
-# example: v-add-backup-host sftp backup.acme.com admin p4$$w@Rd
+# example: v-add-backup-host sftp backup.acme.com admin 'P4$$w@rD'
 #          v-add-backup-host b2 bucketName keyID applicationKey
 #
 # Add a new remote backup location. Currently SFTP, FTP and Backblaze are supported

--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -2,7 +2,7 @@
 # info: add system user
 # options: USER PASSWORD EMAIL [PACKAGE] [NAME] [LASTNAME]
 #
-# example: v-add-user user P4$$w@rD bgates@aol.com
+# example: v-add-user user 'P4$$w@rD' bgates@aol.com
 #
 # This function creates new user account.
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -38,7 +38,7 @@ add backup host
 **Examples**:
 
 ```bash
-v-add-backup-host sftp backup.acme.com admin p4$$w@Rd
+v-add-backup-host sftp backup.acme.com admin 'P4$$w@rD'
 v-add-backup-host b2 bucketName keyID applicationKey
 ```
 
@@ -864,7 +864,7 @@ add system user
 **Examples**:
 
 ```bash
-v-add-user user P4$$w@rD bgates@aol.com
+v-add-user user 'P4$$w@rD' bgates@aol.com
 ```
 
 This function creates new user account.


### PR DESCRIPTION
running p4$$w@Rd un-quoted in bash will actually make the password `P4<pid-of-bash>w@Rd`
because $$ is a special bash variable for "bash's current PID"
```
$ echo P4$$w@rD
P420254w@rD
```

found it while testing gurubase.io ai from https://github.com/hestiacp/hestiacp/pull/4628