### PR TITLE
Fix OpenCartSetup & PrestaShopSetup not found, missing capital

### DIFF
--- a/web/src/app/WebApp/Installers/OpenCart/OpenCartSetup.php
+++ b/web/src/app/WebApp/Installers/OpenCart/OpenCartSetup.php
@@ -5,7 +5,7 @@ namespace Hestia\WebApp\Installers\Opencart;
 use Hestia\WebApp\Installers\BaseSetup as BaseSetup;
 use function Hestiacp\quoteshellarg\quoteshellarg;
 
-class OpencartSetup extends BaseSetup {
+class OpenCartSetup extends BaseSetup {
 	protected $appInfo = [
 		"name" => "OpenCart",
 		"group" => "ecommerce",

--- a/web/src/app/WebApp/Installers/PrestaShop/PrestaShopSetup.php
+++ b/web/src/app/WebApp/Installers/PrestaShop/PrestaShopSetup.php
@@ -5,7 +5,7 @@ namespace Hestia\WebApp\Installers\Prestashop;
 use Hestia\WebApp\Installers\BaseSetup as BaseSetup;
 use function Hestiacp\quoteshellarg\quoteshellarg;
 
-class PrestashopSetup extends BaseSetup {
+class PrestaShopSetup extends BaseSetup {
 	protected $appInfo = [
 		"name" => "PrestaShop",
 		"group" => "ecommerce",

--- a/web/templates/pages/setup_webapp.php
+++ b/web/templates/pages/setup_webapp.php
@@ -71,7 +71,7 @@
 							<select class="form-select" name="<?= $field_name ?>" id="<?= $field_name ?>">
 								<?php foreach ($form_control["options"] as $key => $option):
 									$key = !is_numeric($key) ? $key : $option;
-									$selected = !empty($form_control["value"] && $key == $form_control["value"]) ? "selected" : ""; ?>
+									$selected = (!empty($form_control["value"]) && $key == $form_control["value"]) ? "selected" : ""; ?>
 									<option value="<?= $key ?>" <?= $selected ?>>
 										<?= htmlentities($option) ?>
 									</option>


### PR DESCRIPTION
A missing capital in both installers broke the autoinstaller list throwing the following error:

```
FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Class "\Hestia\WebApp\Installers\PrestaShop\PrestaShopSetup" not found in /usr/local/hestia/web/add/webapp/index.php:122
````

This fix changes `PrestashopSetup.php` to `PrestaShopSetup.php`