### PR TITLE
Drop Maxmind www.maxmind.com/en/high-risk-ip-sample-list

### DIFF
--- a/install/common/firewall/ipset/blacklist.sh
+++ b/install/common/firewall/ipset/blacklist.sh
@@ -5,15 +5,16 @@
 #
 
 BLACKLISTS=(
-	"https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1"          # Project Honey Pot Directory of Dictionary Attacker IPs
-	"https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1" # TOR Exit Nodes
-	"https://danger.rulez.sk/projects/bruteforceblocker/blist.php"       # BruteForceBlocker IP List
-	"https://www.spamhaus.org/drop/drop.lasso"                           # Spamhaus Don't Route Or Peer List (DROP)
-	"https://cinsscore.com/list/ci-badguys.txt"                          # C.I. Army Malicious IP List
-	"https://lists.blocklist.de/lists/all.txt"                           # blocklist.de attackers
-	"https://blocklist.greensnow.co/greensnow.txt"                       # GreenSnow
-	"https://iplists.firehol.org/files/firehol_level1.netset"            # Firehol Level 1
-	"https://iplists.firehol.org/files/stopforumspam_7d.ipset"           # Stopforumspam via Firehol
+	"https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1"                                              # Project Honey Pot Directory of Dictionary Attacker IPs
+	"https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"                                     # TOR Exit Nodes
+	"https://danger.rulez.sk/projects/bruteforceblocker/blist.php"                                           # BruteForceBlocker IP List
+	"https://www.spamhaus.org/drop/drop.lasso"                                                               # Spamhaus Don't Route Or Peer List (DROP)
+	"https://cinsscore.com/list/ci-badguys.txt"                                                              # C.I. Army Malicious IP List
+	"https://lists.blocklist.de/lists/all.txt"                                                               # blocklist.de attackers
+	"https://blocklist.greensnow.co/greensnow.txt"                                                           # GreenSnow
+	"https://iplists.firehol.org/files/firehol_level1.netset"                                                # Firehol Level 1
+	"https://iplists.firehol.org/files/stopforumspam_7d.ipset"                                               # Stopforumspam via Firehol
+	"https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/refs/heads/main/abuseipdb-s100-30d.ipv4" # AbuseIPDB 30d 100% confidence score
 )
 
 IP_BLACKLIST_TMP=$(mktemp)

--- a/install/common/firewall/ipset/blacklist.sh
+++ b/install/common/firewall/ipset/blacklist.sh
@@ -7,7 +7,6 @@
 BLACKLISTS=(
 	"https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1"          # Project Honey Pot Directory of Dictionary Attacker IPs
 	"https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1" # TOR Exit Nodes
-	"https://www.maxmind.com/en/high-risk-ip-sample-list"                # MaxMind GeoIP Anonymous Proxies
 	"https://danger.rulez.sk/projects/bruteforceblocker/blist.php"       # BruteForceBlocker IP List
 	"https://www.spamhaus.org/drop/drop.lasso"                           # Spamhaus Don't Route Or Peer List (DROP)
 	"https://cinsscore.com/list/ci-badguys.txt"                          # C.I. Army Malicious IP List


### PR DESCRIPTION
#4691

Due to 403 when User Agent is missing and/or Certain ASN is used
