### PR TITLE
run UTF-8 locale

### DIFF
--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -77,6 +77,31 @@ if [ "$type" = "NoSupport" ]; then
 	no_support_message
 fi
 
+ensure_utf8_locale() {
+	local locale_file="/etc/default/locale"
+
+	if locale 2> /dev/null | grep -qi 'utf-8'; then
+		return
+	fi
+
+	echo "[ * ] Enabling UTF-8 locale support via C.UTF-8"
+	if ! locale-gen C.UTF-8 > /dev/null 2>&1; then
+		echo "[ ! ] Failed to generate C.UTF-8 locale. Continuing."
+	fi
+
+	if [ ! -f "$locale_file" ]; then
+		touch "$locale_file"
+	fi
+
+	if ! update-locale LANG=C.UTF-8 > /dev/null 2>&1; then
+		echo "[ ! ] Failed to update LANG in $locale_file"
+	fi
+
+	export LANG=C.UTF-8
+}
+
+ensure_utf8_locale
+
 check_wget_curl() {
 	# Check wget
 	if [ -e '/usr/bin/wget' ]; then

--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -80,17 +80,17 @@ fi
 ensure_utf8_locale() {
 	local locale_file="/etc/default/locale"
 
-	if locale 2> /dev/null | grep -qi 'utf-8'; then
+	if locale | grep -qi 'utf-8'; then
 		return
 	fi
 
 	echo "[ * ] Enabling UTF-8 locale support via C.UTF-8"
-	if ! locale-gen C.UTF-8 > /dev/null 2>&1; then
+	if ! locale-gen C.UTF-8; then
 		echo "[ ! ] Failed to generate C.UTF-8 locale. Leaving existing locale untouched."
 		return
 	fi
 
-	if ! update-locale LANG=C.UTF-8 > /dev/null 2>&1; then
+	if ! update-locale LANG=C.UTF-8; then
 		echo "[ ! ] Failed to update LANG in $locale_file. Leaving existing locale untouched."
 		return
 	fi

--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -86,15 +86,13 @@ ensure_utf8_locale() {
 
 	echo "[ * ] Enabling UTF-8 locale support via C.UTF-8"
 	if ! locale-gen C.UTF-8 > /dev/null 2>&1; then
-		echo "[ ! ] Failed to generate C.UTF-8 locale. Continuing."
-	fi
-
-	if [ ! -f "$locale_file" ]; then
-		touch "$locale_file"
+		echo "[ ! ] Failed to generate C.UTF-8 locale. Leaving existing locale untouched."
+		return
 	fi
 
 	if ! update-locale LANG=C.UTF-8 > /dev/null 2>&1; then
-		echo "[ ! ] Failed to update LANG in $locale_file"
+		echo "[ ! ] Failed to update LANG in $locale_file. Leaving existing locale untouched."
+		return
 	fi
 
 	export LANG=C.UTF-8

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -32,15 +32,13 @@ ensure_utf8_locale() {
 
 	echo "[ * ] Enabling UTF-8 locale support via C.UTF-8"
 	if ! locale-gen C.UTF-8 > /dev/null 2>&1; then
-		echo "[ ! ] Failed to generate C.UTF-8 locale. Continuing."
-	fi
-
-	if [ ! -f "$locale_file" ]; then
-		touch "$locale_file"
+		echo "[ ! ] Failed to generate C.UTF-8 locale. Leaving existing locale untouched."
+		return
 	fi
 
 	if ! update-locale LANG=C.UTF-8 > /dev/null 2>&1; then
-		echo "[ ! ] Failed to update LANG in $locale_file"
+		echo "[ ! ] Failed to update LANG in $locale_file. Leaving existing locale untouched."
+		return
 	fi
 
 	export LANG=C.UTF-8

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -23,6 +23,31 @@ upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 
+ensure_utf8_locale() {
+	local locale_file="/etc/default/locale"
+
+	if locale 2> /dev/null | grep -qi 'utf-8'; then
+		return
+	fi
+
+	echo "[ * ] Enabling UTF-8 locale support via C.UTF-8"
+	if ! locale-gen C.UTF-8 > /dev/null 2>&1; then
+		echo "[ ! ] Failed to generate C.UTF-8 locale. Continuing."
+	fi
+
+	if [ ! -f "$locale_file" ]; then
+		touch "$locale_file"
+	fi
+
+	if ! update-locale LANG=C.UTF-8 > /dev/null 2>&1; then
+		echo "[ ! ] Failed to update LANG in $locale_file"
+	fi
+
+	export LANG=C.UTF-8
+}
+
+ensure_utf8_locale
+
 #Fix: avoid spamd execution in Exim when reject_spam is off for current installations
 if [ "$MAIL_SYSTEM" = "exim4" ]; then
 	echo "[ * ] Fixing spamd execution in Exim when reject_spam is off"

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -26,17 +26,17 @@ upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 ensure_utf8_locale() {
 	local locale_file="/etc/default/locale"
 
-	if locale 2> /dev/null | grep -qi 'utf-8'; then
+	if locale | grep -qi 'utf-8'; then
 		return
 	fi
 
 	echo "[ * ] Enabling UTF-8 locale support via C.UTF-8"
-	if ! locale-gen C.UTF-8 > /dev/null 2>&1; then
+	if ! locale-gen C.UTF-8; then
 		echo "[ ! ] Failed to generate C.UTF-8 locale. Leaving existing locale untouched."
 		return
 	fi
 
-	if ! update-locale LANG=C.UTF-8 > /dev/null 2>&1; then
+	if ! update-locale LANG=C.UTF-8; then
 		echo "[ ! ] Failed to update LANG in $locale_file. Leaving existing locale untouched."
 		return
 	fi


### PR DESCRIPTION
ensure that we're running UTF-8 locale.

check this `cyrillicрф` folder before and after:
```
root@ip1:/hans# ls
'cyrillic�'$'\200''�'$'\204'
root@ip1:/hans# sudo locale-gen C.UTF-8
Generating locales (this might take a while)...
  C.UTF-8... done
Generation complete.
root@ip1:/hans# echo LANG="C.UTF-8" | sudo tee /etc/default/locale; LANG=C.UTF-8
root@ip1:/hans# sudo update-locale;
root@ip1:/hans# export LANG=C.UTF-8;
root@ip1:/hans# ls
cyrillicрф
```
close GH-4653