### PR TITLE
Disallow ` character in cronjobs to avoid errors in cron list

### DIFF
--- a/bin/v-add-cron-job
+++ b/bin/v-add-cron-job
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add cron job
-# options: USER MIN HOUR DAY MONTH WDAY COMMAND [JOB] [RESTART]
+# options: USER MIN HOUR DAY MONTH WDAY CRON_COMMAND [JOB] [RESTART]
 #
 # example: v-add-cron-job admin * * * * * sudo /usr/local/hestia/bin/v-backup-users
 #
@@ -18,7 +18,7 @@ hour=$3
 day=$4
 month=$5
 wday=$6
-command=$(echo $7 | sed "s/'/%quote%/g")
+cron_command=$(echo $7 | sed "s/'/%quote%/g")
 job=$8
 restart=$9
 
@@ -36,8 +36,8 @@ HIDE=7
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '7' "$#" 'USER MIN HOUR DAY MONTH WDAY COMMAND [JOB] [RESTART]'
-is_format_valid 'user' 'min' 'hour' 'day' 'month' 'wday' 'command'
+check_args '7' "$#" 'USER MIN HOUR DAY MONTH WDAY CRON_COMMAND [JOB] [RESTART]'
+is_format_valid 'user' 'min' 'hour' 'day' 'month' 'wday' 'cron_command'
 is_system_enabled "$CRON_SYSTEM" 'CRON_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -61,7 +61,7 @@ date=$(echo "$time_n_date" | cut -f 2 -d \ )
 
 # Concatenating cron string
 str="JOB='$job' MIN='$min' HOUR='$hour' DAY='$day' MONTH='$month' WDAY='$wday'"
-str="$str CMD='$command' SUSPENDED='no' TIME='$time' DATE='$date'"
+str="$str CMD='$cron_command' SUSPENDED='no' TIME='$time' DATE='$date'"
 
 # Adding to crontab
 echo "$str" >> $HESTIA/data/users/$user/cron.conf
@@ -87,7 +87,7 @@ $BIN/v-restart-cron "$restart"
 check_result $? "Cron restart failed" > /dev/null
 
 # Logging
-$BIN/v-log-action "$user" "Info" "Cron Jobs" "Cron job added (ID: $job, Command: $command)"
+$BIN/v-log-action "$user" "Info" "Cron Jobs" "Cron job added (ID: $job, Command: $cron_command)"
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-change-cron-job
+++ b/bin/v-change-cron-job
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change cron job
-# options: USER JOB MIN HOUR DAY MONTH WDAY COMMAND
+# options: USER JOB MIN HOUR DAY MONTH WDAY CRON_COMMAND
 #
 # example: v-change-cron-job admin 7 * * * * * /usr/bin/uptime
 #
@@ -19,7 +19,7 @@ hour=$4
 day=$5
 month=$6
 wday=$7
-command=$8
+cron_command=$8
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -33,8 +33,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '7' "$#" 'USER JOB MIN HOUR DAY MONTH WDAY COMMAND'
-is_format_valid 'user' 'job' 'min' 'hour' 'day' 'month' 'wday' 'command'
+check_args '7' "$#" 'USER JOB MIN HOUR DAY MONTH WDAY CRON_COMMAND'
+is_format_valid 'user' 'job' 'min' 'hour' 'day' 'month' 'wday' 'cron_command'
 is_system_enabled "$CRON_SYSTEM" 'CRON_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -54,9 +54,9 @@ time=$(echo "$time_n_date" | cut -f 1 -d \ )
 date=$(echo "$time_n_date" | cut -f 2 -d \ )
 
 # Concatenating cron string
-command=$(echo "$command" | sed -e "s/'/%quote%/g")
+cron_command=$(echo "$cron_command" | sed -e "s/'/%quote%/g")
 str="JOB='$job' MIN='$min' HOUR='$hour' DAY='$day' MONTH='$month' WDAY='$wday'"
-str="$str CMD='$command' SUSPENDED='no' TIME='$time' DATE='$date'"
+str="$str CMD='$cron_command' SUSPENDED='no' TIME='$time' DATE='$date'"
 
 # Deleting old job
 sed -i "/JOB='$job' /d" $USER_DATA/cron.conf
@@ -79,7 +79,7 @@ $BIN/v-restart-cron
 check_result $? "Cron restart failed" > /dev/null
 
 # Logging
-$BIN/v-log-action "$user" "Info" "Cron Jobs" "Cron job updated (Job: $job, Command: $command)."
+$BIN/v-log-action "$user" "Info" "Cron Jobs" "Cron job updated (Job: $job, Command: $cron_command)."
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/func/main.sh
+++ b/func/main.sh
@@ -991,7 +991,11 @@ is_string_format_valid() {
 	fi
 	is_no_new_line_format "$1"
 }
-
+is_cron_command_valid_format() {
+	if [[ ! "$1" =~ ^[^\`]*?$ ]]; then
+		check_result "$E_INVALID" "Invalid cron command format"
+	fi
+}
 # Database format validator
 is_database_format_valid() {
 	exclude="[!|@|#|$|^|&|*|(|)|+|=|{|}|:|,|<|>|?|/|\|\"|'|;|%|\`| ]"
@@ -1266,6 +1270,7 @@ is_format_valid() {
 				charsets) is_common_format_valid "$arg" 'charsets' ;;
 				chain) is_object_format_valid "$arg" 'chain' ;;
 				comment) is_object_format_valid "$arg" 'comment' ;;
+				cron_command) is_cron_command_valid_format "$arg" ;;
 				database) is_database_format_valid "$arg" 'database' ;;
 				day) is_cron_format_valid "$arg" $arg_name ;;
 				dbpass) is_password_format_valid "$arg" ;;


### PR DESCRIPTION
This validates the cron command for backticks "`". To avoid the cronjob breaking the cron listing. If you feel that some other characters should be added feel free to comment and I will add those to to disallow list.

Fix for #4699