### PR TITLE
Auto delete spam and trash after 30 days

### DIFF
--- a/install/common/dovecot/dovecot.conf
+++ b/install/common/dovecot/dovecot.conf
@@ -32,21 +32,25 @@ namespace {
     mailbox Trash {
         auto = subscribe
         special_use = \Trash
+        autoexpunge = 30d
     }
 
     mailbox "Deleted Messages" {
         auto = no
         special_use = \Trash
+        autoexpunge = 30d
     }
 
     mailbox Spam {
         auto = subscribe
         special_use = \Junk
+        autoexpunge = 30d
     }
 
     mailbox Junk {
         auto = no
         special_use = \Junk
+        autoexpunge = 30d
     }
 
     mailbox Sent {

--- a/web/templates/pages/edit_server.php
+++ b/web/templates/pages/edit_server.php
@@ -376,6 +376,17 @@
 								<i class="fas fa-pencil icon-orange"></i>
 							</a>
 						</p>
+						<?php if (!empty($_SESSION["IMAP_SYSTEM"])) { ?>
+						<p>
+							<?= _("IMAP Server") ?>:
+							<span class="u-ml5">
+								<?= $_SESSION["IMAP_SYSTEM"] ?>
+							</span>
+							<a href="/edit/server/<? echo $_SESSION["IMAP_SYSTEM"] ?>/" class="u-ml5">
+								<i class="fas fa-pencil icon-orange"></i>
+							</a>
+						</p>
+						<?php } ?>
 						<?php if (!empty($_SESSION["ANTIVIRUS_SYSTEM"])) { ?>
 							<p>
 								<?= _("Anti-Virus") ?>:


### PR DESCRIPTION
Users are used to spam and trash being cleaned up after some time and for that reason don't manually cleanup this information. It's also the go to way to get rid of credentials from mail that are stored elsewere.

For that reason automatically removing spam and trash would enhance user security but also server security since disks cannot fill up by users not getting rid of their trash and spam.

Fixes: https://github.com/hestiacp/hestiacp/issues/1462

Documentation: https://doc.dovecot.org/2.3/configuration_manual/namespace/#core_setting-namespace/mailbox/autoexpunge