### PR TITLE
Add PHP versions select to installer options

### DIFF
--- a/docs/_data/options.js
+++ b/docs/_data/options.js
@@ -100,7 +100,8 @@ export const options = [
 	{
 		flag: 'multiphp',
 		label: 'MultiPHP',
-		description: 'Allows installing multiple PHP versions',
+		description: 'Allows installing multiple PHP versions, specify comma separated. Eg: 7.4,8.3',
+		type: 'text',
 		default: 'no',
 	},
 	{


### PR DESCRIPTION
Should fix https://github.com/hestiacp/hestiacp/issues/4707 . Sadly don't know how to test it.