### PR TITLE
Fixed a bug when there is multiple network cards but not all have IP

### DIFF
--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -48,6 +48,9 @@ for nic in $nics; do
 	if [ -z "$ips" ]; then
 		ips="$nic_ipv4s"
 	else
+		if [ -z "$nic_ipv4s" ]; then
+			break
+		fi
 		ips="$ips $nic_ipv4s"
 	fi
 done


### PR DESCRIPTION
If a NIC didn't have an IP it would have added a trailing space breaking multiple configs and future attempts to IP updates.