### PR TITLE
Fix typo in default www.conf file causing PHP-FPM not to start

### DIFF
--- a/install/deb/php-fpm/www.conf
+++ b/install/deb/php-fpm/www.conf
@@ -1,6 +1,6 @@
 ; origin-src: deb/php-fpm/dummy.conf
 
-[wwww]
+[www]
 listen = /run/php/www.sock
 listen.owner = hestiamail
 listen.group = www-data


### PR DESCRIPTION
After updating to version 1.9.x, several users are reporting that php8.3-fpm doesn't start:

```
[04-Feb-2025 08:36:32] ALERT: [pool www] the process manager is missing (static, dynamic or ondemand)
[04-Feb-2025 08:36:32] ERROR: failed to post process the configuration
[04-Feb-2025 08:36:32] ERROR: FPM initialization failed
```

The default www.conf file used is using 4 w letters instead of 3.