### PR TITLE
PHP-FPM Include missing info

### DIFF
--- a/install/deb/php-fpm/dummy.conf
+++ b/install/deb/php-fpm/dummy.conf
@@ -16,3 +16,7 @@ listen.mode = 0660
 user = hestiamail
 group = hestiamail
 
+pm = ondemand
+pm.max_children = 4
+pm.max_requests = 4000
+pm.process_idle_timeout = 10s

--- a/install/deb/php-fpm/www.conf
+++ b/install/deb/php-fpm/www.conf
@@ -6,7 +6,6 @@ listen.owner = hestiamail
 listen.group = www-data
 listen.mode = 0660
 
-;"hestiamail" user created to prevent users from abusing this config
 user = hestiamail
 group = hestiamail
 


### PR DESCRIPTION
 pm = ondemand
pm.max_children = 8
pm.max_requests = 4000
pm.process_idle_timeout = 10s
pm.status_path = /status   and these missing configuration in dummy.conf 

For every single PHP version installed in case of new installation.
Long story short, php-fpm configuration in dummy.conf is incomplete.