### PR TITLE
Make jail for work sftp by using the binary sftp-server

### DIFF
--- a/bin/v-add-sys-sftp-jail
+++ b/bin/v-add-sys-sftp-jail
@@ -65,7 +65,7 @@ if [ "$restart" = 'yes' ]; then
             \n\n$(/usr/sbin/sshd -t)"
 		echo -e "$mail_text" | $SENDMAIL -s "$subj" $email
 	else
-		service sshd restart > /dev/null 2>&1
+		service ssh restart > /dev/null 2>&1
 	fi
 fi
 

--- a/bin/v-add-sys-ssh-jail
+++ b/bin/v-add-sys-ssh-jail
@@ -52,6 +52,13 @@ if [ -z "$(grep ^/usr/sbin/jailbash /etc/shells)" ]; then
 	echo "/usr/sbin/jailbash" >> /etc/shells
 fi
 
+# Use sftp-server binary so the sftp process can run inside jailbash
+if [ -z "$(grep 'Subsystem sftp /usr/lib/sftp-server' /etc/ssh/sshd_config)" ]; then
+	sed -i -E "s/Subsystem sftp internal-sftp/Subsystem sftp \/usr\/lib\/sftp-server/g" /etc/ssh/sshd_config
+
+	service ssh restart > /dev/null 2>&1
+fi
+
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#

--- a/bin/v-add-user-sftp-jail
+++ b/bin/v-add-user-sftp-jail
@@ -86,7 +86,7 @@ if [ "$restart" = 'no' ]; then
 	# Skip restart of SSH daemon
 	echo "" > /dev/null 2>&1
 else
-	service sshd restart > /dev/null 2>&1
+	service ssh restart > /dev/null 2>&1
 fi
 
 # Logging

--- a/bin/v-delete-sys-sftp-jail
+++ b/bin/v-delete-sys-sftp-jail
@@ -62,7 +62,7 @@ if [ "$restart" = 'yes' ]; then
             \n\n$(/usr/sbin/sshd -t)"
 		echo -e "$mail_text" | $SENDMAIL -s "$subj" $email
 	else
-		service sshd restart > /dev/null 2>&1
+		service ssh restart > /dev/null 2>&1
 	fi
 fi
 

--- a/bin/v-delete-sys-ssh-jail
+++ b/bin/v-delete-sys-ssh-jail
@@ -40,6 +40,13 @@ if [ -x /usr/sbin/jailbash ]; then
 	service apparmor reload > /dev/null 2>&1
 fi
 
+# Revert back to internal-sftp
+if [ -z "$(grep 'Subsystem sftp internal-sftp' /etc/ssh/sshd_config)" ]; then
+	sed -i -E "s/Subsystem sftp \/usr\/lib\/sftp-server/Subsystem sftp internal-sftp/g" /etc/ssh/sshd_config
+
+	service ssh restart > /dev/null 2>&1
+fi
+
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#

--- a/bin/v-delete-user-sftp-jail
+++ b/bin/v-delete-user-sftp-jail
@@ -76,7 +76,7 @@ delete_chroot_jail $user
 #----------------------------------------------------------#
 
 # Restart ssh service
-service sshd restart > /dev/null 2>&1
+service ssh restart > /dev/null 2>&1
 
 # Logging
 log_event "$OK" "$ARGUMENTS"

--- a/install/common/bubblewrap/jailbash
+++ b/install/common/bubblewrap/jailbash
@@ -10,6 +10,8 @@ set -euo pipefail
 	--ro-bind-try /lib64 /lib64 \
 	--tmpfs /usr/lib/modules \
 	--tmpfs /usr/lib/systemd \
+	--tmpfs /usr/local/hestia \
+	--tmpfs /usr/share \
 	--ro-bind /bin /bin \
 	--ro-bind /sbin /sbin \
 	--dir /var \

--- a/install/upgrade/manual/migrate_jailkit_to_bubblewrap.sh
+++ b/install/upgrade/manual/migrate_jailkit_to_bubblewrap.sh
@@ -90,7 +90,7 @@ if [ -n "$ssh_i" ]; then
             \n\n$(/usr/sbin/sshd -t)"
 		echo -e "$message"
 	else
-		service sshd restart > /dev/null 2>&1
+		service ssh restart > /dev/null 2>&1
 	fi
 fi
 

--- a/install/upgrade/versions/1.9.3.sh
+++ b/install/upgrade/versions/1.9.3.sh
@@ -27,3 +27,8 @@ upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 if [ ! -f /etc/apparmor.d/abi/4.0 ]; then
 	rm -f /etc/apparmor.d/bwrap-userns-restrict
 fi
+
+if [ -x /usr/sbin/jailbash ]; then
+	$HESTIA/bin/v-delete-sys-ssh-jail
+	$HESTIA/bin/v-add-sys-ssh-jail
+fi


### PR DESCRIPTION
The internal-sftp server doesn't start a new process. This makes it improssible jail the sftp process since it's running inside sshd.

By changing to the binary sftp-server the process is run inside the bubblewrap jailbash container.

Fixes #4797

Also found out that the hestia folder was read-only accessible in jailbash I removed it to limit the user of checking the PHP files.