### PR TITLE
Replaced "echo" with "sed" in v-add-cron-hestia-autoupdate

### DIFF
--- a/bin/v-add-cron-hestia-autoupdate
+++ b/bin/v-add-cron-hestia-autoupdate
@@ -62,7 +62,7 @@ if [ "$mode" = "git" ]; then
 	command='v-update-sys-hestia-git'
 fi
 
-echo "$min $hour * * * sudo /usr/local/hestia/bin/$command" > "/var/spool/cron/crontabs/hestiaweb"
+sed -i -e "\$a$min $hour * * * sudo /usr/local/hestia/bin/$command" "/var/spool/cron/crontabs/hestiaweb"
 
 #----------------------------------------------------------#
 #                       Hestia                             #


### PR DESCRIPTION
Replaced "echo" command with equivalent "sed" command as the "echo" resulted in "Permission denied", preventing automatic updates from being resumed/enabled. Also observed that the "echo" command would have overwritten the entire crontab file anyway (used > where it should have used >>).