### PR TITLE
Replaced "echo" with "sed" in v-add-remote-dns-host

### DIFF
--- a/bin/v-add-remote-dns-host
+++ b/bin/v-add-remote-dns-host
@@ -127,7 +127,7 @@ if [ -z "$check_cron" ] && [ ! -z "$CRON_SYSTEM" ]; then
 	day='*'
 	month='*'
 	wday='*'
-	echo "$min $hour * * * sudo /usr/local/hestia/bin/$cmd" > "/var/spool/cron/crontabs/hestiaweb"
+	sed -i -e "\$a$min $hour * * * sudo /usr/local/hestia/bin/$cmd" "/var/spool/cron/crontabs/hestiaweb"
 fi
 
 # Logging


### PR DESCRIPTION
Replaced "echo" command with equivalent "sed" command as the "echo" resulted in "Permission denied". Also observed that the "echo" command would have overwritten the entire crontab file anyway (used > where it should have used >>).