### PR TITLE
Replaced "echo" with "sed" in v-add-cron-restart-job

### DIFF
--- a/bin/v-add-cron-restart-job
+++ b/bin/v-add-cron-restart-job
@@ -33,7 +33,7 @@ check_hestia_demo_mode
 cmd="v-update-sys-queue restart"
 check_cron=$(grep "$cmd" "/var/spool/cron/crontabs/hestiaweb" 2> /dev/null)
 if [ -z "$check_cron" ] && [ -n "$CRON_SYSTEM" ]; then
-	echo "*/2 * * * * sudo /usr/local/hestia/bin/v-update-sys-queue restart" >> "/var/spool/cron/crontabs/hestiaweb"
+	sed -i -e "\$a*/2 * * * * sudo /usr/local/hestia/bin/v-update-sys-queue restart" "/var/spool/cron/crontabs/hestiaweb"
 fi
 
 #----------------------------------------------------------#


### PR DESCRIPTION
Replaced "echo" command with equivalent "sed" command as the "echo" resulted in "Permission denied".