### PR TITLE
Replaced "echo" with "sed" in v-add-cron-letsencrypt-job

### DIFF
--- a/bin/v-add-cron-letsencrypt-job
+++ b/bin/v-add-cron-letsencrypt-job
@@ -33,7 +33,7 @@ check_hestia_demo_mode
 cmd="bin/v-update-sys-queue letsencrypt"
 check_cron=$(grep "$cmd" "/var/spool/cron/crontabs/hestiaweb" 2> /dev/null)
 if [ -z "$check_cron" ] && [ -n "$CRON_SYSTEM" ]; then
-	echo "*/5 * * * * sudo /usr/local/hestia/bin/v-update-sys-queue letsencrypt" >> "/var/spool/cron/crontabs/hestiaweb"
+	sed -i -e "\$a*/5 * * * * sudo /usr/local/hestia/bin/v-update-sys-queue letsencrypt" "/var/spool/cron/crontabs/hestiaweb"
 fi
 
 #----------------------------------------------------------#


### PR DESCRIPTION
Replaced "echo" command with equivalent "sed" command as the "echo" resulted in "Permission denied". From what I can tell, this file is no longer used anywhere, but it has previously been updated to use the new "hestiaweb" user, so for completeness, I believe it should be updated to correctly update the crontab file as well, instead of erroring with "Permission denied".