### PR TITLE
Update hst-install-debian.sh

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -44,7 +44,7 @@ mariadb_v="11.4"
 node_v="20"
 
 # Defining software pack for all distros
-software="acl apache2 apache2-suexec-custom apache2-suexec-pristine apache2-utils awstats bc bind9 bsdmainutils bsdutils
+software="acl apache2 apache2-suexec-custom apache2-suexec-pristine apache2-utils at awstats bc bind9 bsdmainutils bsdutils
   clamav-daemon cron curl dnsutils dovecot-imapd dovecot-managesieved dovecot-pop3d dovecot-sieve e2fslibs e2fsprogs
   exim4 exim4-daemon-heavy expect fail2ban flex ftp git hestia=${HESTIA_INSTALL_VER} hestia-nginx hestia-php hestia-web-terminal
   idn2 imagemagick ipset jq libapache2-mod-fcgid libapache2-mod-php$fpm_v libapache2-mpm-itk libmail-dkim-perl lsb-release


### PR DESCRIPTION
Added the command-line utility "at", which is used in several scripts including:

bin/v-dump-site
bin/v-dump-database
bin/v-add-user-sftp-key
bin/v-add-database-temp-user
bin/v-download-backup
bin/v-generate-ssl-cert

Not sure why it was missing but if it's not installed these scripts leave files and keys lying around and add vulnerability. "at" is persistent and will remember tasks even after a server reboot.