### PR TITLE
Update configuration.php

### DIFF
--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -204,17 +204,7 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 		}
 	}
 
-	preg_match(
-		'/(Hestia SFTP Chroot\nMatch User)(.*)/i',
-		file_get_contents("/etc/ssh/sshd_config"),
-		$matches,
-	);
-	$user_list = explode(",", $matches[2]);
-	if (in_array($v_user, $user_list)) {
-		$root = "/";
-	} else {
-		$root = "/home/" . $v_user;
-	}
+	$root = "/home/" . $v_user;
 
 	return new \League\Flysystem\Sftp\SftpAdapter([
 		"host" => "127.0.0.1",

--- a/install/upgrade/versions/1.9.3.sh
+++ b/install/upgrade/versions/1.9.3.sh
@@ -21,7 +21,7 @@ upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
-upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'true'
 
 # Remove jailbash app armour file if abi 4.0 is no installed
 if [ ! -f /etc/apparmor.d/abi/4.0 ]; then


### PR DESCRIPTION
Fix disparity between using File Manager as a user with SSH access enabled and with SSH access disabled. When disabled, user was presented with a "home" directory, and when enabled, user was taken straight into their "home/$username" directory. I think this is because of historical code that worked prior to the new sftp jail system, but now seems to result in this disparity. I don't see why any user, with or without SSH or SFTP access, would need to see outside of their own "home/$username" directory via the File Manager?