### PR TITLE
Fix for Ubuntu 24.04 i18n GUI support

### DIFF
--- a/web/inc/i18n.php
+++ b/web/inc/i18n.php
@@ -3,7 +3,7 @@
 // I18N support information here
 
 putenv("LANGUAGE=" . detect_user_language());
-setlocale(LC_ALL, "C.UTF-8");
+setlocale(LC_ALL, "en_US.UTF-8");
 
 $domain = "hestiacp";
 $localedir = "/usr/local/hestia/web/locale";


### PR DESCRIPTION
Change default locale to "en_US.UTF-8" for test purposes.