### PR TITLE
Fixed error of database not downloading from UI

### DIFF
--- a/web/download/database/index.php
+++ b/web/download/database/index.php
@@ -18,5 +18,5 @@ exec(
 if ($return_var == 0) {
 	header("Content-type: application/sql");
 	header("Content-Disposition: attachment; filename=" . $output[0]);
-	header("X-Accel-Redirect: " . $output[1]);
+	header("X-Accel-Redirect: " . $output[0]);
 }


### PR DESCRIPTION
Redirection for the download request from GUI was not working, which was also redirecting to: `This site cannot be accessed
The website at site/download/database/?database=dbname_db&token=token` may be temporarily down or has been permanently moved to a new web address. `ERR_INVALID_RESPONSE`

@sahsanu provided the manual fix as: `sed -i 's/\$output\[1\]/\$output\[0\]/' /usr/local/hestia/web/download/database/index.php`

Basically the file does save in the `/backup` folder, but was not redirecting at UI level.

@jaapmarcus please review.

More details: [forum post #18306](https://forum.hestiacp.com/t/18306/)