### PR TITLE
Fix editing Panel Cronjobs for hestiaweb

### DIFF
--- a/bin/v-change-sys-service-config
+++ b/bin/v-change-sys-service-config
@@ -109,14 +109,17 @@ if [ "$update" = 'yes' ] && [ "$restart" != 'no' ]; then
 		fi
 	fi
 
-	$BIN/v-restart-service "$service" > /dev/null 2>&1
-
-	if [ $? -ne 0 ]; then
-		for config in $dst; do
-			cat "$config.vst.back" > "$config"
-			rm -f "$config.vst.back"
-		done
-		check_result "$E_RESTART" "ERROR: $service failed to start with new configuration."
+	if [[ "$service" != "hestiaweb" ]]; then
+		$BIN/v-restart-service "$service" > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			for config in $dst; do
+				cat "$config.vst.back" > "$config"
+				rm -f "$config.vst.back"
+			done
+			check_result "$E_RESTART" "ERROR: $service failed to start with new configuration."
+		fi
+	else
+		rm -f "$config.vst.back"
 	fi
 fi
 

--- a/web/edit/server/hestiaweb/index.php
+++ b/web/edit/server/hestiaweb/index.php
@@ -20,7 +20,7 @@ if (!empty($_POST["save"])) {
 		fwrite($fp, str_replace("\r\n", "\n", $_POST["v_config"]));
 		fclose($fp);
 		exec(
-			HESTIA_CMD . "v-change-sys-service-config " . $new_conf . " hestiaweb no",
+			HESTIA_CMD . "v-change-sys-service-config " . $new_conf . " hestiaweb yes",
 			$output,
 			$return_var,
 		);


### PR DESCRIPTION
https://forum.hestiacp.com/t/fresh-install-automatics-backups-arent-working/18341

When editing hestiaweb cron jobs, Hestia leaves the file `/var/spool/cron/crontabs/hestiaweb.vst.back`, but it should remove it because cron is not applying the new configuration in file `hestiaweb`. Instead, it is using the backup file `hestiaweb.vst.bak`.

This PR fixes the issue by modifying `/usr/local/hestia/web/edit/server/hestiaweb/index.php` and `/usr/local/hestia/bin/v-change-sys-service-config`.