### PR TITLE
Simplify Biome lint commands

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
 	// Run Stylelint on CSS files
 	'*.css': 'stylelint --fix --allow-empty-input',
 	// Run Biome on TS, TSX, JS, JSX files
-	'*.{ts,js}?(x)': 'npx @biomejs/biome lint --write --no-errors-on-unmatched',
+	'*.{ts,js}?(x)': 'biome lint --write --no-errors-on-unmatched',
 	// Run Prettier where supported
 	'*': 'prettier --write --ignore-unknown',
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"docs:serve": "vitepress serve docs",
 		"docs:test": "vitest run --config docs/.vitepress/vitest.config.js",
 		"build": "node build.js",
-		"lint": "prettier --cache --check . && npx @biomejs/biome lint . && stylelint web/css/src/**/*.css && markdownlint-cli2 *.md docs/**/*.md",
+		"lint": "prettier --cache --check . && biome lint . && stylelint web/css/src/**/*.css && markdownlint-cli2 *.md docs/**/*.md",
 		"lint-staged": "lint-staged",
 		"format": "prettier --cache --write .",
 		"preinstall": "npx only-allow npm",


### PR DESCRIPTION
I incorrectly used "@biomejs/biome" instead of "biome" in some commands in #4889.