### PR TITLE
hestia: Fix config path DB and DNS tool sanity checks

### DIFF
--- a/bin/v-change-database-host-password
+++ b/bin/v-change-database-host-password
@@ -34,7 +34,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 args_usage='TYPE HOST DBUSER DBPASS'
 check_args '4' "$#" "$args_usage"
 is_format_valid 'host' 'dbuser'
-is_object_valid "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
 dbpass="$password"
 
 # Perform verification if read-only mode is enabled
@@ -64,8 +64,8 @@ case $type in
 	pgsql) echo "TBD" > /dev/null ;;
 esac
 
-update_object_value "../../conf/$type" 'HOST' "$host" '$USER' "$dbuser"
-update_object_value "../../conf/$type" 'HOST' "$host" '$PASSWORD' "$dbpass"
+update_object_value "../../../conf/$type" 'HOST' "$host" '$USER' "$dbuser"
+update_object_value "../../../conf/$type" 'HOST' "$host" '$PASSWORD' "$dbpass"
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-delete-database-host
+++ b/bin/v-delete-database-host
@@ -33,7 +33,7 @@ check_args '2' "$#" 'TYPE HOST'
 is_format_valid 'type' 'host'
 is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
 is_type_valid "$DB_SYSTEM" "$type"
-is_object_valid "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
 is_dbhost_free
 
 # Perform verification if read-only mode is enabled

--- a/bin/v-delete-remote-dns-host
+++ b/bin/v-delete-remote-dns-host
@@ -30,7 +30,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '1' "$#" 'HOST'
 is_format_valid 'host'
 is_system_enabled "$DNS_CLUSTER" 'DNS_CLUSTER'
-is_object_valid "../../conf/dns-cluster" 'HOST' "$host"
+is_object_valid "../../../conf/dns-cluster" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode

--- a/bin/v-list-database-host
+++ b/bin/v-list-database-host
@@ -88,7 +88,7 @@ is_type_format_valid() {
 check_args '2' "$#" 'TYPE HOST [FORMAT]'
 is_format_valid 'host'
 is_type_format_valid "$type"
-is_object_valid "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
 
 # Set default port values if they don't exist in host configuration file
 database_set_default_ports

--- a/bin/v-suspend-database-host
+++ b/bin/v-suspend-database-host
@@ -29,8 +29,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '2' "$#" 'TYPE HOST'
 is_format_valid 'type' 'host'
 is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
-is_object_valid "../../conf/$type" 'HOST' "$host"
-is_object_unsuspended "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
+is_object_unsuspended "../../../conf/$type" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -40,7 +40,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Suspend database creation on a server
-update_object_value "../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'yes'
+update_object_value "../../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'yes'
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-suspend-remote-dns-host
+++ b/bin/v-suspend-remote-dns-host
@@ -28,8 +28,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '1' "$#" 'HOST'
 is_format_valid 'host'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
-is_object_valid "../../conf/dns-cluster" 'HOST' "$host"
-is_object_unsuspended "../../conf/dns-cluster" 'HOST' "$host"
+is_object_valid "../../../conf/dns-cluster" 'HOST' "$host"
+is_object_unsuspended "../../../conf/dns-cluster" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -39,7 +39,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Unsuspend remote dns server
-update_object_value "../../conf/dns-cluster" 'HOST' "$host" '$SUSPENDED' 'yes'
+update_object_value "../../../conf/dns-cluster" 'HOST' "$host" '$SUSPENDED' 'yes'
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-unsuspend-database-host
+++ b/bin/v-unsuspend-database-host
@@ -29,8 +29,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '2' "$#" 'TYPE HOST'
 is_format_valid 'type' 'host'
 is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
-is_object_valid "../../conf/$type" 'HOST' "$host"
-is_object_suspended "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
+is_object_suspended "../../../conf/$type" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -40,7 +40,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Unsuspend database creation on a server
-update_object_value "../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'no'
+update_object_value "../../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'no'
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-unsuspend-remote-dns-host
+++ b/bin/v-unsuspend-remote-dns-host
@@ -28,8 +28,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '1' "$#" 'HOST'
 is_format_valid 'host'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
-is_object_valid "../../conf/dns-cluster" 'HOST' "$host"
-is_object_suspended "../../conf/dns-cluster" 'HOST' "$host"
+is_object_valid "../../../conf/dns-cluster" 'HOST' "$host"
+is_object_suspended "../../../conf/dns-cluster" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -39,7 +39,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Unsuspend remote dns server
-update_object_value "../../conf/dns-cluster" 'HOST' "$host" '$SUSPENDED' 'no'
+update_object_value "../../../conf/dns-cluster" 'HOST' "$host" '$SUSPENDED' 'no'
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/func/remote.sh
+++ b/func/remote.sh
@@ -171,7 +171,7 @@ remote_dns_health_check() {
 			log_event "$E_CONNECT" "$ARGUMENTS"
 
 			# Suspending remote host
-			dconf="../../conf/dns-cluster"
+			dconf="../../../conf/dns-cluster"
 			update_object_value "$dconf" 'HOST' "$HOST" '$SUSPENDED' 'yes'
 		fi
 	done


### PR DESCRIPTION
hestia: Fix config path DB and DNS tool sanity checks
Issue:
The command `v-delete-remote-dns-host mydnshost.example.com` does not work as expected and returns

```
grep: /usr/local/hestia/data/users/admin/../../conf/dns-cluster.conf: No such file or directory
Error: dns-cluster host mydnshost.example.com doesn't exist
```

This is caused by this check:
https://github.com/hestiacp/hestiacp/blob/7803685957b50c58800965f32e8823a3e5bf7f4d/bin/v-delete-remote-dns-host#L33

Mostly because "HOST" would always check for
`$HESTIA/data/users/$user/$1.conf`
in https://github.com/hestiacp/hestiacp/blob/7803685957b50c58800965f32e8823a3e5bf7f4d/func/main.sh#L339

but the file is located in `/usr/local/hestia/conf/dns-cluster.conf`, not `/usr/local/hestia/data/(users/admin/../../)conf/dns-cluster.conf`.
A fix would be to add an additional `..` to the path, similiar to https://github.com/hestiacp/hestiacp/blob/7803685957b50c58800965f32e8823a3e5bf7f4d/bin/v-add-database#L58

Upon further research we discovered additional sanity checks that used the wrong path in the DNS as well as the DB toolset.
They were confirmed to be broken beforehand and to be fixed afterwards by using the following commands:

```
v-list-database-host mysql localhost
v-delete-remote-dns-host mydnshost.example.com
```