### PR TITLE
Fix how the file manager modifies ~/.ssh permissions

### DIFF
--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -188,7 +188,12 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 		);
 		// filemanager also requires .ssh chmod o+x ... hopefully we can improve it to g+x or u+x someday
 		// current minimum for filemanager: chmod 0701 .ssh
-		shell_exec("sudo chmod o+x " . quoteshellarg("/home/" . basename($v_user) . "/.ssh"));
+		shell_exec(
+			"sudo /usr/local/hestia/bin/v-change-fs-file-permission " .
+				quoteshellarg(basename($v_user)) .
+				" " .
+				quoteshellarg("/home/" . basename($v_user) . "/.ssh" . " 0755"),
+		);
 	}
 
 	if (!isset($_SESSION["SFTP_PORT"])) {

--- a/install/upgrade/versions/1.9.4.sh
+++ b/install/upgrade/versions/1.9.4.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.9.4
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### upgrade_config_set_value only accepts true or false.                    #######
+#######                                                                         #######
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'true'
+
+# Fix how the file manager modifies ~/.ssh permissions
+if cp -f "$HESTIA"/install/deb/filemanager/filegator/configuration.php "$HESTIA"/web/fm/configuration.php &> /dev/null; then
+	echo "[ * ] Success: The file manager's configuration.php has been updated."
+else
+	echo "[ ! ] Error: Failed to update the file manager's configuration.php."
+fi


### PR DESCRIPTION
https://forum.hestiacp.com/t/security-alert-email-when-opening-file-manager-as-admin/18011