### PR TITLE
Added UPDATE_SSL_SCRIPT to v-add-letsencrypt-domain

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -627,6 +627,10 @@ fi
 touch $HESTIA/data/queue/letsencrypt.pipe
 sed -i "/ $domain /d" $HESTIA/data/queue/letsencrypt.pipe
 
+if [ -n "$UPDATE_SSL_SCRIPT" ]; then
+	eval "$UPDATE_SSL_SCRIPT $user $domain"
+fi
+
 # Notifying user
 send_notice 'LETSENCRYPT' "$domain SSL has been installed successfully"
 


### PR DESCRIPTION
Adding onto earlier commits, this will also call the script whenever there is a renewal to LE, instead of only when SSL is enabled the first time.