### PR TITLE
Add SAN support to v-generate-ssl-cert

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -148,21 +148,21 @@ fi
 
 # Generate the cert 1 year
 if [ -z "$aliases" ]; then
-    openssl x509 -req -sha256 \
-        -days $DAYS \
-        -in $domain.csr \
-        -signkey $domain.key \
-        -extfile <(printf "[SAN]\nsubjectAltName=DNS:$domain") \
-        -extensions SAN \
-        -out $domain.crt >/dev/null 2>&1
+	openssl x509 -req -sha256 \
+		-days $DAYS \
+		-in $domain.csr \
+		-signkey $domain.key \
+		-extfile <(printf "[SAN]\nsubjectAltName=DNS:$domain") \
+		-extensions SAN \
+		-out $domain.crt > /dev/null 2>&1
 else
-    openssl x509 -req -sha256 \
-        -days $DAYS \
-        -in $domain.csr \
-        -signkey $domain.key \
-        -extfile <(printf "[SAN]\nsubjectAltName=$dns_aliases") \
-        -extensions SAN \
-        -out $domain.crt >/dev/null 2>&1
+	openssl x509 -req -sha256 \
+		-days $DAYS \
+		-in $domain.csr \
+		-signkey $domain.key \
+		-extfile <(printf "[SAN]\nsubjectAltName=$dns_aliases") \
+		-extensions SAN \
+		-out $domain.crt > /dev/null 2>&1
 fi
 
 # Listing certificates

--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -118,6 +118,9 @@ if [ -z "$aliases" ]; then
 		-batch \
 		-subj "$subj" \
 		-key $domain.key \
+		-reqexts SAN \
+		-config <(cat $ssl_conf \
+			<(printf "[SAN]\nsubjectAltName=DNS:$domain")) \
 		-out $domain.csr > /dev/null 2>&1
 else
 	for alias in $(echo $domain,$aliases | tr ',' '\n' | sort -u); do
@@ -144,11 +147,23 @@ else
 fi
 
 # Generate the cert 1 year
-openssl x509 -req -sha256 \
-	-days $DAYS \
-	-in $domain.csr \
-	-signkey $domain.key \
-	-out $domain.crt > /dev/null 2>&1
+if [ -z "$aliases" ]; then
+    openssl x509 -req -sha256 \
+        -days $DAYS \
+        -in $domain.csr \
+        -signkey $domain.key \
+        -extfile <(printf "[SAN]\nsubjectAltName=DNS:$domain") \
+        -extensions SAN \
+        -out $domain.crt >/dev/null 2>&1
+else
+    openssl x509 -req -sha256 \
+        -days $DAYS \
+        -in $domain.csr \
+        -signkey $domain.key \
+        -extfile <(printf "[SAN]\nsubjectAltName=$dns_aliases") \
+        -extensions SAN \
+        -out $domain.crt >/dev/null 2>&1
+fi
 
 # Listing certificates
 if [ -e "$domain.crt" ]; then


### PR DESCRIPTION
Added SAN support for CSR generation when there is a single domain. Previously, the script was only adding SAN support to CSR when using aliases, but it now also adds it when there is a single domain.

Anyway, it doesn't matter to include it in the CSR because the OpenSSL command used to generate the final certificate doesn't include the SAN extension by default. In fact, you have to force its use and re-specify the SAN values. This commit also includes that.