### PR TITLE
Skip Netplan check for KVM (Proxmox) VMs using systemd-networkd

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -495,7 +495,7 @@ if [ -n "$conflicts" ] && [ -z "$force" ]; then
 fi
 
 # Check network configuration
-if [ -d /etc/netplan ] && [ -z "$force" ]; then
+if [ -d /etc/netplan ] && [ -z "$force" ] && [ "$(systemd-detect-virt)" != "kvm" ]; then
 	if [ -z "$(ls -A /etc/netplan)" ]; then
 		echo '!!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!'
 		echo


### PR DESCRIPTION
This change extends the existing netplan detection logic to also skip the check when running under KVM/QEMU virtualization (e.g., Proxmox VMs), similar to how LXC containers are handled.

Many Proxmox virtual machines use `systemd-networkd` for network configuration and leave `/etc/netplan/` empty. While networking works fine, HestiaCP aborts the installation due to missing netplan configuration, even though the system is fully operational.

This patch adds a simple check using `systemd-detect-virt` and skips the netplan validation if the VM is under KVM.

Reference to existing logic for LXC: https://github.com/hestiacp/hestiacp/commit/9df67ff6008e89a6fe29adf38f563223b65c75e3