### PR TITLE
Fixed Type Conversion bug 

### DIFF
--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -124,7 +124,9 @@ if (
 
 $redirect_code_options = [301, 302];
 $v_redirect = $data[$v_domain]["REDIRECT"];
-$v_redirect_code = isset($data[$v_domain]["REDIRECT_CODE"]) ? intval($data[$v_domain]["REDIRECT_CODE"])	: 302;
+$v_redirect_code = isset($data[$v_domain]["REDIRECT_CODE"])
+  ? intval($data[$v_domain]["REDIRECT_CODE"])
+  : 302;
 if (!in_array($v_redirect, ["www." . $v_domain, $v_domain])) {
 	$v_redirect_custom = $v_redirect;
 }

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -125,8 +125,8 @@ if (
 $redirect_code_options = [301, 302];
 $v_redirect = $data[$v_domain]["REDIRECT"];
 $v_redirect_code = isset($data[$v_domain]["REDIRECT_CODE"])
-  ? intval($data[$v_domain]["REDIRECT_CODE"])
-  : 302;
+	? intval($data[$v_domain]["REDIRECT_CODE"])
+	: 302;
 if (!in_array($v_redirect, ["www." . $v_domain, $v_domain])) {
 	$v_redirect_custom = $v_redirect;
 }

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -124,7 +124,7 @@ if (
 
 $redirect_code_options = [301, 302];
 $v_redirect = $data[$v_domain]["REDIRECT"];
-$v_redirect_code = $data[$v_domain]["REDIRECT_CODE"];
+$v_redirect_code = isset($data[$v_domain]["REDIRECT_CODE"]) ? intval($data[$v_domain]["REDIRECT_CODE"])	: 302;
 if (!in_array($v_redirect, ["www." . $v_domain, $v_domain])) {
 	$v_redirect_custom = $v_redirect;
 }


### PR DESCRIPTION
Fixed Type Conversion bug by casting the REDIRECT_CODE from the config file to int.

This fixes #4980 by making sure the code read from the domains config file is an int. 

If there's no code in the file, we'll use 302 as the default, because it doesn't leave long term impacts like with a 301 redirect that can persist on user's devices for quite a long time.

