### PR TITLE
Remove the apache2-suexec-pristine package from the Debian installer

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -44,7 +44,7 @@ mariadb_v="11.4"
 node_v="20"
 
 # Defining software pack for all distros
-software="acl apache2 apache2-suexec-custom apache2-suexec-pristine apache2-utils at awstats bc bind9 bsdmainutils bsdutils
+software="acl apache2 apache2-suexec-custom apache2-utils at awstats bc bind9 bsdmainutils bsdutils
   clamav-daemon cron curl dnsutils dovecot-imapd dovecot-managesieved dovecot-pop3d dovecot-sieve e2fslibs e2fsprogs
   exim4 exim4-daemon-heavy expect fail2ban flex ftp git hestia=${HESTIA_INSTALL_VER} hestia-nginx hestia-php hestia-web-terminal
   idn2 imagemagick ipset jq libapache2-mod-fcgid libapache2-mod-php$fpm_v libapache2-mpm-itk libmail-dkim-perl lsb-release


### PR DESCRIPTION
In the Debian installer, the `apache2-suexec-pristine` package appears listed in the software selection. The problem is that if Apache is not selected, this package is not removed from the list, and as a result, both `apache2-suexec-pristine` and its dependency `apache2-bin` end up being installed. I don't believe this package is necessary when `apache2-suexec-custom` is already being installed, so I’ve removed it from the list.

Note: the Ubuntu installer does not include this package.

Forum topic: https://forum.hestiacp.com/t/successfull-install-but-2-issues-why-was-apache-on-a-pure-nginx/19018 