### PR TITLE
Fix(#4979): Fixes domain redirects not being suspended

### DIFF
--- a/install/deb/templates/web/nginx/suspended.stpl
+++ b/install/deb/templates/web/nginx/suspended.stpl
@@ -41,5 +41,5 @@ server {
 		alias %home%/%user%/web/%domain%/document_errors/;
 	}
 
-	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_lets*;
 }

--- a/install/deb/templates/web/nginx/suspended.tpl
+++ b/install/deb/templates/web/nginx/suspended.tpl
@@ -32,5 +32,6 @@ server {
 		alias %home%/%user%/web/%domain%/document_errors/;
 	}
 
-	include %home%/%user%/conf/web/%domain%/nginx.conf_*;
+	include %home%/%user%/conf/web/%domain%/nginx.conf_lets*;
+
 }

--- a/install/upgrade/versions/1.9.4.sh
+++ b/install/upgrade/versions/1.9.4.sh
@@ -17,7 +17,7 @@
 ####### You can use \n within the string to create new lines.                   #######
 #######################################################################################
 
-upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'true'
 upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'


### PR DESCRIPTION
This PR fixes domain redirects not being suspended because the suspended proxy template contains the line `include %home%/%user%/conf/web/%domain%/nginx{|.ssl}.conf_*;` which includes the `nginx{.ssl.}conf_redirects` file. (Fixes #4979)

By being more specific with the glob import (`include %home%/%user%/conf/web/%domain%/nginx{|.ssl}.conf_lets*;`), all the letsencrypt functionality keeps working, even when the domain is suspended, so there are no issues with rate limits of failed certificate renewals. 

