### PR TITLE
Ensure newline at end of hestiaweb user crontab

### DIFF
--- a/web/edit/server/hestiaweb/index.php
+++ b/web/edit/server/hestiaweb/index.php
@@ -17,7 +17,11 @@ if (!empty($_POST["save"])) {
 		exec("mktemp", $mktemp_output, $return_var);
 		$new_conf = $mktemp_output[0];
 		$fp = fopen($new_conf, "w");
-		fwrite($fp, str_replace("\r\n", "\n", $_POST["v_config"]));
+		$config = str_replace("\r\n", "\n", $_POST["v_config"]);
+		if (!str_ends_with($config, "\n")) {
+			$config .= "\n";
+		}
+		fwrite($fp, $config);
 		fclose($fp);
 		exec(
 			HESTIA_CMD . "v-change-sys-service-config " . $new_conf . " hestiaweb yes",


### PR DESCRIPTION
This fix complements #4891 

The hestiaweb user's crontab requires a newline character at the end of the file to be parsed correctly by crontab. 

Fixes #4946