### PR TITLE
Fix installation error due to failure to create self-signed certificates

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -113,6 +113,11 @@ fi
 subj="$subj/C=$country/ST=$state/L=$city/O=$org"
 subj="$subj/OU=$org_unit/CN=$domain_idn"
 
+if [ -e "/etc/ssl/openssl.cnf" ]; then
+	ssl_conf='/etc/ssl/openssl.cnf'
+else
+	ssl_conf="/etc/pki/tls/openssl.cnf"
+fi
 if [ -z "$aliases" ]; then
 	openssl req -sha256 -new \
 		-batch \
@@ -130,12 +135,6 @@ else
 		dns_aliases="${dns_aliases}DNS:$alias,"
 	done
 	dns_aliases=$(echo $dns_aliases | sed "s/,$//")
-	if [ -e "/etc/ssl/openssl.cnf" ]; then
-		ssl_conf='/etc/ssl/openssl.cnf'
-	else
-		ssl_conf="/etc/pki/tls/openssl.cnf"
-	fi
-
 	openssl req -sha256 -new \
 		-batch \
 		-subj "$subj" \


### PR DESCRIPTION
This fixes #4993 by making sure the `$ssl_conf` is set before creating the csr.