### PR TITLE
Fix bug in PR #4937

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -113,6 +113,12 @@ fi
 subj="$subj/C=$country/ST=$state/L=$city/O=$org"
 subj="$subj/OU=$org_unit/CN=$domain_idn"
 
+if [ -e "/etc/ssl/openssl.cnf" ]; then
+	ssl_conf='/etc/ssl/openssl.cnf'
+else
+	ssl_conf="/etc/pki/tls/openssl.cnf"
+fi
+
 if [ -z "$aliases" ]; then
 	openssl req -sha256 -new \
 		-batch \
@@ -130,12 +136,6 @@ else
 		dns_aliases="${dns_aliases}DNS:$alias,"
 	done
 	dns_aliases=$(echo $dns_aliases | sed "s/,$//")
-	if [ -e "/etc/ssl/openssl.cnf" ]; then
-		ssl_conf='/etc/ssl/openssl.cnf'
-	else
-		ssl_conf="/etc/pki/tls/openssl.cnf"
-	fi
-
 	openssl req -sha256 -new \
 		-batch \
 		-subj "$subj" \


### PR DESCRIPTION
If aliases variable is empty, ssl_conf is not defined when generating the CSR.