### PR TITLE
feat(Firewall): Added the ability to order firewall rules, changing their precedence within the iptables 

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -113,6 +113,12 @@ fi
 subj="$subj/C=$country/ST=$state/L=$city/O=$org"
 subj="$subj/OU=$org_unit/CN=$domain_idn"
 
+if [ -e "/etc/ssl/openssl.cnf" ]; then
+	ssl_conf='/etc/ssl/openssl.cnf'
+else
+	ssl_conf="/etc/pki/tls/openssl.cnf"
+fi
+
 if [ -z "$aliases" ]; then
 	openssl req -sha256 -new \
 		-batch \
@@ -130,12 +136,6 @@ else
 		dns_aliases="${dns_aliases}DNS:$alias,"
 	done
 	dns_aliases=$(echo $dns_aliases | sed "s/,$//")
-	if [ -e "/etc/ssl/openssl.cnf" ]; then
-		ssl_conf='/etc/ssl/openssl.cnf'
-	else
-		ssl_conf="/etc/pki/tls/openssl.cnf"
-	fi
-
 	openssl req -sha256 -new \
 		-batch \
 		-subj "$subj" \

--- a/bin/v-move-firewall-rule
+++ b/bin/v-move-firewall-rule
@@ -5,12 +5,12 @@
 # example: v-move-firewall-rule 4 up
 #
 # This function is used for moving an existing firewall rule.
-# Direction can be either "up" or "down". 
-# 
-# If the direction is "up", the rule will be moved to a lower 
+# Direction can be either "up" or "down".
+#
+# If the direction is "up", the rule will be moved to a lower
 # number (higher priority).
-# 
-# If the direction is "down", the rule will be moved to a 
+#
+# If the direction is "down", the rule will be moved to a
 # higher number (lower priority).
 
 #----------------------------------------------------------#
@@ -32,7 +32,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 get_rule_id() {
 	local source_rule_id=$1
 	local direction=$2
-	
+
 	if [ "$direction" == "UP" ]; then
 		target_rule_id=$(($source_rule_id - 1))
 	else
@@ -88,7 +88,6 @@ check_hestia_demo_mode
 
 target_rule=$(get_rule_id "$source_rule" "$direction")
 
-
 # Get the rule that will be moved
 parse_object_kv_list $(grep "RULE='$source_rule'" $HESTIA/data/firewall/rules.conf)
 
@@ -120,7 +119,6 @@ target_str="$target_str TIME='$time' DATE='$date'"
 # Deleting old target rule
 sed -i "/RULE='$target_rule' /d" $HESTIA/data/firewall/rules.conf
 
-
 # Adding new soruce and target rules
 echo "$source_str" >> $HESTIA/data/firewall/rules.conf
 echo "$target_str" >> $HESTIA/data/firewall/rules.conf
@@ -136,6 +134,6 @@ $BIN/v-update-firewall
 #----------------------------------------------------------#
 
 # Logging
-$BIN/v-log-action "system" "Info" "Firewall" "Firewall rule $source_rule moved $direction (Source rule: $source_rule, Target rule: $target_rule).\n (Source rule: $source_str, \n Target rule: $target_str)."
+$BIN/v-log-action "system" "Info" "Firewall" "Firewall rule $source_rule moved $direction (Source rule: $source_rule, Target rule: $target_rule)."
 log_event "$OK" "$ARGUMENTS"
 exit

--- a/bin/v-move-firewall-rule
+++ b/bin/v-move-firewall-rule
@@ -1,0 +1,87 @@
+#!/bin/bash
+# info: change firewall rule
+# options: RULE [DIRECTION] [NEW_POSITON]
+#
+# example: v-move-firewall-rule 4 UP
+#
+# This function is used for changing existing firewall rule.
+# It fully replace rule with new one but keeps same id.
+
+#----------------------------------------------------------#
+#                Variables & Functions                     #
+#----------------------------------------------------------#
+
+# Argument definition
+rule=$1
+direction=$(echo $2 | tr '[:lower:]' '[:upper:]')
+new_pos=$3
+
+# Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+# load config file
+source_conf "$HESTIA/conf/hestia.conf"
+
+# recursive move function
+move_rule() {
+	local 
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+check_args '4' "$#" 'RULE ACTION IPV4_CIDR PORT [PROTOCOL] [COMMENT]'
+is_format_valid 'rule' 'action' 'protocol' 'port_ext'
+if [ ! -z "$comment" ]; then
+	is_format_valid 'comment'
+fi
+is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
+is_object_valid '../../../data/firewall/rules' 'RULE' "$rule"
+
+if [[ "$ipv4_cidr" =~ ^ipset: ]]; then
+	ipset_name="${ipv4_cidr#ipset:}"
+	$BIN/v-list-firewall-ipset plain | grep "^$ipset_name\s" > /dev/null
+	check_result $? 'ipset object not found' "$E_NOTEXIST"
+else
+	is_format_valid 'ipv4_cidr'
+fi
+
+# Perform verification if read-only mode is enabled
+check_hestia_demo_mode
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+# Generating timestamp
+time_n_date=$(date +'%T %F')
+time=$(echo "$time_n_date" | cut -f 1 -d \ )
+date=$(echo "$time_n_date" | cut -f 2 -d \ )
+
+# Concatenating firewall rule
+str="RULE='$rule' ACTION='$action' PROTOCOL='$protocol' PORT='$port_ext'"
+str="$str IP='$ipv4_cidr' COMMENT='$comment' SUSPENDED='no'"
+str="$str TIME='$time' DATE='$date'"
+
+# Deleting old rule
+sed -i "/RULE='$rule' /d" $HESTIA/data/firewall/rules.conf
+
+# Adding new
+echo "$str" >> $HESTIA/data/firewall/rules.conf
+
+# Sorting firewall rules by id number
+sort_fw_rules
+
+# Updating system firewall
+$BIN/v-update-firewall
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Logging
+$BIN/v-log-action "system" "Info" "Firewall" "Firewall rule changed (Rule: $rule, Action: $action, Protocol: $protocol, Port: $port_ext)."
+log_event "$OK" "$ARGUMENTS"
+exit

--- a/bin/v-move-firewall-rule
+++ b/bin/v-move-firewall-rule
@@ -1,20 +1,25 @@
 #!/bin/bash
 # info: change firewall rule
-# options: RULE [DIRECTION] [NEW_POSITON]
+# options: RULE DIRECTION
 #
-# example: v-move-firewall-rule 4 UP
+# example: v-move-firewall-rule 4 up
 #
-# This function is used for changing existing firewall rule.
-# It fully replace rule with new one but keeps same id.
+# This function is used for moving an existing firewall rule.
+# Direction can be either "up" or "down". 
+# 
+# If the direction is "up", the rule will be moved to a lower 
+# number (higher priority).
+# 
+# If the direction is "down", the rule will be moved to a 
+# higher number (lower priority).
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #
 #----------------------------------------------------------#
 
 # Argument definition
-rule=$1
+source_rule=$1
 direction=$(echo $2 | tr '[:lower:]' '[:upper:]')
-new_pos=$3
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -24,28 +29,54 @@ source $HESTIA/func/main.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 
-# recursive move function
-move_rule() {
-	local 
+get_rule_id() {
+	local source_rule_id=$1
+	local direction=$2
+	
+	if [ "$direction" == "UP" ]; then
+		target_rule_id=$(($source_rule_id - 1))
+	else
+		target_rule_id=$(($source_rule_id + 1))
+	fi
 
+	echo "$target_rule_id"
+}
+
+# Sort function
+sort_fw_rules() {
+	cat $HESTIA/data/firewall/rules.conf \
+		| sort -n -k 2 -t \' > $HESTIA/data/firewall/rules.conf.tmp
+	mv -f $HESTIA/data/firewall/rules.conf.tmp \
+		$HESTIA/data/firewall/rules.conf
+}
 #----------------------------------------------------------#
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '4' "$#" 'RULE ACTION IPV4_CIDR PORT [PROTOCOL] [COMMENT]'
-is_format_valid 'rule' 'action' 'protocol' 'port_ext'
+check_args '2' "$#" 'RULE DIRECTION'
+is_format_valid 'rule' "$source_rule"
 if [ ! -z "$comment" ]; then
 	is_format_valid 'comment'
 fi
 is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
-is_object_valid '../../../data/firewall/rules' 'RULE' "$rule"
+is_object_valid '../../../data/firewall/rules' 'RULE' "$source_rule"
 
-if [[ "$ipv4_cidr" =~ ^ipset: ]]; then
-	ipset_name="${ipv4_cidr#ipset:}"
-	$BIN/v-list-firewall-ipset plain | grep "^$ipset_name\s" > /dev/null
-	check_result $? 'ipset object not found' "$E_NOTEXIST"
-else
-	is_format_valid 'ipv4_cidr'
+# Check if the direction is valid
+if [[ "$direction" != "UP" && "$direction" != "DOWN" ]]; then
+	echo "Invalid direction. Use 'up' or 'down'."
+	exit 1
+fi
+
+# Check if the rule can be moved up (if it's not the first rule)
+if [[ "$direction" == "UP" && "$source_rule" -eq 1 ]]; then
+	echo "Cannot move rule up. It's already the first rule."
+	exit 1
+fi
+# Check if the rule can be moved down (if it's not the last rule)
+last_rule=$(tail -n 1 $HESTIA/data/firewall/rules.conf | cut -d "'" -f 2)
+if [[ "$direction" == "DOWN" && "$source_rule" -eq "$last_rule" ]]; then
+	echo "Cannot move rule down. It's already the last rule."
+	exit 1
 fi
 
 # Perform verification if read-only mode is enabled
@@ -55,21 +86,44 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
+target_rule=$(get_rule_id "$source_rule" "$direction")
+
+
+# Get the rule that will be moved
+parse_object_kv_list $(grep "RULE='$source_rule'" $HESTIA/data/firewall/rules.conf)
+
 # Generating timestamp
 time_n_date=$(date +'%T %F')
 time=$(echo "$time_n_date" | cut -f 1 -d \ )
 date=$(echo "$time_n_date" | cut -f 2 -d \ )
 
 # Concatenating firewall rule
-str="RULE='$rule' ACTION='$action' PROTOCOL='$protocol' PORT='$port_ext'"
-str="$str IP='$ipv4_cidr' COMMENT='$comment' SUSPENDED='no'"
-str="$str TIME='$time' DATE='$date'"
+source_str="RULE='$target_rule' ACTION='$ACTION' PROTOCOL='$PROTOCOL' PORT='$PORT'"
+source_str="$source_str IP='$IP' COMMENT='$COMMENT' SUSPENDED='$SUSPENDED'"
+source_str="$source_str TIME='$time' DATE='$date'"
 
-# Deleting old rule
-sed -i "/RULE='$rule' /d" $HESTIA/data/firewall/rules.conf
+# Deleting old source rule
+sed -i "/RULE='$source_rule' /d" $HESTIA/data/firewall/rules.conf
 
-# Adding new
-echo "$str" >> $HESTIA/data/firewall/rules.conf
+parse_object_kv_list $(grep "RULE='$target_rule'" $HESTIA/data/firewall/rules.conf)
+
+# Generating timestamp
+time_n_date=$(date +'%T %F')
+time=$(echo "$time_n_date" | cut -f 1 -d \ )
+date=$(echo "$time_n_date" | cut -f 2 -d \ )
+
+# Concatenating firewall rule
+target_str="RULE='$source_rule' ACTION='$ACTION' PROTOCOL='$PROTOCOL' PORT='$PORT'"
+target_str="$target_str IP='$IP' COMMENT='$COMMENT' SUSPENDED='$SUSPENDED'"
+target_str="$target_str TIME='$time' DATE='$date'"
+
+# Deleting old target rule
+sed -i "/RULE='$target_rule' /d" $HESTIA/data/firewall/rules.conf
+
+
+# Adding new soruce and target rules
+echo "$source_str" >> $HESTIA/data/firewall/rules.conf
+echo "$target_str" >> $HESTIA/data/firewall/rules.conf
 
 # Sorting firewall rules by id number
 sort_fw_rules
@@ -82,6 +136,6 @@ $BIN/v-update-firewall
 #----------------------------------------------------------#
 
 # Logging
-$BIN/v-log-action "system" "Info" "Firewall" "Firewall rule changed (Rule: $rule, Action: $action, Protocol: $protocol, Port: $port_ext)."
+$BIN/v-log-action "system" "Info" "Firewall" "Firewall rule $source_rule moved $direction (Source rule: $source_rule, Target rule: $target_rule).\n (Source rule: $source_str, \n Target rule: $target_str)."
 log_event "$OK" "$ARGUMENTS"
 exit

--- a/bin/v-move-firewall-rule
+++ b/bin/v-move-firewall-rule
@@ -119,7 +119,7 @@ target_str="$target_str TIME='$time' DATE='$date'"
 # Deleting old target rule
 sed -i "/RULE='$target_rule' /d" $HESTIA/data/firewall/rules.conf
 
-# Adding new soruce and target rules
+# Adding new source and target rules
 echo "$source_str" >> $HESTIA/data/firewall/rules.conf
 echo "$target_str" >> $HESTIA/data/firewall/rules.conf
 

--- a/func/main.sh
+++ b/func/main.sh
@@ -1147,6 +1147,13 @@ is_object_format_valid() {
 	fi
 }
 
+# Comment validator
+is_comment_format_valid() {
+	if ! [[ "$1" =~ ^[[:alnum:]][[:alnum:] ._-]{0,64}[[:alnum:]]$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
 # Role validator
 is_role_valid() {
 	if ! [[ "$1" =~ ^admin$|^user$|^dns-cluster$ ]]; then
@@ -1203,7 +1210,7 @@ is_format_valid() {
 				charset) is_object_format_valid "$arg" "$arg_name" ;;
 				charsets) is_common_format_valid "$arg" 'charsets' ;;
 				chain) is_object_format_valid "$arg" 'chain' ;;
-				comment) is_object_format_valid "$arg" 'comment' ;;
+				comment) is_comment_format_valid "$arg" 'comment' ;;
 				cron_command) is_cron_command_valid_format "$arg" ;;
 				database) is_database_format_valid "$arg" 'database' ;;
 				day) is_cron_format_valid "$arg" $arg_name ;;

--- a/func/main.sh
+++ b/func/main.sh
@@ -1149,7 +1149,7 @@ is_object_format_valid() {
 
 # Comment validator
 is_comment_format_valid() {
-	if ! [[ "$1" =~ ^[[:alnum:]][[:alnum:] ._-]{0,64}[[:alnum:]]$ ]]; then
+	if ! [[ "$1" =~ ^[[:alnum:]][[:alnum:][:space:]._-]{0,64}[[:alnum:]]$ ]]; then
 		check_result "$E_INVALID" "invalid $2 format :: $1"
 	fi
 }

--- a/install/deb/templates/web/nginx/suspended.stpl
+++ b/install/deb/templates/web/nginx/suspended.stpl
@@ -41,5 +41,5 @@ server {
 		alias %home%/%user%/web/%domain%/document_errors/;
 	}
 
-	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_lets*;
 }

--- a/install/deb/templates/web/nginx/suspended.tpl
+++ b/install/deb/templates/web/nginx/suspended.tpl
@@ -32,5 +32,6 @@ server {
 		alias %home%/%user%/web/%domain%/document_errors/;
 	}
 
-	include %home%/%user%/conf/web/%domain%/nginx.conf_*;
+	include %home%/%user%/conf/web/%domain%/nginx.conf_lets*;
+
 }

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -44,7 +44,7 @@ mariadb_v="11.4"
 node_v="20"
 
 # Defining software pack for all distros
-software="acl apache2 apache2-suexec-custom apache2-suexec-pristine apache2-utils at awstats bc bind9 bsdmainutils bsdutils
+software="acl apache2 apache2-suexec-custom apache2-utils at awstats bc bind9 bsdmainutils bsdutils
   clamav-daemon cron curl dnsutils dovecot-imapd dovecot-managesieved dovecot-pop3d dovecot-sieve e2fslibs e2fsprogs
   exim4 exim4-daemon-heavy expect fail2ban flex ftp git hestia=${HESTIA_INSTALL_VER} hestia-nginx hestia-php hestia-web-terminal
   idn2 imagemagick ipset jq libapache2-mod-fcgid libapache2-mod-php$fpm_v libapache2-mpm-itk libmail-dkim-perl lsb-release

--- a/install/upgrade/versions/1.9.4.sh
+++ b/install/upgrade/versions/1.9.4.sh
@@ -17,7 +17,7 @@
 ####### You can use \n within the string to create new lines.                   #######
 #######################################################################################
 
-upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'true'
 upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'

--- a/web/edit/server/hestiaweb/index.php
+++ b/web/edit/server/hestiaweb/index.php
@@ -17,7 +17,11 @@ if (!empty($_POST["save"])) {
 		exec("mktemp", $mktemp_output, $return_var);
 		$new_conf = $mktemp_output[0];
 		$fp = fopen($new_conf, "w");
-		fwrite($fp, str_replace("\r\n", "\n", $_POST["v_config"]));
+		$config = str_replace("\r\n", "\n", $_POST["v_config"]);
+		if (!str_ends_with($config, "\n")) {
+			$config .= "\n";
+		}
+		fwrite($fp, $config);
 		fclose($fp);
 		exec(
 			HESTIA_CMD . "v-change-sys-service-config " . $new_conf . " hestiaweb yes",

--- a/web/move/firewall/index.php
+++ b/web/move/firewall/index.php
@@ -17,7 +17,8 @@ if ($_SESSION["userContext"] != "admin") {
 
 if (!empty($_GET["rule"])) {
 	$v_rule = quoteshellarg($_GET["rule"]);
-	exec(HESTIA_CMD . "v-move-firewall-rule " . $v_rule, $output, $return_var);
+	$v_direction = quoteshellarg($_GET["direction"]);
+	exec(HESTIA_CMD . "v-move-firewall-rule " . $v_rule . " ". $v_direction, $output, $return_var);
 }
 check_return_code($return_var, $output);
 unset($output);

--- a/web/move/firewall/index.php
+++ b/web/move/firewall/index.php
@@ -18,7 +18,7 @@ if ($_SESSION["userContext"] != "admin") {
 if (!empty($_GET["rule"])) {
 	$v_rule = quoteshellarg($_GET["rule"]);
 	$v_direction = quoteshellarg($_GET["direction"]);
-	exec(HESTIA_CMD . "v-move-firewall-rule " . $v_rule . " ". $v_direction, $output, $return_var);
+	exec(HESTIA_CMD . "v-move-firewall-rule " . $v_rule . " " . $v_direction, $output, $return_var);
 }
 check_return_code($return_var, $output);
 unset($output);

--- a/web/sort/firewall/index.php
+++ b/web/sort/firewall/index.php
@@ -1,0 +1,32 @@
+<?php
+use function Hestiacp\quoteshellarg\quoteshellarg;
+
+ob_start();
+
+session_start();
+include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
+
+// Check token
+verify_csrf($_GET);
+
+// Check user
+if ($_SESSION["userContext"] != "admin") {
+	header("Location: /list/user");
+	exit();
+}
+
+if (!empty($_GET["rule"])) {
+	$v_rule = quoteshellarg($_GET["rule"]);
+	exec(HESTIA_CMD . "v-move-firewall-rule " . $v_rule, $output, $return_var);
+}
+check_return_code($return_var, $output);
+unset($output);
+
+$back = getenv("HTTP_REFERER");
+if (!empty($back)) {
+	header("Location: " . $back);
+	exit();
+}
+
+header("Location: /list/firewall/");
+exit();

--- a/web/templates/pages/list_firewall.php
+++ b/web/templates/pages/list_firewall.php
@@ -79,6 +79,15 @@
 		<?php
 			foreach ($data as $key => $value) {
 				++$i;
+				if ($i === 1) {
+					$move_up_enabled = false;
+				} elseif ($i == count($data)) {
+					$move_up_enabled = true;
+					$move_down_enabled = false;
+				} else {
+					$move_up_enabled = true;
+					$move_down_enabled = true;
+				}
 				if ($data[$key]['SUSPENDED'] == 'yes') {
 					$status = 'suspended';
 					$spnd_action = 'unsuspend';
@@ -121,6 +130,16 @@
 				</div>
 				<div class="units-table-cell">
 					<ul class="units-table-row-actions">
+						<li class="units-table-row-action shortcut-enter" data-key-action="href">
+							<a
+								class="units-table-row-action-link"
+								href="/update/firewall/?rule=<?= $key ?>&token=<?= $_SESSION["token"] ?>"
+								title="<?= _("Edit Firewall Rule") ?>"
+							>
+								<i class="fas fa-arrow-up icon-orange"></i>
+								<span class="u-hide-desktop"><?= _("Move Firewall Rule Up") ?></span>
+							</a>
+						</li>
 						<li class="units-table-row-action shortcut-enter" data-key-action="href">
 							<a
 								class="units-table-row-action-link"

--- a/web/templates/pages/list_firewall.php
+++ b/web/templates/pages/list_firewall.php
@@ -67,6 +67,8 @@
 			<div class="units-table-cell">
 				<input type="checkbox" class="js-toggle-all-checkbox" title="<?= _("Select all") ?>">
 			</div>
+			<div class="units-table-cell"><?= _("Pos") ?></div>
+			<div class="units-table-cell"></div>
 			<div class="units-table-cell"><?= _("Action") ?></div>
 			<div class="units-table-cell"></div>
 			<div class="units-table-cell"><?= _("Comment") ?></div>
@@ -117,6 +119,43 @@
 					</div>
 				</div>
 				<div class="units-table-cell units-table-heading-cell u-text-bold">
+					<span class="u-hide-desktop"><?= _("Position") ?>:</span>
+					<a href="/edit/firewall/?rule=<?= $key ?>&token=<?= $_SESSION["token"] ?>" title="<?= _("Edit Firewall Rule") ?>">
+						<?php
+							$rule = $key;
+						?>
+						<?= $rule ?>
+					</a>
+				</div>
+				<div class="units-table-cell" style="padding-left: 0;padding-right: 0;">
+					<ul class="units-table-row-actions">
+						<li class="units-table-row-action shortcut-up" data-key-action="js">
+							<a
+								class="units-table-row-action-link data-controls js-confirm-action"
+								style="<?= $move_up_enabled ? "display:block!important" : "display:none!important" ?>"
+								href="/move/firewall/?rule=<?= $key ?>&direction=up&token=<?= $_SESSION["token"] ?>"
+								title="<?= _("Move Firewall Rule Up") ?>"
+								data-confirm-title="<?= _("Move Up") ?>"
+								data-confirm-message="<?= sprintf(_("Are you sure you want to move rule #%s up?"), $key) ?>">
+								<i class="fas fa-arrow-up icon-blue"></i>
+								<span class="u-hide-desktop"><?= _("Move Firewall Rule Up") ?></span>
+							</a>
+						</li>
+						<li class="units-table-row-action shortcut-down" data-key-action="js">
+							<a
+								class="units-table-row-action-link data-controls js-confirm-action"
+								style="<?= $move_down_enabled ? "" : "display:block!important" ?>"
+								href="/move/firewall/?rule=<?= $key ?>&direction=down&token=<?= $_SESSION["token"] ?>"
+								title="<?= _("Move Firewall Rule Down") ?>"
+								data-confirm-title="<?= _("Move Down") ?>"
+								data-confirm-message="<?= sprintf(_("Are you sure you want to move rule #%s down?"), $key) ?>">
+								<i class="fas fa-arrow-down icon-blue"></i>
+								<span class="u-hide-desktop"><?= _("Move Firewall Rule Down") ?></span>
+							</a>
+						</li>
+					</ul>
+				</div>
+				<div class="units-table-cell units-table-heading-cell u-text-bold">
 					<span class="u-hide-desktop"><?= _("Action") ?>:</span>
 					<a href="/edit/firewall/?rule=<?= $key ?>&token=<?= $_SESSION["token"] ?>" title="<?= _("Edit Firewall Rule") ?>">
 						<?php
@@ -130,16 +169,6 @@
 				</div>
 				<div class="units-table-cell">
 					<ul class="units-table-row-actions">
-						<li class="units-table-row-action shortcut-enter" data-key-action="href">
-							<a
-								class="units-table-row-action-link"
-								href="/update/firewall/?rule=<?= $key ?>&token=<?= $_SESSION["token"] ?>"
-								title="<?= _("Edit Firewall Rule") ?>"
-							>
-								<i class="fas fa-arrow-up icon-orange"></i>
-								<span class="u-hide-desktop"><?= _("Move Firewall Rule Up") ?></span>
-							</a>
-						</li>
 						<li class="units-table-row-action shortcut-enter" data-key-action="href">
 							<a
 								class="units-table-row-action-link"


### PR DESCRIPTION
I've added the ability to sort the firewall rules and therefore change their precedence in iptables filtering. 

![grafik](https://github.com/user-attachments/assets/0fa95df5-fbed-4ee6-85c4-7b9be1540774)

This allows for some services to be allowed through, before for example being blocked by ipset filters or other rules.

I've also added the ability to enter comments containing spaces, which increases the usefulness of the comment field.  

![grafik](https://github.com/user-attachments/assets/1fbc79af-a2eb-439a-986f-b4c5f821a8df)
![grafik](https://github.com/user-attachments/assets/648c8bf9-2a3b-444f-a5cf-46b1af49c7d7)

This is a MVP for this ability, so there are some future improvements I can see:
- It would be great to have buttons for "Insert new rule here"
- Also, "Move selected rule {in front|after} this rule." would help with sorting