### PR TITLE
Comment out ssl_stapling directives (Fixes #4984)

### DIFF
--- a/install/deb/templates/mail/nginx/default.stpl
+++ b/install/deb/templates/mail/nginx/default.stpl
@@ -8,8 +8,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/mail/nginx/default_disabled.stpl
+++ b/install/deb/templates/mail/nginx/default_disabled.stpl
@@ -7,8 +7,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/mail/nginx/default_snappymail.stpl
+++ b/install/deb/templates/mail/nginx/default_snappymail.stpl
@@ -8,8 +8,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/mail/nginx/disabled.stpl
+++ b/install/deb/templates/mail/nginx/disabled.stpl
@@ -8,8 +8,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/mail/nginx/snappymail.stpl
+++ b/install/deb/templates/mail/nginx/snappymail.stpl
@@ -8,8 +8,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/mail/nginx/web_system.stpl
+++ b/install/deb/templates/mail/nginx/web_system.stpl
@@ -8,8 +8,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/caching.stpl
+++ b/install/deb/templates/web/nginx/caching.stpl
@@ -11,8 +11,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/default.stpl
+++ b/install/deb/templates/web/nginx/default.stpl
@@ -11,8 +11,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/hosting.stpl
+++ b/install/deb/templates/web/nginx/hosting.stpl
@@ -11,8 +11,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/chevereto.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/chevereto.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/codeigniter.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/codeigniter.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/craftcms.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/craftcms.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/default.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/default.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/dolibarr.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/dolibarr.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/drupal-composer.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/drupal-composer.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/drupal-social.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/drupal-social.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/drupal.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/drupal.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/flarum-composer.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/flarum-composer.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/flarum.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/flarum.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/forgejo.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/forgejo.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/gitea.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/gitea.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/grav.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/grav.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/joomla.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/laravel.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/magento.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/mautic.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/mautic.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/modx.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/moodle.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/no-php.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/odoo.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/opencart.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/opengist.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/opengist.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/openproject.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/openproject.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/osticket.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/osticket.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/owncloud.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/phpbb.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/phpbb.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/piwik.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/prestashop.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/prestashop.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/projectsend.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/projectsend.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/sendy.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/suspended.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/suspended.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/symfony2-3.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/symfony2-3.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/symfony4-5.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/symfony4-5.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/thunder.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/thunder.stpl
@@ -9,8 +9,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/vvveb.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/vvveb.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/webasyst.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/webasyst.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/wordpress-disable-xmlrpc.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress-disable-xmlrpc.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/wordpress_mu_subdir.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress_mu_subdir.stpl
@@ -15,8 +15,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/php-fpm/yourls.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/yourls.stpl
@@ -14,8 +14,9 @@ server {
 
 	ssl_certificate      %ssl_pem%;
 	ssl_certificate_key  %ssl_key%;
-	ssl_stapling on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/install/deb/templates/web/nginx/suspended.stpl
+++ b/install/deb/templates/web/nginx/suspended.stpl
@@ -14,8 +14,9 @@ server {
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	ssl_stapling        on;
-	ssl_stapling_verify on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }

--- a/src/deb/nginx/nginx.conf
+++ b/src/deb/nginx/nginx.conf
@@ -84,8 +84,9 @@ http {
 	ssl_session_cache             shared:SSL:10m;
 	ssl_session_tickets           on;
 	ssl_session_timeout           7d;
-	ssl_stapling                  on;
-	ssl_stapling_verify           on;
+	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling                  on;
+	#ssl_stapling_verify           on;
 	resolver                      1.0.0.1 8.8.4.4 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout              5s;
 	# Security headers


### PR DESCRIPTION
Due to Lets Encrypt ending OCSP support in 2025, ssl_stapling directives have been commented out to avoid warnings in logs.

The directives have been commented out in:

Nginx conf:
```
src/deb/nginx/nginx.conf
```
All Nginx mail and web templates: 
```
install/deb/templates/{mail,web}/*.stpl
```

Fixes #4984