### PR TITLE
Fix: v-restart-ftp only reloads vsftpd; full restart needed to reload certs (Fixes #5004)

### DIFF
--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -65,7 +65,6 @@ for service in $service_list; do
 		"$service" = "dovecot" -o \
 		"$service" = "bind9" -o \
 		"$service" = "named" -o \
-		"$service" = "vsftpd" -o \
 		"$service" = "php5.6-fpm" -o \
 		"$service" = "php7.0-fpm" -o \
 		"$service" = "php7.1-fpm" -o \


### PR DESCRIPTION
Fixes #5004

Proftpd is not affected.