### PR TITLE
Update wordpress.stpl

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,13 @@ server {
 	access_log  /var/log/nginx/domains/%domain%.bytes bytes;
 	error_log   /var/log/nginx/domains/%domain%.error.log error;
 
+
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:;" always;
+
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
 	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025


### PR DESCRIPTION
Add security headers to default WordPress SSL NGINX template

Added standard HTTP security headers to the WordPress SSL nginx template:
- X-Frame-Options: SAMEORIGIN
- X-Content-Type-Options: nosniff
- Referrer-Policy: strict-origin-when-cross-origin
- Permissions-Policy: disable geolocation, microphone, and camera
- Content-Security-Policy: self-restrictive policy for scripts and styles

These headers follow common WordPress security recommendations and enhance protection against clickjacking, MIME sniffing, and data leaks via referrer headers.