### PR TITLE
Improve logging of Spamhaus DQS lookups without exposing query key

### DIFF
--- a/docs/docs/server-administration/email.md
+++ b/docs/docs/server-administration/email.md
@@ -64,7 +64,7 @@ When you are done you can check the configuration via [MXToolBox](https://mxtool
 1. Fill in the form and verify your email address by via the link in the email you recive.
 1. Once logged, go to Products → DQS and you will see your Query Key and below you will see the exactly fqdn that you will need to use Zen Spamhaus black list. Something like: `HereYourQueryKey.zen.dq.spamhaus.net`
 1. Edit /etc/exim4/dnsbl.conf and replace `zen.spamhaus.org` with `HereYourQueryKey.zen.dq.spamhaus.net`
-1. Also edit /etc/exim4/exim4.conf.template on the line: `deny    message       = Rejected because $sender_host_address is in a black list at $dnslist_domain\n$dnslist_text` to `deny    message       = Rejected because $sender_host_address is in a black list` to prevent your Query key from leaking
+1. Also edit /etc/exim4/exim4.conf.template on the line: `deny    message       = Rejected because $sender_host_address is in a black list at $dnslist_domain\n$dnslist_text` to `deny    message       = Rejected because $sender_host_address is in a black list at ${if match{$dnslist_domain}{.*zen.dq.spamhaus.*}{zen.dq.spamhaus.net}{$dnslist_domain}}\n$dnslist_text` to prevent your Query key from leaking
 1. Restart exim4 with systemctl restart exim4
 
 ## How do I disable internal lookup for email


### PR DESCRIPTION
Enhanced the Exim rejection message template to preserve information about the blacklist being used (e.g., zen.dq.spamhaus.net) without exposing the private DQS query key.

The new conditional format ensures that if the domain matches Spamhaus DQS, a generic name is shown instead of the full domain with the query key, thus improving both observability and security.
