### PR TITLE
Fix: Remove incorrect 'hestia-zone' setting from master in DNS cluste…

### DIFF
--- a/docs/docs/server-administration/dns.md
+++ b/docs/docs/server-administration/dns.md
@@ -92,8 +92,7 @@ Preparing your **Slave** server(s):
 
 Preparing your **Master** server:
 
-1. On the **Master** server, open `/usr/local/hestia/conf/hestia.conf`, change `DNS_CLUSTER_SYSTEM='hestia'` to `DNS_CLUSTER_SYSTEM='hestia-zone'`.
-2. Edit `/etc/bind/named.conf.options`, do the following changes, then restart bind9 with `systemctl restart bind9`.
+1. Edit `/etc/bind/named.conf.options`, do the following changes, then restart bind9 with `systemctl restart bind9`.
 
    ```bash
    # Change this line
@@ -106,7 +105,7 @@ Preparing your **Master** server:
    also-notify { second.slave.ip.address; };
    ```
 
-3. Run the following command to enable each Slave DNS server, and wait a short while for it to complete zone transfers:
+2. Run the following command to enable each Slave DNS server, and wait a short while for it to complete zone transfers:
 
    ```bash
    v-add-remote-dns-host <your slave host name> <port number> '<accesskey>:<secretkey>' '' 'api' '<your chosen slave user name>'
@@ -118,7 +117,7 @@ Preparing your **Master** server:
    v-add-remote-dns-host slave.yourhost.com 8083 'admin' 'strongpassword' 'api' 'user-name'
    ```
 
-4. Check it worked by listing the DNS zones on the **Slave** for the dns-user with the CLI command `v-list-dns-domains dns-user` or by connecting to the web interface as dns-user and reviewing the DNS zones.
+3. Check it worked by listing the DNS zones on the **Slave** for the dns-user with the CLI command `v-list-dns-domains dns-user` or by connecting to the web interface as dns-user and reviewing the DNS zones.
 
 ### Converting an existing DNS cluster to Master -> Slave
 


### PR DESCRIPTION
…r setup

In the official DNS cluster documentation, the master server is instructed to set DNS_CLUSTER_SYSTEM='hestia-zone' in /usr/local/hestia/conf/hestia.conf.

However, this setting causes issues where the master fails to push DNS records to the slave correctly — zones are created via API, but remain empty in the Hestia UI due to missing integration.

This commit removes that line from the master configuration instructions. The correct setting for the master is: DNS_CLUSTER_SYSTEM='hestia'

Only the slave should use:
DNS_CLUSTER_SYSTEM='hestia-zone'

This restores proper sync behavior, and ensures that records are counted and visible in the slave panel as expected.