### PR TITLE
nitpicks

### DIFF
--- a/web/edit/server/hestiaweb/index.php
+++ b/web/edit/server/hestiaweb/index.php
@@ -16,14 +16,17 @@ if ($_SESSION["userContext"] !== "admin" && $user_plain === "$ROOT_USER") {
 if (!empty($_POST["save"])) {
 	if (!empty($_POST["v_config"])) {
 		$fp = tmpfile();
-		$new_conf = stream_get_meta_data($fp)['uri'];
+		$new_conf = stream_get_meta_data($fp)["uri"];
 		$config = str_replace("\r\n", "\n", $_POST["v_config"]);
 		if (!str_ends_with($config, "\n")) {
 			$config .= "\n";
 		}
 		fwrite($fp, $config);
 		exec(
-			HESTIA_CMD . "v-change-sys-service-config " . quoteshellarg($new_conf) . " hestiaweb yes",
+			HESTIA_CMD .
+				"v-change-sys-service-config " .
+				quoteshellarg($new_conf) .
+				" hestiaweb yes",
 			$output,
 			$return_var,
 		);

--- a/web/edit/server/hestiaweb/index.php
+++ b/web/edit/server/hestiaweb/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Hestiacp\quoteshellarg\quoteshellarg;
 $TAB = "SERVER";
 
 // Main include
@@ -14,23 +15,21 @@ if ($_SESSION["userContext"] !== "admin" && $user_plain === "$ROOT_USER") {
 // Check POST request
 if (!empty($_POST["save"])) {
 	if (!empty($_POST["v_config"])) {
-		exec("mktemp", $mktemp_output, $return_var);
-		$new_conf = $mktemp_output[0];
-		$fp = fopen($new_conf, "w");
+		$fp = tmpfile();
+		$new_conf = stream_get_meta_data($fp)['uri'];
 		$config = str_replace("\r\n", "\n", $_POST["v_config"]);
 		if (!str_ends_with($config, "\n")) {
 			$config .= "\n";
 		}
 		fwrite($fp, $config);
-		fclose($fp);
 		exec(
-			HESTIA_CMD . "v-change-sys-service-config " . $new_conf . " hestiaweb yes",
+			HESTIA_CMD . "v-change-sys-service-config " . quoteshellarg($new_conf) . " hestiaweb yes",
 			$output,
 			$return_var,
 		);
 		check_return_code($return_var, $output);
 		unset($output);
-		unlink($new_conf);
+		fclose($fp);
 	}
 }
 


### PR DESCRIPTION
no need to call cli mktemp, php have tmpfile().

technically if the tmp dir is in a custom location, quoteshellarg is needed (in practice it /is/ /tmp/ and we don't need it, but it's good practice to use quoteshellarg anyway)