### PR TITLE
Fix: 421 error on all web and mail domains after Apache 2.4.64 update

### DIFF
--- a/install/deb/templates/mail/nginx/default.stpl
+++ b/install/deb/templates/mail/nginx/default.stpl
@@ -31,6 +31,8 @@ server {
 
 		try_files $uri $uri/ =404;
 
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 
 		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
@@ -40,6 +42,8 @@ server {
 	}
 
 	location @fallback {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 	}
 

--- a/install/deb/templates/mail/nginx/default_disabled.stpl
+++ b/install/deb/templates/mail/nginx/default_disabled.stpl
@@ -21,6 +21,8 @@ server {
 	}
 
 	location / {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass http://%ip%:%web_port%;
 	}
 

--- a/install/deb/templates/mail/nginx/default_snappymail.stpl
+++ b/install/deb/templates/mail/nginx/default_snappymail.stpl
@@ -31,6 +31,8 @@ server {
 
 		try_files $uri $uri/ =404;
 
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 
 		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
@@ -40,6 +42,8 @@ server {
 	}
 
 	location @fallback {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 	}
 

--- a/install/deb/templates/web/nginx/caching.stpl
+++ b/install/deb/templates/web/nginx/caching.stpl
@@ -27,6 +27,8 @@ server {
 	}
 
 	location / {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 
 		proxy_cache %domain%;
@@ -64,6 +66,8 @@ server {
 	}
 
 	location @fallback {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 	}
 

--- a/install/deb/templates/web/nginx/default.stpl
+++ b/install/deb/templates/web/nginx/default.stpl
@@ -27,6 +27,8 @@ server {
 	}
 
 	location / {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 
 		location ~* ^.+\.(%proxy_extensions%)$ {
@@ -41,6 +43,8 @@ server {
 	}
 
 	location @fallback {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 	}
 

--- a/install/deb/templates/web/nginx/hosting.stpl
+++ b/install/deb/templates/web/nginx/hosting.stpl
@@ -27,6 +27,8 @@ server {
 	}
 
 	location / {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 
 		location ~* ^.+\.(%proxy_extensions%)$ {
@@ -41,6 +43,8 @@ server {
 	}
 
 	location @fallback {
+		proxy_ssl_server_name on;
+		proxy_ssl_name $host;
 		proxy_pass https://%ip%:%web_ssl_port%;
 	}
 

--- a/install/upgrade/versions/1.9.4.sh
+++ b/install/upgrade/versions/1.9.4.sh
@@ -19,7 +19,7 @@
 
 upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'true'
 upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
-upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'true'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'true'
 


### PR DESCRIPTION
After updating **Apache2** to version **2.4.64**, all web and mail domains began returning a **421 error**.

This appears to be due to the new version fixing several critical bugs related to SNI (Server Name Indication). Since Nginx connects to Apache2 using the IP address, it does not send the correct Host header.

To resolve this issue, I modified all `.stpl` Nginx templates (web and mail) that use the `proxy_pass` directive to include the following directives:

```nginx
proxy_ssl_server_name on;
proxy_ssl_name $host;
```
Fixes #5057