### PR TITLE
Prevent open 4 process, remove cat

### DIFF
--- a/bin/v-list-user
+++ b/bin/v-list-user
@@ -180,8 +180,8 @@ is_object_valid 'user' 'USER' "$user"
 USER=$user
 HOME=$HOMEDIR/$user
 source_conf "$HESTIA/data/users/$user/user.conf"
-U_USERS=$(cat "$HESTIA/data/users/$ROOT_USER/user.conf" | grep "U_USERS" | cut -d'=' -f2 | sed "s/'//g")
-SUSPENDED_USERS=$(cat "$HESTIA/data/users/$ROOT_USER/user.conf" | grep "SUSPENDED_USERS" | cut -d'=' -f2 | sed "s/'//g")
+U_USERS=$(awk -F"'" '/^U_USERS=/ {print $2}' "$HESTIA/data/users/$ROOT_USER/user.conf")
+SUSPENDED_USERS=$(awk -F"'" '/^SUSPENDED_USERS=/ {print $2}' "$HESTIA/data/users/$ROOT_USER/user.conf")
 
 # Listing data
 case $format in


### PR DESCRIPTION
Just Comment here: I don't understand why, when listing any system user using v-list-user in JSON format, Hestia shows the field U_USERS—which appears to represent the total number of users in the system.

Example

v-list-user test

"ROLE": "user",
        "SUSPENDED": "no",
        "SUSPENDED_USERS": "0",
        "SUSPENDED_WEB": "0",
        "SUSPENDED_DNS": "0",
        "SUSPENDED_MAIL": "0",
        "SUSPENDED_DB": "0",
        "SUSPENDED_CRON": "0",
        "IP_AVAIL": "1",
        "IP_OWNED": "0",
        "U_USERS": "3",<<<<<<<<<<<< why we need this information here ?
        

It seems odd to display the global user count (U_USERS) in the details of a specific user.

Wouldn't it make more sense to include something like U_USER_NUMBER, which indicates the index or order of that user in the system?

For example:
If we have 40 users, and we create a user named "test", then:

U_USER_NUMBER: "41"

I’m not sure what the original intention was, but in my opinion, showing the total number of users in a single user’s profile seems strange and irrelevant.
        
        


