### PR TITLE
Removes support for Ubuntu 20.04

### DIFF
--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -68,7 +68,7 @@ no_support_message() {
 	echo "Hestia Control Panel. Officially supported releases:"
 	echo "****************************************************"
 	echo "  Debian 11, 12"
-	echo "  Ubuntu 20.04, 22.04, 24.04 LTS"
+	echo "  Ubuntu 22.04, 24.04 LTS"
 	echo ""
 	exit 1
 }
@@ -107,7 +107,7 @@ check_wget_curl() {
 
 # Check for supported operating system before proceeding with download
 # of OS-specific installer, and throw error message if unsupported OS detected.
-if [[ "$release" =~ ^(11|12|20.04|22.04|24.04)$ ]]; then
+if [[ "$release" =~ ^(11|12|22.04|24.04)$ ]]; then
 	check_wget_curl $*
 else
 	no_support_message


### PR DESCRIPTION
Removes Ubuntu 20.04 from the list of supported operating systems in the installer script.

This change ensures that users are aware of the officially supported OS versions for Hestia Control Panel, streamlining the installation process and preventing potential issues on unsupported systems.