### PR TITLE
Fix: avoid spamd execution in Exim when reject_spam is off

### DIFF
--- a/install/deb/exim/exim4.conf.4.94.template
+++ b/install/deb/exim/exim4.conf.4.94.template
@@ -225,8 +225,8 @@ acl_check_data:
 
   # Deny spam at high score if spam score > SPAM_REJECT_SCORE and delete_spam is enabled
   deny   message        = This message scored $spam_score spam points
-         spam           = debian-spamd:true
          condition      = ${if eq{$acl_m3}{yes}{yes}{no}}
+         spam           = debian-spamd:true
          condition      = ${if >{$spam_score_int}{SPAM_REJECT_SCORE}{1}{0}}
 .endif
 

--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -227,8 +227,8 @@ acl_check_data:
 
   # Deny spam at high score if spam score > SPAM_REJECT_SCORE and delete_spam is enabled
   deny   message        = This message scored $spam_score spam points
-         spam           = debian-spamd:true
          condition      = ${if eq{$acl_m3}{yes}{yes}{no}}
+         spam           = debian-spamd:true
          condition      = ${if >{$spam_score_int}{SPAM_REJECT_SCORE}{1}{0}}
 .endif
 

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -226,8 +226,8 @@ acl_check_data:
 
   # Deny spam at high score if spam score > SPAM_REJECT_SCORE and delete_spam is enabled
   deny   message        = This message scored $spam_score spam points
-         spam           = debian-spamd:true
          condition      = ${if eq{$acl_m3}{yes}{yes}{no}}
+         spam           = debian-spamd:true
          condition      = ${if >{$spam_score_int}{SPAM_REJECT_SCORE}{1}{0}}
 .endif
 

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.9.5
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### upgrade_config_set_value only accepts true or false.                    #######
+#######                                                                         #######
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
+#Fix: avoid spamd execution in Exim when reject_spam is off for current installations
+if [ "$MAIL_SYSTEM" = "exim4" ]; then
+	echo "[ * ] Fixing spamd execution in Exim when reject_spam is off"
+	#shellcheck disable=SC2016
+	sed -i -E '/^\s*spam\s*=\s*debian-spamd:true$/{N;/\n\s*condition\s*=\s*\$\{if eq\{\$acl_m3\}\{yes\}\{yes\}\{no\}\}$/{s/(.*)\n(.*)/\2\n\1/}}' /etc/exim4/exim4.conf.template
+fi


### PR DESCRIPTION
Ensure spamd is not called when `reject_spam` is disabled, preventing unnecessary processing and potential errors in Exim.

Discussion on the forum https://forum.hestiacp.com/t/spamassassing-being-called-for-every-message/19757