### PR TITLE
Fix assets openproject and 2 news templates

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/blazor.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/blazor.stpl
@@ -1,0 +1,64 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://docs.hestiacp.com/admin_docs/web.html#how-do-web-templates-work #
+#=========================================================================#
+
+server {
+    listen      %ip%:%web_ssl_port% ssl http2;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+    #Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
+
+    include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+
+    location / {
+      # App server url
+      proxy_pass https://localhost:5001;
+
+      # Configuration for WebSockets
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_cache off;
+      # WebSockets were implemented after http/1.0
+      proxy_http_version 1.1;
+
+      # Configuration for ServerSentEvents
+      proxy_buffering off;
+
+      # Configuration for LongPolling or if your KeepAliveInterval is longer than 60 seconds
+      proxy_read_timeout 100s;
+
+      proxy_set_header Host               $host;
+      proxy_set_header X-Real-IP          $remote_addr;
+      proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto  $scheme;
+    }
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~ /\.(?!well-known\/) { 
+       deny all; 
+       return 404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/web/%domain%/stats/auth.conf*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+}

--- a/install/deb/templates/web/nginx/php-fpm/blazor.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/blazor.tpl
@@ -1,0 +1,56 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://docs.hestiacp.com/admin_docs/web.html#how-do-web-templates-work #
+#=========================================================================#
+
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+        
+    include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+
+    location / {
+      # App server url
+      proxy_pass http://localhost:5000;
+
+      # Configuration for WebSockets
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_cache off;
+      # WebSockets were implemented after http/1.0
+      proxy_http_version 1.1;
+
+      # Configuration for ServerSentEvents
+      proxy_buffering off;
+
+      # Configuration for LongPolling or if your KeepAliveInterval is longer than 60 seconds
+      proxy_read_timeout 100s;
+
+      proxy_set_header Host               $host;
+      proxy_set_header X-Real-IP          $remote_addr;
+    }
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~ /\.(?!well-known\/) { 
+       deny all; 
+       return 404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/web/%domain%/stats/auth.conf*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     %home%/%user%/conf/web/%domain%/nginx.conf_*;
+}

--- a/install/deb/templates/web/nginx/php-fpm/openproject.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/openproject.stpl
@@ -51,6 +51,10 @@ server {
 
 	proxy_hide_header Upgrade;
 
+	location ^~ /assets {
+                alias /opt/openproject/public/assets;
+        }
+
 	include /etc/nginx/conf.d/phpmyadmin.inc*;
 	include /etc/nginx/conf.d/phppgadmin.inc*;
 	include %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;

--- a/install/deb/templates/web/nginx/php-fpm/openproject.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/openproject.tpl
@@ -36,6 +36,10 @@ server {
 		include %home%/%user%/web/%domain%/stats/auth.conf*;
 	}
 
+	location ^~ /assets {
+                alias /opt/openproject/public/assets;
+        }
+
 	include /etc/nginx/conf.d/phpmyadmin.inc*;
 	include /etc/nginx/conf.d/phppgadmin.inc*;
 	include %home%/%user%/conf/web/%domain%/nginx.conf_*;

--- a/install/deb/templates/web/nginx/php-fpm/vaultwarden.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/vaultwarden.stpl
@@ -1,0 +1,64 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://docs.hestiacp.com/admin_docs/web.html#how-do-web-templates-work #
+#=========================================================================#
+
+server {
+    listen      %ip%:%web_ssl_port% ssl http2;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+    #Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+	#ssl_stapling        on;
+	#ssl_stapling_verify on;
+
+    include %home%/%user%/conf/web/%domain%/nginx.hsts.conf*;
+
+    location / {
+      # App server url
+      proxy_pass http://localhost:8000;
+
+      # Configuration for WebSockets
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_cache off;
+      # WebSockets were implemented after http/1.0
+      proxy_http_version 1.1;
+
+      # Configuration for ServerSentEvents
+      proxy_buffering off;
+
+      # Configuration for LongPolling or if your KeepAliveInterval is longer than 60 seconds
+      proxy_read_timeout 100s;
+
+      proxy_set_header Host               $host;
+      proxy_set_header X-Real-IP          $remote_addr;
+      proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto  $scheme;
+    }
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~ /\.(?!well-known\/) { 
+       deny all; 
+       return 404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/web/%domain%/stats/auth.conf*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     %home%/%user%/conf/web/%domain%/nginx.ssl.conf_*;
+}

--- a/install/deb/templates/web/nginx/php-fpm/vaultwarden.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/vaultwarden.tpl
@@ -1,0 +1,56 @@
+#=========================================================================#
+# Default Web Domain Template                                             #
+# DO NOT MODIFY THIS FILE! CHANGES WILL BE LOST WHEN REBUILDING DOMAINS   #
+# https://docs.hestiacp.com/admin_docs/web.html#how-do-web-templates-work #
+#=========================================================================#
+
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+        
+    include %home%/%user%/conf/web/%domain%/nginx.forcessl.conf*;
+
+    location / {
+      # App server url
+      proxy_pass http://localhost:8000;
+
+      # Configuration for WebSockets
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_cache off;
+      # WebSockets were implemented after http/1.0
+      proxy_http_version 1.1;
+
+      # Configuration for ServerSentEvents
+      proxy_buffering off;
+
+      # Configuration for LongPolling or if your KeepAliveInterval is longer than 60 seconds
+      proxy_read_timeout 100s;
+
+      proxy_set_header Host               $host;
+      proxy_set_header X-Real-IP          $remote_addr;
+    }
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~ /\.(?!well-known\/) { 
+       deny all; 
+       return 404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/web/%domain%/stats/auth.conf*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     %home%/%user%/conf/web/%domain%/nginx.conf_*;
+}


### PR DESCRIPTION
- Update template openproject fix assets.
- Add template for Blazor Apps (It is necessary to enable sockets in nginx).
- Add template for Vaultwarden (It is necessary to enable sockets in nginx).