### PR TITLE
Add -f flag to rm command in v-add-mail-domain-smtp-relay

### DIFF
--- a/bin/v-add-mail-domain-smtp-relay
+++ b/bin/v-add-mail-domain-smtp-relay
@@ -54,7 +54,7 @@ port:$port
 user:$username
 pass:$password
 EOL
-rm $HOMEDIR/$user/conf/mail/$domain/ip
+rm -f $HOMEDIR/$user/conf/mail/$domain/ip
 
 #----------------------------------------------------------#
 #                       Hestia                             #


### PR DESCRIPTION
This PR adds `-f` flag to `rm` command in `v-add-mail-domain-smtp-relay` to avoid errors if `ip` file doesn't exist.