### PR TITLE
Replace deprecated keyserver flow with HTTPS signed-by for Hestia APT key (Debian 11/12)

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -856,17 +856,17 @@ if [ "$mysql8" = 'yes' ]; then
 	echo "#deb [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-tools-preview" >> /etc/apt/sources.list.d/mysql.list
 	echo "deb-src [arch=$ARCH signed-by=/usr/share/keyrings/mysql-keyring.gpg] http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
 
-	GNUPGHOME="$(mktemp -d)"
-	export GNUPGHOME
-	for keyserver in $(shuf -e ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80); do
-		gpg --no-default-keyring --keyring /usr/share/keyrings/mysql-keyring.gpg --keyserver "${keyserver}" --recv-keys "B7B3B788A8D3785C" > /dev/null 2>&1 && break
-	done
+    curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 \
+      | gpg --dearmor \
+      | tee /usr/share/keyrings/mysql-keyring.gpg > /dev/null 2>&1
 fi
 
 # Installing HestiaCP repo
 echo "[ * ] Hestia Control Panel"
 echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/hestia-keyring.gpg] https://$RHOST/ $codename main" > $apt/hestia.list
-gpg --no-default-keyring --keyring /usr/share/keyrings/hestia-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A189E93654F0B0E5 > /dev/null 2>&1
+curl -fsSL https://gpg.hestiacp.com/deb_signing.key \
+  | gpg --dearmor \
+  | tee /usr/share/keyrings/hestia-keyring.gpg > /dev/null 2>&1
 
 # Installing Node.js repo
 if [ "$webterminal" = 'yes' ]; then


### PR DESCRIPTION
Summary:

- The installer currently uses apt-key/gpg --recv-keys with a keyserver to import the Hestia APT signing key.
- apt-key and SKS keyservers are deprecated and unreliable — they often hang or fail.
- Debian 11/12 recommend repository keyring files + signed-by= instead.
- This PR aligns the Hestia repo installation with best practices and makes the installer more reliable.