### PR TITLE
Added missing check to see if user can access DNS templates or is admin

### DIFF
--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -118,24 +118,29 @@ if (!empty($_POST["save"]) && !empty($_GET["domain"]) && empty($_GET["record_id"
 		unset($output);
 	}
 
-	// Change domain template
-	if ($v_template != $_POST["v_template"] && empty($_SESSION["error_msg"])) {
-		$v_template = quoteshellarg($_POST["v_template"]);
-		exec(
-			HESTIA_CMD .
-				"v-change-dns-domain-tpl " .
-				$user .
-				" " .
-				$v_domain .
-				" " .
-				$v_template .
-				" 'no'",
-			$output,
-			$return_var,
-		);
-		check_return_code($return_var, $output);
-		unset($output);
-		$restart_dns = "yes";
+	if (
+			$_SESSION["POLICY_USER_EDIT_DNS_TEMPLATES"] == "yes" ||
+			$_SESSION["userContext"] === "admin"
+	) {
+		// Change domain template
+		if ($v_template != $_POST["v_template"] && empty($_SESSION["error_msg"])) {
+			$v_template = quoteshellarg($_POST["v_template"]);
+			exec(
+				HESTIA_CMD .
+					"v-change-dns-domain-tpl " .
+					$user .
+					" " .
+					$v_domain .
+					" " .
+					$v_template .
+					" 'no'",
+				$output,
+				$return_var,
+			);
+			check_return_code($return_var, $output);
+			unset($output);
+			$restart_dns = "yes";
+		}
 	}
 
 	// Change SOA record


### PR DESCRIPTION
Added missing check to see if user can access DNS templates or is an admin - if the system policy "Allow users to change templates when editing DNS zones" is set to "no", the templates selection field is not displayed to the user when adding or editing a DNS zone (which is correct/expected behaviour), BUT it seems that the code here was not carrying out the appropriate check before attempting to change the DNS template - and an "Undefined array key "v_dnssec" in /usr/local/hestia/web/edit/dns/idex.php" error was occurring.