### PR TITLE
Secure SSL settings

### DIFF
--- a/install/deb/nginx/nginx.conf
+++ b/install/deb/nginx/nginx.conf
@@ -90,7 +90,7 @@ http {
 	ssl_protocols                   TLSv1.2 TLSv1.3;
 	ssl_session_cache               shared:SSL:20m;
 	ssl_session_tickets             on;
-	ssl_session_timeout             7d;
+	ssl_session_timeout             1h;
 	resolver                        1.0.0.1 8.8.4.4 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout                5s;
 	# Error pages

--- a/install/deb/nginx/nginx.conf
+++ b/install/deb/nginx/nginx.conf
@@ -90,7 +90,7 @@ http {
 	ssl_protocols                   TLSv1.2 TLSv1.3;
 	ssl_session_cache               shared:SSL:20m;
 	ssl_session_tickets             on;
-	ssl_session_timeout             1h;
+	ssl_session_timeout             4h;
 	resolver                        1.0.0.1 8.8.4.4 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout                5s;
 	# Error pages

--- a/src/deb/nginx/nginx.conf
+++ b/src/deb/nginx/nginx.conf
@@ -83,7 +83,7 @@ http {
 	ssl_protocols                 TLSv1.2 TLSv1.3;
 	ssl_session_cache             shared:SSL:10m;
 	ssl_session_tickets           on;
-	ssl_session_timeout           7d;
+	ssl_session_timeout           1h;
 	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
 	#ssl_stapling                  on;
 	#ssl_stapling_verify           on;

--- a/src/deb/nginx/nginx.conf
+++ b/src/deb/nginx/nginx.conf
@@ -81,9 +81,9 @@ http {
 	ssl_ecdh_curve                auto;
 	ssl_prefer_server_ciphers     on;
 	ssl_protocols                 TLSv1.2 TLSv1.3;
-	ssl_session_cache             shared:SSL:10m;
+	ssl_session_cache             shared:SSL:20m;
 	ssl_session_tickets           on;
-	ssl_session_timeout           1h;
+	ssl_session_timeout           4h;
 	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
 	#ssl_stapling                  on;
 	#ssl_stapling_verify           on;


### PR DESCRIPTION
I noticed that the newly installed HestiaCP contains a setting for a very long lifetime of ssl session:
```
ssl_session_timeout             7d;
```
Please let's change this setting. I don't think it's normal.

By the way, I do not consider these changes to be exhaustive.
Perhaps we need a revision of other settings as well.