### PR TITLE
fix v-list-database-host: correct path to configuration file

### DIFF
--- a/bin/v-change-database-host-password
+++ b/bin/v-change-database-host-password
@@ -34,7 +34,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 args_usage='TYPE HOST DBUSER DBPASS'
 check_args '4' "$#" "$args_usage"
 is_format_valid 'host' 'dbuser'
-is_object_valid "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
 dbpass="$password"
 
 # Perform verification if read-only mode is enabled
@@ -64,8 +64,8 @@ case $type in
 	pgsql) echo "TBD" > /dev/null ;;
 esac
 
-update_object_value "../../conf/$type" 'HOST' "$host" '$USER' "$dbuser"
-update_object_value "../../conf/$type" 'HOST' "$host" '$PASSWORD' "$dbpass"
+update_object_value "../../../conf/$type" 'HOST' "$host" '$USER' "$dbuser"
+update_object_value "../../../conf/$type" 'HOST' "$host" '$PASSWORD' "$dbpass"
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-delete-database-host
+++ b/bin/v-delete-database-host
@@ -33,7 +33,7 @@ check_args '2' "$#" 'TYPE HOST'
 is_format_valid 'type' 'host'
 is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
 is_type_valid "$DB_SYSTEM" "$type"
-is_object_valid "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
 is_dbhost_free
 
 # Perform verification if read-only mode is enabled

--- a/bin/v-list-database-host
+++ b/bin/v-list-database-host
@@ -88,7 +88,7 @@ is_type_format_valid() {
 check_args '2' "$#" 'TYPE HOST [FORMAT]'
 is_format_valid 'host'
 is_type_format_valid "$type"
-is_object_valid "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
 
 # Set default port values if they don't exist in host configuration file
 database_set_default_ports

--- a/bin/v-suspend-database-host
+++ b/bin/v-suspend-database-host
@@ -29,8 +29,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '2' "$#" 'TYPE HOST'
 is_format_valid 'type' 'host'
 is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
-is_object_valid "../../conf/$type" 'HOST' "$host"
-is_object_unsuspended "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
+is_object_unsuspended "../../../conf/$type" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -40,7 +40,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Suspend database creation on a server
-update_object_value "../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'yes'
+update_object_value "../../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'yes'
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-unsuspend-database-host
+++ b/bin/v-unsuspend-database-host
@@ -29,8 +29,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '2' "$#" 'TYPE HOST'
 is_format_valid 'type' 'host'
 is_system_enabled "$DB_SYSTEM" 'DB_SYSTEM'
-is_object_valid "../../conf/$type" 'HOST' "$host"
-is_object_suspended "../../conf/$type" 'HOST' "$host"
+is_object_valid "../../../conf/$type" 'HOST' "$host"
+is_object_suspended "../../../conf/$type" 'HOST' "$host"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -40,7 +40,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Unsuspend database creation on a server
-update_object_value "../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'no'
+update_object_value "../../../conf/$type" 'HOST' "$host" '$SUSPENDED' 'no'
 
 #----------------------------------------------------------#
 #                       Hestia                             #


### PR DESCRIPTION
Update call to `is_object_valid` to use `../../../conf/$type` instead of `../../conf/$type`, fixing the path to the host configuration file.