### PR TITLE
Add Cloudflare Origin CA issuance and management

### DIFF
--- a/bin/v-add-cloudflare-origin-cert
+++ b/bin/v-add-cloudflare-origin-cert
@@ -1,0 +1,269 @@
+#!/bin/bash
+# info: request Cloudflare Origin CA certificate for a web domain
+# options: USER DOMAIN [ALIASES]
+#
+# example: v-add-cloudflare-origin-cert admin example.com www.example.com,blog.example.com
+
+user=$1
+domain=$2
+aliases=${3// /}
+
+# Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+# shellcheck source=/usr/local/hestia/func/domain.sh
+source $HESTIA/func/domain.sh
+# load config file
+source_conf "$HESTIA/conf/hestia.conf"
+
+check_args '2' "$#" 'USER DOMAIN [ALIASES]'
+is_format_valid 'user' 'domain' 'aliases'
+is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
+is_system_enabled "$WEB_SSL" 'SSL_SUPPORT'
+is_object_valid 'user' 'USER' "$user"
+is_object_unsuspended 'user' 'USER' "$user"
+is_object_valid 'web' 'DOMAIN' "$domain"
+is_object_unsuspended 'web' 'DOMAIN' "$domain"
+
+check_hestia_demo_mode
+
+if [ "$CF_ORIGIN_ENABLED" != "yes" ]; then
+        check_result "$E_DISABLED" "Cloudflare Origin CA integration disabled"
+fi
+
+cf_auth_type=${CF_ORIGIN_AUTH_TYPE:-token}
+cf_api_base=${CF_ORIGIN_API_BASE:-https://api.cloudflare.com/client/v4}
+
+declare -a CF_HEADERS
+CF_HEADERS+=("-H" "Content-Type: application/json")
+
+case "$cf_auth_type" in
+        token)
+                if [ -z "$CF_ORIGIN_API_TOKEN" ]; then
+                        check_result "$E_INVALID" "Cloudflare API token is not configured"
+                fi
+                CF_HEADERS+=("-H" "Authorization: Bearer $CF_ORIGIN_API_TOKEN")
+                ;;
+        service_key)
+                if [ -z "$CF_ORIGIN_SERVICE_KEY" ]; then
+                        check_result "$E_INVALID" "Cloudflare service key is not configured"
+                fi
+                CF_HEADERS+=("-H" "X-Auth-User-Service-Key: $CF_ORIGIN_SERVICE_KEY")
+                if [ -n "$CF_ORIGIN_AUTH_EMAIL" ]; then
+                        CF_HEADERS+=("-H" "X-Auth-Email: $CF_ORIGIN_AUTH_EMAIL")
+                fi
+                ;;
+        *)
+                check_result "$E_INVALID" "Unsupported Cloudflare authentication type: $cf_auth_type"
+                ;;
+esac
+
+get_domain_values 'web'
+
+if [ -z "$aliases" ]; then
+        aliases="$ALIAS"
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+log_file="/var/log/hestia/CF-${user}-${domain}.log"
+touch "$log_file"
+chmod 600 "$log_file"
+
+log_debug() {
+        echo -e "\n==[$1]==\n$2" >> "$log_file"
+}
+
+log_debug "Start" "Issuing Cloudflare Origin CA certificate for $domain (user: $user)"
+
+domain_idn="$domain"
+if [[ "$domain" = *[![:ascii:]]* ]]; then
+        domain_idn=$(idn2 --quiet "$domain")
+fi
+
+declare -a hostnames
+hostnames+=("$domain")
+
+if [ -n "$aliases" ]; then
+        IFS=',' read -ra alias_array <<< "$aliases"
+        for alias in "${alias_array[@]}"; do
+                alias=$(echo "$alias" | xargs)
+                [ -z "$alias" ] && continue
+                hostnames+=("$alias")
+        done
+fi
+
+unique_hosts=$(printf "%s\n" "${hostnames[@]}" | sed '/^$/d' | sort -u)
+if [ -z "$unique_hosts" ]; then
+        check_result "$E_INVALID" "No hostnames found for certificate request"
+fi
+
+dns_alt=""
+declare -a hostnames_payload
+while read -r hostname; do
+        hostname_ascii="$hostname"
+        if [[ "$hostname_ascii" = *[![:ascii:]]* ]]; then
+                hostname_ascii=$(idn2 --quiet "$hostname_ascii")
+        fi
+        [ -z "$hostname_ascii" ] && continue
+        hostnames_payload+=("$hostname_ascii")
+        if [ -z "$dns_alt" ]; then
+                dns_alt="DNS:$hostname_ascii"
+        else
+                dns_alt="$dns_alt,DNS:$hostname_ascii"
+        fi
+done <<< "$unique_hosts"
+
+if [ -z "$dns_alt" ]; then
+        check_result "$E_INVALID" "Unable to build subjectAltName list"
+fi
+
+if [ -e "/etc/ssl/openssl.cnf" ]; then
+        ssl_conf="/etc/ssl/openssl.cnf"
+else
+        ssl_conf="/etc/pki/tls/openssl.cnf"
+fi
+
+cf_request_type=${CF_ORIGIN_REQUEST_TYPE:-origin-rsa}
+rsa_bits=${CF_ORIGIN_RSA_BITS:-2048}
+ecc_curve=${CF_ORIGIN_ECC_CURVE:-prime256v1}
+
+case "$cf_request_type" in
+        origin-ecc)
+                log_debug "Key" "Generating ECC key ($ecc_curve)"
+                openssl ecparam -name "$ecc_curve" -genkey -noout -out "$tmpdir/$domain_idn.key" >/dev/null 2>&1
+                check_result $? "Failed to generate ECC key"
+                ;;
+        *)
+                cf_request_type="origin-rsa"
+                log_debug "Key" "Generating RSA key (${rsa_bits} bits)"
+                openssl genrsa "$rsa_bits" > "$tmpdir/$domain_idn.key" 2>/dev/null
+                check_result $? "Failed to generate RSA key"
+                ;;
+esac
+
+log_debug "CSR" "Building CSR with SAN=$dns_alt"
+
+openssl req -new -sha256 \
+        -batch \
+        -subj "/CN=$domain_idn" \
+        -key "$tmpdir/$domain_idn.key" \
+        -reqexts SAN \
+        -config <(cat "$ssl_conf" <(printf "[SAN]\nsubjectAltName=%s\n" "$dns_alt")) \
+        -out "$tmpdir/$domain_idn.csr" >/dev/null 2>&1
+check_result $? "Failed to generate CSR"
+
+csr_payload=$(cat "$tmpdir/$domain_idn.csr")
+hostnames_json=$(printf "%s\n" "${hostnames_payload[@]}" | jq -R . | jq -s .)
+requested_validity=${CF_ORIGIN_VALIDITY:-5475}
+requested_validity=${requested_validity//[^0-9]/}
+if [ -z "$requested_validity" ]; then
+        requested_validity=5475
+fi
+
+payload=$(jq -n \
+        --arg csr "$csr_payload" \
+        --arg requested_type "$cf_request_type" \
+        --argjson requested_validity "$requested_validity" \
+        --argjson hostnames "$hostnames_json" \
+        '{csr:$csr, requested_type:$requested_type, requested_validity:$requested_validity, hostnames:$hostnames}')
+
+cloudflare_api() {
+        local method=$1
+        local endpoint=$2
+        local data=$3
+        local raw
+        if [ -n "$data" ]; then
+                raw=$(curl --silent --show-error --request "$method" "$cf_api_base$endpoint" "${CF_HEADERS[@]}" --data "$data" --write-out '\n%{http_code}')
+        else
+                raw=$(curl --silent --show-error --request "$method" "$cf_api_base$endpoint" "${CF_HEADERS[@]}" --write-out '\n%{http_code}')
+        fi
+        local exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+                return $exit_code
+        fi
+        cf_http_code=$(echo "$raw" | tail -n1)
+        echo "$raw" | sed '$d'
+        return 0
+}
+
+log_debug "API Request" "$payload"
+
+response=$(cloudflare_api POST "/certificates" "$payload")
+api_status=$?
+if [ $api_status -ne 0 ]; then
+        check_result "$E_CONNECT" "Cloudflare API request failed"
+fi
+
+log_debug "API Response" "$response (HTTP $cf_http_code)"
+
+if [ "${cf_http_code:-0}" -ge 400 ]; then
+        errors=$(echo "$response" | jq -c '.errors // empty')
+        check_result "$E_CONNECT" "Cloudflare API error ($cf_http_code) $errors"
+fi
+
+success=$(echo "$response" | jq -r '.success')
+if [ "$success" != "true" ]; then
+        errors=$(echo "$response" | jq -c '.errors // empty')
+        check_result "$E_CONNECT" "Cloudflare API returned error: $errors"
+fi
+
+certificate=$(echo "$response" | jq -r '.result.certificate // empty')
+certificate_id=$(echo "$response" | jq -r '.result.id // empty')
+if [ -z "$certificate" ] || [ -z "$certificate_id" ]; then
+        check_result "$E_CONNECT" "Cloudflare API response missing certificate data"
+fi
+
+printf "%s\n" "$certificate" > "$tmpdir/$domain_idn.crt"
+
+log_debug "Certificate" "$certificate_id"
+
+$BIN/v-add-web-domain-ssl "$user" "$domain" "$tmpdir" "$SSL_HOME" 'no'
+check_result $? "Failed to install Cloudflare certificate"
+
+update_object_value 'web' 'DOMAIN' "$domain" '$CF_ORIGIN_CERT' 'yes'
+update_object_value 'web' 'DOMAIN' "$domain" '$CF_ORIGIN_CERT_ID' "$certificate_id"
+update_object_value 'web' 'DOMAIN' "$domain" '$LETSENCRYPT' 'no'
+
+if [ "${CF_ORIGIN_SSL_MODE,,}" = "strict" ]; then
+        lookup_zone_id() {
+                local candidate="$1"
+                while [ -n "$candidate" ]; do
+                        local ascii="$candidate"
+                        if [[ "$ascii" = *[![:ascii:]]* ]]; then
+                                ascii=$(idn2 --quiet "$ascii")
+                        fi
+                        local zone_resp
+                        zone_resp=$(cloudflare_api GET "/zones?name=$ascii")
+                        if [ $? -eq 0 ] && [ "${cf_http_code:-0}" -lt 400 ]; then
+                                local zone_success
+                                zone_success=$(echo "$zone_resp" | jq -r '.success')
+                                if [ "$zone_success" = "true" ]; then
+                                        local zone_id
+                                        zone_id=$(echo "$zone_resp" | jq -r '.result[0].id // empty')
+                                        if [ -n "$zone_id" ]; then
+                                                echo "$zone_id"
+                                                return 0
+                                        fi
+                                fi
+                        fi
+                        [[ "$candidate" != *.* ]] && break
+                        candidate="${candidate#*.}"
+                done
+                return 1
+        }
+        if zone_id=$(lookup_zone_id "$domain"); then
+                mode_payload='{"value":"strict"}'
+                mode_resp=$(cloudflare_api PATCH "/zones/$zone_id/settings/ssl" "$mode_payload")
+                log_debug "Set SSL mode" "$mode_resp"
+        else
+                log_debug "Set SSL mode" "Unable to determine zone id for $domain"
+        fi
+fi
+
+$BIN/v-log-action "$user" "Info" "Web" "Cloudflare Origin certificate issued (Domain: $domain)."
+log_event "$OK" "$ARGUMENTS"
+exit

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -239,7 +239,7 @@ date=$(echo "$time_n_date" | cut -f 2 -d \ )
 
 # Adding domain in web.conf
 echo "DOMAIN='$domain' IP='$ip' IP6='' CUSTOM_DOCROOT='' ALIAS='$ALIAS' TPL='$WEB_TEMPLATE'\
- SSL='no' SSL_FORCE='no' SSL_HOME='same' LETSENCRYPT='no' FTP_USER='' FTP_MD5=''\
+ SSL='no' SSL_FORCE='no' SSL_HOME='same' LETSENCRYPT='no' CF_ORIGIN_CERT='no' CF_ORIGIN_CERT_ID='' FTP_USER='' FTP_MD5=''\
  BACKEND='$BACKEND_TEMPLATE' PROXY='$PROXY_TEMPLATE' PROXY_EXT='$PROXY_EXT'\
  STATS='' STATS_USER='' STATS_CRYPT='' U_DISK='0' U_BANDWIDTH='0'\
  SUSPENDED='no' TIME='$time' DATE='$date'" >> $USER_DATA/web.conf

--- a/bin/v-delete-cloudflare-origin-cert
+++ b/bin/v-delete-cloudflare-origin-cert
@@ -1,0 +1,91 @@
+#!/bin/bash
+# info: revoke Cloudflare Origin CA certificate for a web domain
+# options: USER DOMAIN [RESTART]
+#
+# example: v-delete-cloudflare-origin-cert admin example.com yes
+
+user=$1
+domain=$2
+restart=$3
+
+# Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+# shellcheck source=/usr/local/hestia/func/domain.sh
+source $HESTIA/func/domain.sh
+# load config file
+source_conf "$HESTIA/conf/hestia.conf"
+
+check_args '2' "$#" 'USER DOMAIN [RESTART]'
+is_format_valid 'user' 'domain' 'restart'
+is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
+is_object_valid 'user' 'USER' "$user"
+is_object_unsuspended 'user' 'USER' "$user"
+is_object_valid 'web' 'DOMAIN' "$domain"
+is_object_unsuspended 'web' 'DOMAIN' "$domain"
+
+check_hestia_demo_mode
+
+get_domain_values 'web'
+certificate_id="$CF_ORIGIN_CERT_ID"
+restart_flag=${restart:-no}
+
+cf_auth_type=${CF_ORIGIN_AUTH_TYPE:-token}
+cf_api_base=${CF_ORIGIN_API_BASE:-https://api.cloudflare.com/client/v4}
+
+declare -a CF_HEADERS
+CF_HEADERS+=("-H" "Content-Type: application/json")
+cf_api_available="no"
+
+case "$cf_auth_type" in
+        token)
+                if [ -n "$CF_ORIGIN_API_TOKEN" ]; then
+                        CF_HEADERS+=("-H" "Authorization: Bearer $CF_ORIGIN_API_TOKEN")
+                        cf_api_available="yes"
+                fi
+                ;;
+        service_key)
+                if [ -n "$CF_ORIGIN_SERVICE_KEY" ]; then
+                        CF_HEADERS+=("-H" "X-Auth-User-Service-Key: $CF_ORIGIN_SERVICE_KEY")
+                        if [ -n "$CF_ORIGIN_AUTH_EMAIL" ]; then
+                                CF_HEADERS+=("-H" "X-Auth-Email: $CF_ORIGIN_AUTH_EMAIL")
+                        fi
+                        cf_api_available="yes"
+                fi
+                ;;
+esac
+
+cloudflare_api() {
+        local method=$1
+        local endpoint=$2
+        local raw
+        raw=$(curl --silent --show-error --request "$method" "$cf_api_base$endpoint" "${CF_HEADERS[@]}" --write-out '\n%{http_code}')
+        local exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+                return $exit_code
+        fi
+        cf_http_code=$(echo "$raw" | tail -n1)
+        echo "$raw" | sed '$d'
+        return 0
+}
+
+if [ -n "$certificate_id" ] && [ "$cf_api_available" = "yes" ]; then
+        response=$(cloudflare_api DELETE "/certificates/$certificate_id")
+        if [ $? -eq 0 ]; then
+                log_event "$OK" "$ARGUMENTS"
+        else
+                log_event "$E_CONNECT" "Failed to revoke Cloudflare certificate $certificate_id ($domain)"
+        fi
+fi
+
+$BIN/v-delete-web-domain-ssl "$user" "$domain" "$restart_flag" >/dev/null 2>&1
+check_result $? "Failed to delete SSL for $domain"
+
+update_object_value 'web' 'DOMAIN' "$domain" '$CF_ORIGIN_CERT' 'no'
+update_object_value 'web' 'DOMAIN' "$domain" '$CF_ORIGIN_CERT_ID' ''
+
+$BIN/v-log-action "$user" "Warning" "Web" "Cloudflare Origin certificate removed (Domain: $domain)."
+log_event "$OK" "$ARGUMENTS"
+exit

--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -52,7 +52,7 @@ function syshealth_update_web_config_format() {
 	# WEB DOMAINS
 	# Create array of known keys in configuration file
 	system="web"
-	known_keys="DOMAIN IP IP6 CUSTOM_DOCROOT CUSTOM_PHPROOT FASTCGI_CACHE FASTCGI_DURATION ALIAS TPL SSL SSL_FORCE SSL_HSTS SSL_HOME LETSENCRYPT FTP_USER FTP_MD5 FTP_PATH BACKEND PROXY PROXY_EXT STATS STATS_USER STATS_CRYPT REDIRECT REDIRECT_CODE AUTH_USER AUTH_HASH SUSPENDED TIME DATE"
+        known_keys="DOMAIN IP IP6 CUSTOM_DOCROOT CUSTOM_PHPROOT FASTCGI_CACHE FASTCGI_DURATION ALIAS TPL SSL SSL_FORCE SSL_HSTS SSL_HOME LETSENCRYPT CF_ORIGIN_CERT CF_ORIGIN_CERT_ID FTP_USER FTP_MD5 FTP_PATH BACKEND PROXY PROXY_EXT STATS STATS_USER STATS_CRYPT REDIRECT REDIRECT_CODE AUTH_USER AUTH_HASH SUSPENDED TIME DATE"
 	write_kv_config_file
 	unset system
 	unset known_keys
@@ -198,7 +198,7 @@ function syshealth_update_system_config_format() {
 	# SYSTEM CONFIGURATION
 	# Create array of known keys in configuration file
 	system="system"
-	known_keys="ANTISPAM_SYSTEM ANTIVIRUS_SYSTEM API_ALLOWED_IP API BACKEND_PORT BACKUP_GZIP BACKUP_MODE BACKUP_SYSTEM CRON_SYSTEM DB_PMA_ALIAS DB_SYSTEM DISK_QUOTA DNS_SYSTEM ENFORCE_SUBDOMAIN_OWNERSHIP FILE_MANAGER FIREWALL_EXTENSION FIREWALL_SYSTEM FTP_SYSTEM IMAP_SYSTEM INACTIVE_SESSION_TIMEOUT LANGUAGE LOGIN_STYLE MAIL_SYSTEM PROXY_PORT PROXY_SSL_PORT PROXY_SYSTEM RELEASE_BRANCH STATS_SYSTEM THEME UPDATE_HOSTNAME_SSL UPGRADE_SEND_EMAIL UPGRADE_SEND_EMAIL_LOG WEB_BACKEND WEBMAIL_ALIAS WEBMAIL_SYSTEM WEB_PORT WEB_RGROUPS WEB_SSL WEB_SSL_PORT WEB_SYSTEM WEB_TERMINAL WEB_TERMINAL_PORT VERSION DISABLE_IP_CHECK"
+        known_keys="ANTISPAM_SYSTEM ANTIVIRUS_SYSTEM API_ALLOWED_IP API BACKEND_PORT BACKUP_GZIP BACKUP_MODE BACKUP_SYSTEM CF_ORIGIN_ENABLED CF_ORIGIN_AUTH_TYPE CF_ORIGIN_API_TOKEN CF_ORIGIN_SERVICE_KEY CF_ORIGIN_AUTH_EMAIL CF_ORIGIN_REQUEST_TYPE CF_ORIGIN_RSA_BITS CF_ORIGIN_ECC_CURVE CF_ORIGIN_VALIDITY CF_ORIGIN_SSL_MODE CRON_SYSTEM DB_PMA_ALIAS DB_SYSTEM DISK_QUOTA DNS_SYSTEM ENFORCE_SUBDOMAIN_OWNERSHIP FILE_MANAGER FIREWALL_EXTENSION FIREWALL_SYSTEM FTP_SYSTEM IMAP_SYSTEM INACTIVE_SESSION_TIMEOUT LANGUAGE LOGIN_STYLE MAIL_SYSTEM PROXY_PORT PROXY_SSL_PORT PROXY_SYSTEM RELEASE_BRANCH STATS_SYSTEM THEME UPDATE_HOSTNAME_SSL UPGRADE_SEND_EMAIL UPGRADE_SEND_EMAIL_LOG WEB_BACKEND WEBMAIL_ALIAS WEBMAIL_SYSTEM WEB_PORT WEB_RGROUPS WEB_SSL WEB_SSL_PORT WEB_SYSTEM WEB_TERMINAL WEB_TERMINAL_PORT VERSION DISABLE_IP_CHECK"
 	write_kv_config_file
 	unset system
 	unset known_keys
@@ -543,10 +543,48 @@ function syshealth_repair_system_config() {
 		echo "[ ! ] Adding missing variable to hestia.conf: ROOT_USER ('admin')"
 		$BIN/v-change-sys-config-value "ROOT_USER" "admin"
 	fi
-	if [[ -z $(check_key_exists 'DOMAINDIR_WRITABLE') ]]; then
-		echo "[ ! ] Adding missing variable to hestia.conf: DOMAINDIR_WRITABLE ('no')"
-		$BIN/v-change-sys-config-value "DOMAINDIR_WRITABLE" "no"
-	fi
+        if [[ -z $(check_key_exists 'DOMAINDIR_WRITABLE') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: DOMAINDIR_WRITABLE ('no')"
+                $BIN/v-change-sys-config-value "DOMAINDIR_WRITABLE" "no"
+        fi
+
+        if [[ -z $(check_key_exists 'CF_ORIGIN_ENABLED') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_ENABLED ('no')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_ENABLED' 'no'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_AUTH_TYPE') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_AUTH_TYPE ('token')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_AUTH_TYPE' 'token'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_REQUEST_TYPE') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_REQUEST_TYPE ('origin-rsa')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_REQUEST_TYPE' 'origin-rsa'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_RSA_BITS') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_RSA_BITS ('2048')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_RSA_BITS' '2048'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_ECC_CURVE') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_ECC_CURVE ('prime256v1')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_ECC_CURVE' 'prime256v1'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_VALIDITY') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_VALIDITY ('5475')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_VALIDITY' '5475'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_SSL_MODE') ]]; then
+                echo "[ ! ] Adding missing variable to hestia.conf: CF_ORIGIN_SSL_MODE ('off')"
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_SSL_MODE' 'off'
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_API_TOKEN') ]]; then
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_API_TOKEN' ''
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_SERVICE_KEY') ]]; then
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_SERVICE_KEY' ''
+        fi
+        if [[ -z $(check_key_exists 'CF_ORIGIN_AUTH_EMAIL') ]]; then
+                $BIN/v-change-sys-config-value 'CF_ORIGIN_AUTH_EMAIL' ''
+        fi
 
 	touch $HESTIA/conf/hestia.conf.new
 	while IFS='= ' read -r lhs rhs; do

--- a/web/js/src/editWebListeners.js
+++ b/web/js/src/editWebListeners.js
@@ -35,19 +35,37 @@ export default function handleEditWebListeners() {
 		});
 	});
 
-	// Listen to "Use Lets Encrypt to obtain SSL certificate" checkbox to
-	// hide/show SSL textareas
-	const toggleLetsEncryptCheckbox = document.querySelector('.js-toggle-lets-encrypt');
-	const sslDetails = document.querySelector('.js-ssl-details');
-	if (toggleLetsEncryptCheckbox && sslDetails) {
-		toggleLetsEncryptCheckbox.addEventListener('change', () => {
-			if (toggleLetsEncryptCheckbox.checked) {
-				sslDetails.style.display = 'none';
-			} else {
-				sslDetails.style.display = 'block';
-			}
-		});
-	}
+        // Listen to automatic certificate checkboxes to hide/show SSL textareas
+        const toggleLetsEncryptCheckbox = document.querySelector('.js-toggle-lets-encrypt');
+        const toggleCloudflareCheckbox = document.querySelector('.js-toggle-cloudflare-origin');
+        const sslDetails = document.querySelector('.js-ssl-details');
+        const updateSslDetailsVisibility = () => {
+                if (!sslDetails) {
+                        return;
+                }
+                const letsEncryptChecked = toggleLetsEncryptCheckbox && toggleLetsEncryptCheckbox.checked;
+                const cloudflareChecked = toggleCloudflareCheckbox && toggleCloudflareCheckbox.checked;
+                sslDetails.style.display = letsEncryptChecked || cloudflareChecked ? 'none' : 'block';
+        };
+        if (toggleLetsEncryptCheckbox) {
+                toggleLetsEncryptCheckbox.addEventListener('change', () => {
+                        if (toggleLetsEncryptCheckbox.checked && toggleCloudflareCheckbox && toggleCloudflareCheckbox.checked) {
+                                toggleCloudflareCheckbox.checked = false;
+                                toggleCloudflareCheckbox.dispatchEvent(new Event('change'));
+                        }
+                        updateSslDetailsVisibility();
+                });
+        }
+        if (toggleCloudflareCheckbox) {
+                toggleCloudflareCheckbox.addEventListener('change', () => {
+                        if (toggleCloudflareCheckbox.checked && toggleLetsEncryptCheckbox && toggleLetsEncryptCheckbox.checked) {
+                                toggleLetsEncryptCheckbox.checked = false;
+                                toggleLetsEncryptCheckbox.dispatchEvent(new Event('change'));
+                        }
+                        updateSslDetailsVisibility();
+                });
+        }
+        updateSslDetailsVisibility();
 
 	// Listen to "Advanced Options -> Proxy Template" select menu to
 	// show "Purge Nginx Cache" button if "caching" selected

--- a/web/locale/hestiacp.pot
+++ b/web/locale/hestiacp.pot
@@ -425,6 +425,35 @@ msgstr ""
 msgid "Package"
 msgstr ""
 
+#: ../../web/edit/server/index.php:703
+msgid "Invalid Cloudflare authentication method."
+msgstr ""
+
+#: ../../web/edit/server/index.php:766
+msgid "Invalid Cloudflare certificate type."
+msgstr ""
+
+#: ../../web/edit/server/index.php:803
+msgid "Cloudflare Origin certificate validity must be between 7 and 5475 days."
+msgstr ""
+
+#: ../../web/edit/server/index.php:835
+msgid "Cloudflare API token is required when token authentication is selected."
+msgstr ""
+
+#: ../../web/edit/server/index.php:842
+msgid "Cloudflare user service key is required when service-key authentication is selected."
+msgstr ""
+
+#: ../../web/edit/web/index.php:216
+#: ../../web/edit/web/index.php:1013
+msgid "Cloudflare Origin CA integration is not configured by the server administrator."
+msgstr ""
+
+#: ../../web/edit/web/index.php:219
+msgid "Please choose either Let's Encrypt or Cloudflare for automatic SSL certificates."
+msgstr ""
+
 #: ../../web/edit/package/index.php:146 ../../web/add/package/index.php:26
 #: ../../web/templates/pages/add_package.php:97
 #: ../../web/templates/pages/edit_web.php:265
@@ -2308,6 +2337,14 @@ msgstr ""
 msgid "Use Let's Encrypt to obtain SSL certificate"
 msgstr ""
 
+#: ../../web/templates/pages/edit_web.php:197
+msgid "Use Cloudflare to obtain SSL origin certificate"
+msgstr ""
+
+#: ../../web/templates/pages/edit_web.php:200
+msgid "Cloudflare credentials are required before requesting new certificates."
+msgstr ""
+
 #: ../../web/templates/pages/edit_web.php:180
 msgid "Enable automatic HTTPS redirection"
 msgstr ""
@@ -2321,6 +2358,90 @@ msgstr ""
 #: ../../web/templates/pages/edit_mail.php:119
 #: ../../web/templates/pages/list_ssl.php:19
 msgid "SSL Certificate"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1079
+msgid "Cloudflare Origin CA"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1092
+msgid "Enable Cloudflare Origin CA integration"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1102
+msgid "Authentication method"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1110
+msgid "API Token"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1111
+msgid "User Service Key"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1113
+msgid "Provide a token with Origin CA and (optional) Zone:Settings:Edit permissions."
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1117
+msgid "Cloudflare API token"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1127
+msgid "Leave blank to keep the currently stored token."
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1132
+msgid "Cloudflare User Service Key"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1142
+msgid "Leave blank to keep the currently stored service key."
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1147
+msgid "Account email (optional)"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1159
+msgid "Certificate key type"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1167
+msgid "RSA (origin-rsa)"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1168
+msgid "ECC (origin-ecc)"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1173
+msgid "RSA key size"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1183
+msgid "ECC curve"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1192
+msgid "Requested validity (days)"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1206
+msgid "Zone SSL mode after issuance"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1209
+msgid "Do not change"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1210
+msgid "Full (strict)"
+msgstr ""
+
+#: ../../web/templates/pages/edit_server.php:1212
+msgid "Requires API permissions that allow editing zone SSL settings."
 msgstr ""
 
 #: ../../web/templates/pages/edit_web.php:196

--- a/web/templates/pages/edit_server.php
+++ b/web/templates/pages/edit_server.php
@@ -27,11 +27,14 @@
 <!-- Begin form -->
 <div class="container">
 	<form
-		x-data="{
-			timezone: '<?= $v_timezone ?? "" ?>',
-			theme: '<?= $_SESSION["THEME"] ?>',
-			language: '<?= $_SESSION["LANGUAGE"] ?>',
-			hasSmtpRelay: <?= $v_smtp_relay == "true" ? "true" : "false" ?>,
+                x-data="{
+                        timezone: '<?= $v_timezone ?? "" ?>',
+                        theme: '<?= $_SESSION["THEME"] ?>',
+                        language: '<?= $_SESSION["LANGUAGE"] ?>',
+                        hasSmtpRelay: <?= $v_smtp_relay == "true" ? "true" : "false" ?>,
+                        cfOriginEnabled: <?= $v_cf_origin_enabled === "yes" ? "true" : "false" ?>,
+                        cfAuthType: '<?= $v_cf_origin_auth_type ?>',
+                        cfRequestType: '<?= $v_cf_origin_request_type ?>',
 			remoteBackupEnabled: <?= !empty($v_backup_remote_adv) ? "true" : "false" ?>,
 			incrementalBackups: '<?=$v_backup_incremental ?? '' ?>',
 			backupType: '<?= (!empty($v_backup_type)) ? trim($v_backup_type, "'") : "" ?>',
@@ -1038,11 +1041,11 @@
 							id="v_ssl_key"
 						><?= htmlentities(trim($v_ssl_key, "'")) ?></textarea>
 					</div>
-					<ul class="values-list">
-						<li class="values-list-item">
-							<span class="values-list-label"><?= _("Issued To") ?></span>
-							<span class="values-list-value"><?= htmlentities($v_ssl_subject) ?></span>
-						</li>
+                                        <ul class="values-list">
+                                                <li class="values-list-item">
+                                                        <span class="values-list-label"><?= _("Issued To") ?></span>
+                                                        <span class="values-list-value"><?= htmlentities($v_ssl_subject) ?></span>
+                                                </li>
 						<?php if ($v_ssl_aliases) { ?>
 							<li class="values-list-item">
 								<span class="values-list-label"><?= _("Alternate") ?></span>
@@ -1067,11 +1070,152 @@
 						</li>
 						<li class="values-list-item">
 							<span class="values-list-label"><?= _("Issued By") ?></span>
-							<span class="values-list-value"><?= htmlentities($v_ssl_issuer) ?></span>
-						</li>
-					</ul>
-				</div>
-			</details>
+                                                        <span class="values-list-value"><?= htmlentities($v_ssl_issuer) ?></span>
+                                                </li>
+                                        </ul>
+
+                                        <details class="collapse">
+                                                <summary class="collapse-header">
+                                                        <?= _("Cloudflare Origin CA") ?>
+                                                </summary>
+                                                <div class="collapse-content">
+                                                        <div class="form-check u-mb10">
+                                                                <input
+                                                                        x-model="cfOriginEnabled"
+                                                                        class="form-check-input"
+                                                                        type="checkbox"
+                                                                        name="v_cf_origin_enabled"
+                                                                        id="v_cf_origin_enabled"
+                                                                        <?= $v_cf_origin_enabled === "yes" ? "checked" : "" ?>
+                                                                >
+                                                                <label for="v_cf_origin_enabled">
+                                                                        <?= _("Enable Cloudflare Origin CA integration") ?>
+                                                                </label>
+                                                        </div>
+                                                        <div
+                                                                x-cloak
+                                                                x-show="cfOriginEnabled"
+                                                                class="u-pl30 u-mt15"
+                                                        >
+                                                                <div class="u-mb10">
+                                                                        <label for="v_cf_origin_auth_type" class="form-label">
+                                                                                <?= _("Authentication method") ?>
+                                                                        </label>
+                                                                        <select
+                                                                                x-model="cfAuthType"
+                                                                                class="form-select"
+                                                                                name="v_cf_origin_auth_type"
+                                                                                id="v_cf_origin_auth_type"
+                                                                        >
+                                                                                <option value="token"><?= _("API Token") ?></option>
+                                                                                <option value="service_key"><?= _("User Service Key") ?></option>
+                                                                        </select>
+                                                                        <p class="hint"><?= _("Provide a token with Origin CA and (optional) Zone:Settings:Edit permissions.") ?></p>
+                                                                </div>
+                                                                <div class="u-mb10" x-cloak x-show="cfAuthType === 'token'">
+                                                                        <label for="v_cf_origin_api_token" class="form-label">
+                                                                                <?= _("Cloudflare API token") ?>
+                                                                        </label>
+                                                                        <input
+                                                                                type="password"
+                                                                                class="form-control"
+                                                                                name="v_cf_origin_api_token"
+                                                                                id="v_cf_origin_api_token"
+                                                                                placeholder="••••••••"
+                                                                        >
+                                                                        <p class="hint">
+                                                                                <?= _("Leave blank to keep the currently stored token.") ?>
+                                                                        </p>
+                                                                </div>
+                                                                <div class="u-mb10" x-cloak x-show="cfAuthType === 'service_key'">
+                                                                        <label for="v_cf_origin_service_key" class="form-label">
+                                                                                <?= _("Cloudflare User Service Key") ?>
+                                                                        </label>
+                                                                        <input
+                                                                                type="password"
+                                                                                class="form-control"
+                                                                                name="v_cf_origin_service_key"
+                                                                                id="v_cf_origin_service_key"
+                                                                                placeholder="••••••••"
+                                                                        >
+                                                                        <p class="hint">
+                                                                                <?= _("Leave blank to keep the currently stored service key.") ?>
+                                                                        </p>
+                                                                </div>
+                                                                <div class="u-mb10" x-cloak x-show="cfAuthType === 'service_key'">
+                                                                        <label for="v_cf_origin_auth_email" class="form-label">
+                                                                                <?= _("Account email (optional)") ?>
+                                                                        </label>
+                                                                        <input
+                                                                                type="email"
+                                                                                class="form-control"
+                                                                                name="v_cf_origin_auth_email"
+                                                                                id="v_cf_origin_auth_email"
+                                                                                value="<?= htmlentities($_SESSION["CF_ORIGIN_AUTH_EMAIL"] ?? "") ?>"
+                                                                        >
+                                                                </div>
+                                                                <div class="u-mb10">
+                                                                        <label for="v_cf_origin_request_type" class="form-label">
+                                                                                <?= _("Certificate key type") ?>
+                                                                        </label>
+                                                                        <select
+                                                                                x-model="cfRequestType"
+                                                                                class="form-select"
+                                                                                name="v_cf_origin_request_type"
+                                                                                id="v_cf_origin_request_type"
+                                                                        >
+                                                                                <option value="origin-rsa"><?= _("RSA (origin-rsa)") ?></option>
+                                                                                <option value="origin-ecc"><?= _("ECC (origin-ecc)") ?></option>
+                                                                        </select>
+                                                                </div>
+                                                                <div class="u-mb10" x-cloak x-show="cfRequestType === 'origin-rsa'">
+                                                                        <label for="v_cf_origin_rsa_bits" class="form-label">
+                                                                                <?= _("RSA key size") ?>
+                                                                        </label>
+                                                                        <select class="form-select" name="v_cf_origin_rsa_bits" id="v_cf_origin_rsa_bits">
+                                                                                <option value="2048" <?= $v_cf_origin_rsa_bits === "2048" ? "selected" : "" ?>>2048</option>
+                                                                                <option value="3072" <?= $v_cf_origin_rsa_bits === "3072" ? "selected" : "" ?>>3072</option>
+                                                                                <option value="4096" <?= $v_cf_origin_rsa_bits === "4096" ? "selected" : "" ?>>4096</option>
+                                                                        </select>
+                                                                </div>
+                                                                <div class="u-mb10" x-cloak x-show="cfRequestType === 'origin-ecc'">
+                                                                        <label for="v_cf_origin_ecc_curve" class="form-label">
+                                                                                <?= _("ECC curve") ?>
+                                                                        </label>
+                                                                        <select class="form-select" name="v_cf_origin_ecc_curve" id="v_cf_origin_ecc_curve">
+                                                                                <option value="prime256v1" <?= $v_cf_origin_ecc_curve === "prime256v1" ? "selected" : "" ?>>prime256v1</option>
+                                                                                <option value="secp384r1" <?= $v_cf_origin_ecc_curve === "secp384r1" ? "selected" : "" ?>>secp384r1</option>
+                                                                        </select>
+                                                                </div>
+                                                                <div class="u-mb10">
+                                                                        <label for="v_cf_origin_validity" class="form-label">
+                                                                                <?= _("Requested validity (days)") ?>
+                                                                        </label>
+                                                                        <input
+                                                                                type="number"
+                                                                                class="form-control"
+                                                                                name="v_cf_origin_validity"
+                                                                                id="v_cf_origin_validity"
+                                                                                min="7"
+                                                                                max="5475"
+                                                                                value="<?= htmlentities($v_cf_origin_validity) ?>"
+                                                                        >
+                                                                </div>
+                                                                <div class="u-mb10">
+                                                                        <label for="v_cf_origin_ssl_mode" class="form-label">
+                                                                                <?= _("Zone SSL mode after issuance") ?>
+                                                                        </label>
+                                                                        <select class="form-select" name="v_cf_origin_ssl_mode" id="v_cf_origin_ssl_mode">
+                                                                                <option value="off" <?= $v_cf_origin_ssl_mode === "off" ? "selected" : "" ?>><?= _("Do not change") ?></option>
+                                                                                <option value="strict" <?= $v_cf_origin_ssl_mode === "strict" ? "selected" : "" ?>><?= _("Full (strict)") ?></option>
+                                                                        </select>
+                                                                        <p class="hint"><?= _("Requires API permissions that allow editing zone SSL settings.") ?></p>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </details>
+                                </div>
+                        </details>
 
 			<!-- Security section -->
 			<details class="box-collapse u-mb10">

--- a/web/templates/pages/edit_web.php
+++ b/web/templates/pages/edit_web.php
@@ -26,12 +26,13 @@
 <div class="container">
 
 	<form
-		x-data="{
-			statsAuthEnabled: <?= !empty($v_stats_user) ? "true" : "false" ?>,
-			redirectEnabled: <?= !empty($v_redirect) ? "true" : "false" ?>,
-			sslEnabled: <?= $v_ssl == "yes" ? "true" : "false" ?>,
-			letsEncryptEnabled: <?= $v_letsencrypt == "yes" || $v_letsencrypt == "on" ? "true" : "false" ?>,
-			showCertificates: <?= $v_letsencrypt == "yes" || $v_letsencrypt == "on" ? "false" : "true" ?>,
+                x-data="{
+                        statsAuthEnabled: <?= !empty($v_stats_user) ? "true" : "false" ?>,
+                        redirectEnabled: <?= !empty($v_redirect) ? "true" : "false" ?>,
+                        sslEnabled: <?= $v_ssl == "yes" ? "true" : "false" ?>,
+                        letsEncryptEnabled: <?= $v_letsencrypt == "yes" || $v_letsencrypt == "on" ? "true" : "false" ?>,
+                        cfOriginEnabled: <?= $v_cf_origin == "yes" ? "true" : "false" ?>,
+                        showCertificates: <?= ($v_letsencrypt == "yes" || $v_letsencrypt == "on" || $v_cf_origin == "yes") ? "false" : "true" ?>,
 			showAdvanced: false,
 			nginxCacheEnabled: <?= $v_nginx_cache == "yes" ? "true" : "false" ?>,
 			proxySupportEnabled: <?= !empty($v_proxy) ? "true" : "false" ?>,
@@ -168,17 +169,43 @@
 				</label>
 			</div>
 			<div x-cloak x-show="sslEnabled" class="u-pl30">
-				<div class="form-check u-mb10">
-					<input x-model="letsEncryptEnabled" class="form-check-input js-toggle-lets-encrypt" type="checkbox" name="v_letsencrypt" id="v_letsencrypt">
-					<label for="v_letsencrypt">
-						<?= _("Use Let's Encrypt to obtain SSL certificate") ?>
-					</label>
-				</div>
-				<div class="form-check u-mb10">
-					<input class="form-check-input" type="checkbox" name="v_ssl_forcessl" id="v_ssl_forcessl" <?php if ($v_ssl_forcessl == 'yes') echo 'checked' ?>>
-					<label for="v_ssl_forcessl">
-						<?= _("Enable automatic HTTPS redirection") ?>
-					</label>
+                                <div class="form-check u-mb10">
+                                        <input
+                                                x-model="letsEncryptEnabled"
+                                                class="form-check-input js-toggle-lets-encrypt"
+                                                type="checkbox"
+                                                name="v_letsencrypt"
+                                                id="v_letsencrypt"
+                                                x-on:change="if (letsEncryptEnabled) { cfOriginEnabled = false; showCertificates = false; } else if (!cfOriginEnabled) { showCertificates = true; }"
+                                        >
+                                        <label for="v_letsencrypt">
+                                                <?= _("Use Let's Encrypt to obtain SSL certificate") ?>
+                                        </label>
+                                </div>
+                                <?php if ($cf_origin_option_visible) { ?>
+                                <div class="form-check u-mb10">
+                                        <input
+                                                x-model="cfOriginEnabled"
+                                                class="form-check-input js-toggle-cloudflare-origin"
+                                                type="checkbox"
+                                                name="v_cf_origin"
+                                                id="v_cf_origin"
+                                                x-on:change="if (cfOriginEnabled) { letsEncryptEnabled = false; showCertificates = false; } else if (!letsEncryptEnabled) { showCertificates = true; }"
+                                                <?= $v_cf_origin == "yes" ? "checked" : "" ?>
+                                        >
+                                        <label for="v_cf_origin">
+                                                <?= _("Use Cloudflare to obtain SSL origin certificate") ?>
+                                        </label>
+                                        <?php if (!$cf_origin_issue_allowed) { ?>
+                                                <p class="hint"><?= _("Cloudflare credentials are required before requesting new certificates.") ?></p>
+                                        <?php } ?>
+                                </div>
+                                <?php } ?>
+                                <div class="form-check u-mb10">
+                                        <input class="form-check-input" type="checkbox" name="v_ssl_forcessl" id="v_ssl_forcessl" <?php if ($v_ssl_forcessl == 'yes') echo 'checked' ?>>
+                                        <label for="v_ssl_forcessl">
+                                                <?= _("Enable automatic HTTPS redirection") ?>
+                                        </label>
 				</div>
 				<div class="form-check u-mb20">
 					<input class="form-check-input" type="checkbox" name="v_ssl_hsts" id="ssl_hsts" <?php if ($v_ssl_hsts == 'yes') echo 'checked' ?>>
@@ -189,7 +216,7 @@
 						</a>
 					</label>
 				</div>
-				<div x-cloak x-show="showCertificates" class="js-ssl-details">
+                                <div x-cloak x-show="showCertificates" class="js-ssl-details">
 					<div class="u-mb10">
 						<label for="ssl_crt" class="form-label">
 							<?= _("SSL Certificate") ?>
@@ -241,12 +268,12 @@
 							<span class="values-list-label"><?= _("Issued By") ?></span>
 							<span class="values-list-value"><?= $v_ssl_issuer ?></span>
 						</li>
-						<p x-cloak x-show="letsEncryptEnabled" id="letsinfo">
-							<button
-								type="button"
-								class="form-link"
-								x-on:click="showCertificates = !showCertificates"
-								x-text="showCertificates ? '<?= _("Hide Certificate") ?>' : '<?= _("Show Certificate") ?>'">
+                                                <p x-cloak x-show="letsEncryptEnabled || cfOriginEnabled" id="letsinfo">
+                                                        <button
+                                                                type="button"
+                                                                class="form-link"
+                                                                x-on:click="showCertificates = !showCertificates"
+                                                                x-text="showCertificates ? '<?= _("Hide Certificate") ?>' : '<?= _("Show Certificate") ?>'">
 								<?= _("Show Certificate") ?>
 							</button>
 						</p>


### PR DESCRIPTION
add scripts and defaults for issuing and removing Cloudflare Origin CA certificates
expose Cloudflare integration controls in the server settings UI and web domain editor
update web domain handling, client logic, and translations to support Cloudflare certificates alongside Let's Encrypt