### PR TITLE
Add support to roundcube 1.7

### DIFF
--- a/bin/v-add-sys-roundcube
+++ b/bin/v-add-sys-roundcube
@@ -63,13 +63,23 @@ if [ -d "/usr/share/roundcube" ]; then
 fi
 
 # Get current version
-if [ -f "/var/lib/roundcube/index.php" ]; then
-	version=$(cat $RC_INSTALL_DIR/index.php | grep -o -E '[0-9].[0-9].[0-9]+' | head -1)
+if [ -f "$RC_INSTALL_DIR/program/include/iniset.php" ]; then
+	version="$(grep RCMAIL_VERSION "$RC_INSTALL_DIR/program/include/iniset.php" | cut -d "'" -f 4)"
 	if [ "$version" == "$rc_v" ]; then
 		echo "Error: Installed version ($version) is equal to the available version ($rc_v)"
 		exit 2
 	else
 		UPDATE="yes"
+	fi
+fi
+
+# Roundcube 1.7 requires PHP 8.1 or greater
+if grep -q '^1\.7' <<< "$rc_v" &> /dev/null; then
+	php_min="8.1"
+	php_ver="$("$HESTIA/bin/v-list-default-php" plain)"
+	if dpkg --compare-versions "$php_ver" "lt" "$php_min"; then
+		echo "Error: PHP $php_ver < $php_min (Roundcube $rc_v requires PHP >= $php_min)"
+		exit 2
 	fi
 fi
 

--- a/install/deb/templates/mail/apache2/default.stpl
+++ b/install/deb/templates/mail/apache2/default.stpl
@@ -1,7 +1,7 @@
 <VirtualHost %ip%:%web_ssl_port%>
     ServerName %domain_idn%
     ServerAlias %alias%
-    Alias / /var/lib/roundcube/
+    Alias / /var/lib/roundcube/public_html/
     Alias /error/ %home%/%user%/web/%root_domain%/document_errors/
     #SuexecUserGroup %user% %group%
 
@@ -11,13 +11,13 @@
     SSLCertificateKeyFile      %home%/%user%/conf/mail/%root_domain%/ssl/%root_domain%.key
 
     <Directory "/usr/share/tinymce/www/">
-      Options Indexes MultiViews FollowSymLinks
-      AllowOverride None
-      Order allow,deny
-      allow from all
+        Options Indexes MultiViews FollowSymLinks
+        AllowOverride None
+        Order allow,deny
+        allow from all
     </Directory>
 
-    <Directory /var/lib/roundcube/>
+    <Directory /var/lib/roundcube/public_html/>
         Options +FollowSymLinks
         # This is needed to parse /var/lib/roundcube/.htaccess. See its
         # content before setting AllowOverride to None.
@@ -27,21 +27,26 @@
     </Directory>
 
     # Protecting basic directories:
+    <Directory /var/lib/roundcube>
+        Options -FollowSymLinks
+        AllowOverride None
+    </Directory>
+
     <Directory /var/lib/roundcube/config>
-            Options -FollowSymLinks
-            AllowOverride None
+        Options -FollowSymLinks
+        AllowOverride None
     </Directory>
 
     <Directory /var/lib/roundcube/temp>
-            Options -FollowSymLinks
-            AllowOverride None
+        Options -FollowSymLinks
+        AllowOverride None
         Order allow,deny
         Deny from all
     </Directory>
 
     <Directory /var/lib/roundcube/logs>
-            Options -FollowSymLinks
-            AllowOverride None
+        Options -FollowSymLinks
+        AllowOverride None
         Order allow,deny
         Deny from all
     </Directory>

--- a/install/deb/templates/mail/apache2/default.tpl
+++ b/install/deb/templates/mail/apache2/default.tpl
@@ -1,22 +1,24 @@
 <VirtualHost %ip%:%web_port%>
     ServerName %domain_idn%
     ServerAlias %alias_idn%
-    Alias / /var/lib/roundcube/
+    Alias / /var/lib/roundcube/public_html/
     Alias /error/ %home%/%user%/web/%root_domain%/document_errors/
     #SuexecUserGroup %user% %group%
 
     IncludeOptional %home%/%user%/conf/mail/%root_domain%/apache2.forcessl.conf*
 
+    AcceptPathInfo On
+
     <Directory "/usr/share/tinymce/www/">
-      Options Indexes MultiViews FollowSymLinks
-      AllowOverride None
-      Order allow,deny
-      allow from all
+        Options Indexes MultiViews FollowSymLinks
+        AllowOverride None
+        Order allow,deny
+        allow from all
     </Directory>
 
-    <Directory /var/lib/roundcube/>
+    <Directory /var/lib/roundcube/public_html/>
         Options +FollowSymLinks
-        # This is needed to parse /var/lib/roundcube/.htaccess. See its
+        # This is needed to parse /var/lib/roundcube/public_html/.htaccess. See its
         # content before setting AllowOverride to None.
         AllowOverride All
         order allow,deny
@@ -24,21 +26,26 @@
     </Directory>
 
     # Protecting basic directories:
+    <Directory /var/lib/roundcube>
+        Options -FollowSymLinks
+        AllowOverride None
+    </Directory>
+
     <Directory /var/lib/roundcube/config>
-            Options -FollowSymLinks
-            AllowOverride None
+        Options -FollowSymLinks
+        AllowOverride None
     </Directory>
 
     <Directory /var/lib/roundcube/temp>
-            Options -FollowSymLinks
-            AllowOverride None
+        Options -FollowSymLinks
+        AllowOverride None
         Order allow,deny
         Deny from all
     </Directory>
 
     <Directory /var/lib/roundcube/logs>
-            Options -FollowSymLinks
-            AllowOverride None
+        Options -FollowSymLinks
+        AllowOverride None
         Order allow,deny
         Deny from all
     </Directory>

--- a/install/deb/templates/mail/nginx/default.stpl
+++ b/install/deb/templates/mail/nginx/default.stpl
@@ -1,16 +1,16 @@
 server {
 	listen      %ip%:%proxy_ssl_port% ssl;
 	server_name %domain_idn% %alias_idn%;
-	root        /var/lib/roundcube;
+	root        /var/lib/roundcube/public_html;
 	index       index.php index.html index.htm;
 	access_log  /var/log/nginx/domains/%domain%.log combined;
 	error_log   /var/log/nginx/domains/%domain%.error.log error;
 
 	ssl_certificate     %ssl_pem%;
 	ssl_certificate_key %ssl_key%;
-	#Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
-	#ssl_stapling        on;
-	#ssl_stapling_verify on;
+        #Commented out ssl_stapling directives due to Lets Encrypt ending OCSP support in 2025
+        #ssl_stapling        on;
+        #ssl_stapling_verify on;
 
 	# TLS 1.3 0-RTT anti-replay
 	if ($anti_replay = 307) { return 307 https://$host$request_uri; }
@@ -26,20 +26,17 @@ server {
 		return 404;
 	}
 
-	location / {
-		alias /var/lib/roundcube/;
-
-		try_files $uri $uri/ =404;
-
-		proxy_ssl_server_name on;
-		proxy_ssl_name $host;
-		proxy_pass https://%ip%:%web_ssl_port%;
-
-		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-			expires 7d;
-			fastcgi_hide_header "Set-Cookie";
-		}
-	}
+        location / {
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header SCRIPT_NAME "";
+                proxy_set_header PATH_INFO $request_uri;
+                proxy_ssl_server_name on;
+                proxy_ssl_name $host;
+                proxy_pass https://%ip%:%web_ssl_port%;
+        }
 
 	location @fallback {
 		proxy_ssl_server_name on;

--- a/install/deb/templates/mail/nginx/default.tpl
+++ b/install/deb/templates/mail/nginx/default.tpl
@@ -1,7 +1,7 @@
 server {
 	listen      %ip%:%proxy_port%;
 	server_name %domain_idn% %alias_idn%;
-	root        /var/lib/roundcube;
+	root        /var/lib/roundcube/public_html;
 	index       index.php index.html index.htm;
 	access_log  /var/log/nginx/domains/%domain%.log combined;
 	error_log   /var/log/nginx/domains/%domain%.error.log error;
@@ -19,16 +19,13 @@ server {
 	}
 
 	location / {
-		alias /var/lib/roundcube/;
-
-		try_files $uri $uri/ =404;
-
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header SCRIPT_NAME "";
+                proxy_set_header PATH_INFO $request_uri;
 		proxy_pass http://%ip%:%web_port%;
-
-		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-			expires 7d;
-			fastcgi_hide_header "Set-Cookie";
-		}
 	}
 
 	location @fallback {

--- a/install/deb/templates/mail/nginx/web_system.stpl
+++ b/install/deb/templates/mail/nginx/web_system.stpl
@@ -1,7 +1,7 @@
 server {
 	listen      %ip%:%web_ssl_port% ssl;
 	server_name %domain_idn% %alias_idn%;
-	root        /var/lib/roundcube;
+	root        /var/lib/roundcube/public_html;
 	index       index.php index.html index.htm;
 	access_log  /var/log/nginx/domains/%domain%.log combined;
 	error_log   /var/log/nginx/domains/%domain%.error.log error;
@@ -26,24 +26,18 @@ server {
 		return 404;
 	}
 
-	location / {
-		try_files $uri $uri/ =404;
+        location / {
+                try_files $uri $uri/ =404;
 
-		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-			expires 7d;
-			fastcgi_hide_header "Set-Cookie";
-		}
-
-		location ~ ^/(.*\.php)$ {
-			include /etc/nginx/fastcgi_params;
-
-			fastcgi_index index.php;
-			fastcgi_param HTTP_EARLY_DATA $rfc_early_data if_not_empty;
-			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-
-			fastcgi_pass unix:/run/php/www.sock;
-		}
-	}
+                location ~ ^(.+\.php)(.*)$ {
+                        include /etc/nginx/fastcgi_params;
+                        fastcgi_split_path_info       ^(.+\.php)(.*)$;
+                        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                        fastcgi_param PATH_INFO       $fastcgi_path_info;
+                        fastcgi_index index.php;
+                        fastcgi_pass unix:/run/php/www.sock;
+                }
+        }
 
 	location /error/ {
 		alias /var/www/document_errors/;

--- a/install/deb/templates/mail/nginx/web_system.tpl
+++ b/install/deb/templates/mail/nginx/web_system.tpl
@@ -1,7 +1,7 @@
 server {
 	listen      %ip%:%web_port%;
 	server_name %domain_idn% %alias_idn%;
-	root        /var/lib/roundcube;
+	root        /var/lib/roundcube/public_html;
 	index       index.php index.html index.htm;
 	access_log  /var/log/nginx/domains/%domain%.log combined;
 	error_log   /var/log/nginx/domains/%domain%.error.log error;
@@ -21,17 +21,12 @@ server {
 	location / {
 		try_files $uri $uri/ =404;
 
-		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
-			expires 7d;
-			fastcgi_hide_header "Set-Cookie";
-		}
-
-		location ~ ^/(.*\.php)$ {
+		location ~ ^(.+\.php)(.*)$ {
 			include /etc/nginx/fastcgi_params;
-
-			fastcgi_index index.php;
+			fastcgi_split_path_info       ^(.+\.php)(.*)$;
 			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-
+    			fastcgi_param PATH_INFO       $fastcgi_path_info;
+			fastcgi_index index.php;
 			fastcgi_pass unix:/run/php/www.sock;
 		}
 	}

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -19,9 +19,12 @@
 
 upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
-upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
-upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'no'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+# Set UPGRADE_UPDATE_MAIL_TEMPLATES and UPGRADE_REBUILD_USERS tp true to update mail
+# templates and rebuild mail domains to apply the new templates to add support to
+# Roundcube 1.7 (same templates work for Roundcube 1.6)
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'true'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'true'
 
 #Fix: avoid spamd execution in Exim when reject_spam is off for current installations
 if [ "$MAIL_SYSTEM" = "exim4" ]; then


### PR DESCRIPTION
This PR can be applied to next **HestiaCP** release `1.9.5` because all changes work fine also with current Roundcube version `1.6.11`.

**1.-** Add new **mail** templates (for Apache2 and Nginx) to support Roundcube `1.7`.  
The same mail templates work correctly with both Roundcube `1.6` and `1.7` versions.

**2.-** Modify `v-add-sys-roundcube`:  
Previously, the script checked the Roundcube version using the file `$RC_INSTALL_DIR/index.php`, but this file no longer contains the version in Roundcube `1.7`.  
Instead, the script now checks `$RC_INSTALL_DIR/program/include/iniset.php`, which works fine for Roundcube `1.6.x` and `1.7` versions.

It also checks that the default PHP version used when installing Roundcube `1.7.x` is equal to or greater than `8.1`, since Roundcube `1.7` introduces this new minimum requirement.

**3.-** Modify `1.9.5.sh` upgrade script to replace mail templates and rebuild users.
