### PR TITLE
Add ESMTP to SMTP banner in Exim configuration templates

### DIFF
--- a/install/deb/exim/exim4.conf.4.94.template
+++ b/install/deb/exim/exim4.conf.4.94.template
@@ -9,7 +9,7 @@
 #SPAM_REJECT_SCORE = 100
 #CLAMD = yes
 
-smtp_banner = $smtp_active_hostname
+smtp_banner = $smtp_active_hostname ESMTP
 smtp_active_hostname = ${lookup dnsdb{>: defer_never,ptr=$interface_address}{${listextract{1}{$value}}}{$primary_hostname}}
 add_environment = <; PATH=/bin:/usr/bin
 keep_environment =

--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -9,7 +9,7 @@
 #SPAM_REJECT_SCORE = 100
 #CLAMD = yes
 
-smtp_banner = $smtp_active_hostname
+smtp_banner = $smtp_active_hostname ESMTP
 smtp_active_hostname = ${lookup dnsdb{>: defer_never,ptr=$interface_address}{${listextract{1}{$value}}}{$primary_hostname}}
 add_environment = <; PATH=/bin:/usr/bin
 keep_environment =

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -9,7 +9,7 @@
 #SPAM_REJECT_SCORE = 100
 #CLAMD = yes
 
-smtp_banner = $smtp_active_hostname
+smtp_banner = $smtp_active_hostname ESMTP
 smtp_active_hostname = ${lookup dnsdb{>: defer_never,ptr=$interface_address}{${listextract{1}{$value}}}{$primary_hostname}}
 add_environment = <; PATH=/bin:/usr/bin
 keep_environment =

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -29,3 +29,10 @@ if [ "$MAIL_SYSTEM" = "exim4" ]; then
 	#shellcheck disable=SC2016
 	sed -i -E '/^\s*spam\s*=\s*debian-spamd:true$/{N;/\n\s*condition\s*=\s*\$\{if eq\{\$acl_m3\}\{yes\}\{yes\}\{no\}\}$/{s/(.*)\n(.*)/\2\n\1/}}' /etc/exim4/exim4.conf.template
 fi
+
+#Add ESMTP to smtp_banner directive in Exim
+if [ "$MAIL_SYSTEM" = "exim4" ]; then
+	echo "[ * ] Adding ESMTP to Exim smtp banner"
+	#shellcheck disable=SC2016
+	sed -i 's/^smtp_banner = $smtp_active_hostname.*/smtp_banner = $smtp_active_hostname ESMTP/' /etc/exim4/exim4.conf.template
+fi


### PR DESCRIPTION
Updated all Exim configuration templates (`exim4.conf.template`, `exim4.conf.4.94.template` and `exim4.conf.4.95.template`) to include "**ESMTP**" in the SMTP banner.

This change ensures that the server correctly identifies itself as supporting Extended SMTP, improving compatibility and compliance with modern mail clients and servers.