### PR TITLE
Fix: Preserve SSL and redirect on cert renewal failure

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -17,6 +17,10 @@ domain=$2
 aliases=$3
 mail=${4// /}
 
+# Define variables to preserve redirect/force-ssl if renewal fails
+deleted_redirect=0
+deleted_force_ssl=0
+
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf
@@ -67,6 +71,26 @@ query_le_v2() {
 	curl --location --user-agent "HestiaCP" --insecure --retry 5 --retry-connrefused --silent --dump-header /dev/stdout --data "$post_data" "$1" --header "$content" --output "$save_to_file"
 	debug_log "API call" "exit status: $?"
 }
+
+# Function to preserve redirect/force-ssl on cert renewal failure
+on_error_exit() {
+	local exit_code=$?
+	if [[ $exit_code -eq 0 ]]; then
+		exit "$exit_code"
+	fi
+
+	if [[ -z "$mail" ]]; then
+		if [[ "$domain_forcessl" == 'yes' && "${deleted_force_ssl:-0}" -eq 1 ]]; then
+			"$BIN/v-add-web-domain-ssl-force" "$user" "$domain"
+		fi
+		if [[ -n "$domain_redirect" && "${deleted_redirect:-0}" -eq 1 ]]; then
+			"$BIN/v-add-web-domain-redirect" "$user" "$domain" "$domain_redirect" "$domain_redirect_code"
+		fi
+	fi
+}
+
+# Trap exit code to keep redirect/force-ssl if cert renewal fails
+trap on_error_exit EXIT
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -134,11 +158,13 @@ else
 	if [[ -n "$domain_redirect" ]]; then
 		domain_redirect_code="$REDIRECT_CODE"
 		$BIN/v-delete-web-domain-redirect $user $domain
+		deleted_redirect=1
 	fi
 
 	domain_forcessl="$SSL_FORCE"
 	if [[ "$domain_forcessl" == 'yes' ]]; then
 		$BIN/v-delete-web-domain-ssl-force $user $domain
+		deleted_force_ssl=1
 	fi
 fi
 
@@ -602,9 +628,11 @@ if [ -z "$mail" ]; then
 
 	if [[ "$domain_forcessl" == 'yes' ]]; then
 		$BIN/v-add-web-domain-ssl-force $user $domain
+		deleted_force_ssl=0
 	fi
 	if [[ -n "$domain_redirect" ]]; then
 		$BIN/v-add-web-domain-redirect $user $domain $domain_redirect $domain_redirect_code
+		deleted_redirect=0
 	fi
 
 else


### PR DESCRIPTION
Preserve web domain redirect and force-SSL settings on Let's Encrypt certificate renewal failure

Fixes #4640