### PR TITLE
Ensure composer alias uses the user-defined PHP CLI

### DIFF
--- a/bin/v-add-user-composer
+++ b/bin/v-add-user-composer
@@ -67,7 +67,10 @@ mkdir -p "$COMPOSER_DIR"
 chown $user: "$COMPOSER_DIR"
 mkdir -p "$HOMEDIR/$user/.config"
 chown $user: "$HOMEDIR/$user/.config"
-echo "alias composer=/home/"$user"/.composer/composer" >> /home/$user/.bash_aliases
+if [[ -f "/home/$user/.bash_aliases" ]]; then
+	sed -i '/^alias composer=/d' "/home/$user/.bash_aliases"
+fi
+echo "alias composer='php /home/$user/.composer/composer'" >> "/home/$user/.bash_aliases"
 
 COMPOSER_SETUP_FILE=$(mktemp)
 check_result $? "Create temp file"


### PR DESCRIPTION
This change updates the creation of the composer alias so that it explicitly runs `composer` using the PHP CLI defined for the user rather than the system default. It also removes any previous composer alias to prevent conflicts and ensures consistent behavior with the user-specific PHP configuration.

Forum post: https://forum.hestiacp.com/t/composer-uses-wrong-php-version-but-php-v-shows-the-correct-one/20593