### PR TITLE
Fix netplan permissions.

### DIFF
--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -93,7 +93,15 @@ if [ -z "$sys_ip_check" ]; then
 	fi
 
 	if [ "$netplan" = "true" ]; then
-		if [ -f "/etc/netplan/60-hestia.yaml" ]; then
+		netplan_file="/etc/netplan/60-hestia.yaml"
+		if [ -f "$netplan_file" ]; then
+			netplan_file_exists="true"
+		else
+			netplan_file_exists="false"
+			install -m 600 /dev/null "$netplan_file"
+		fi
+
+		if [ "$netplan_file_exists" = "true" ]; then
 			sys_ip="        - $ip/$cidr"
 		else
 			sys_ip="# Added by Hestia, please do not edit the file manually!"
@@ -106,7 +114,7 @@ if [ -z "$sys_ip_check" ]; then
 			sys_ip="$sys_ip\n        - $ip/$cidr"
 		fi
 		IFS='%'
-		echo -e "$sys_ip" >> /etc/netplan/60-hestia.yaml
+		echo -e "$sys_ip" >> "$netplan_file"
 		unset IFS
 	else
 		sys_ip="\n# Added by Hestia Control Panel"

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -36,3 +36,10 @@ if [ "$MAIL_SYSTEM" = "exim4" ]; then
 	#shellcheck disable=SC2016
 	sed -i 's/^smtp_banner = $smtp_active_hostname.*/smtp_banner = $smtp_active_hostname ESMTP/' /etc/exim4/exim4.conf.template
 fi
+
+# Ensure netplan configs with hestia in the name have restrictive permissions
+for netplan_file in /etc/netplan/*hestia*; do
+	[ -e "$netplan_file" ] || break
+	echo "[ * ] Setting permissions on '$netplan_file' to 600"
+	chmod 600 "$netplan_file"
+done


### PR DESCRIPTION
IMO a mild-severity "information disclosure vulnerability", quote
```
root@host2:/# netplan generate

** (generate:1843186): WARNING **: 10:24:11.770: Permissions for /etc/netplan/60-hestia.yaml are too open. Netplan configuration should NOT be accessible by others.
root@host2:/# namei -l /etc/netplan/60-hestia.yaml 
f: /etc/netplan/60-hestia.yaml
drwxr-xr-x root root /
drwxr-xr-x root root etc
drwxr-xr-x root root netplan
-rw-r--r-- root root 60-hestia.yaml
```
- `/etc/netplan/60-hestia.yaml` was created world-readable.