### PR TITLE
Remove _domainkey entries from DKIM DNS script

### DIFF
--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -182,10 +182,6 @@ if [ -n "$DNS_SYSTEM" ] && [ "$dkim" = 'yes' ]; then
 	check_dns_domain=$(is_object_valid 'dns' 'DOMAIN' "$domain")
 	if [ "$?" -eq 0 ]; then
 		p=$(cat $USER_DATA/mail/$domain.pub | grep -v ' KEY---' | tr -d '\n')
-		record='_domainkey'
-		policy="\"t=y; o=~;\""
-		$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$policy" '' '' 'no' '' 'yes'
-
 		record='mail._domainkey'
 		selector="\"v=DKIM1\; k=rsa\; p=$p\""
 		$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$selector" '' '' 'yes' '' 'yes'

--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -74,10 +74,6 @@ fi
 # Adding dns records
 if [ -n "$DNS_SYSTEM" ] && [ -e "$USER_DATA/dns/$domain.conf" ]; then
 	p=$(cat $USER_DATA/mail/$domain.pub | grep -v ' KEY---' | tr -d '\n')
-	record="_domainkey"
-	policy="\"t=y\; o=~\;\""
-	$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$policy" '' '' 'no' '' 'yes'
-
 	record="mail._domainkey"
 	selector="\"v=DKIM1\; k=rsa\; p=$p\""
 	$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$selector" '' '' 'yes' '' 'yes'

--- a/bin/v-change-dns-domain-tpl
+++ b/bin/v-change-dns-domain-tpl
@@ -110,10 +110,6 @@ if [ "$template" = "default" ] || [ "$template" = "child-ns" ]; then
 		check_dns_domain=$(is_object_valid 'dns' 'DOMAIN' "$domain")
 		if [ "$?" -eq 0 ]; then
 			p=$(cat "$USER_DATA/mail/$domain.pub" | grep -v ' KEY---' | tr -d '\n')
-			record='_domainkey'
-			policy="\"t=y; o=~;\""
-			$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$policy" '' '' 'no'
-
 			record='mail._domainkey'
 			selector="\"v=DKIM1\; k=rsa\; p=$p\""
 			$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$selector"

--- a/bin/v-delete-mail-domain
+++ b/bin/v-delete-mail-domain
@@ -60,6 +60,7 @@ fi
 
 # Deleting dkim dns record
 if [ "$DKIM" = 'yes' ] && [ -e "$USER_DATA/dns/$domain.conf" ]; then
+	# Legacy _domainkey policy records are deprecated but still cleaned up; remove once obsolete.
 	dkim_records=$($BIN/v-list-dns-records "$user" "$domain" | grep -E "\s(mail\._domainkey|_domainkey)\s" | cut -f 1 -d ' ')
 	for id in $dkim_records; do
 		$BIN/v-delete-dns-record "$user" "$domain" "$id" '' 'yes'

--- a/bin/v-delete-mail-domain-dkim
+++ b/bin/v-delete-mail-domain-dkim
@@ -53,6 +53,7 @@ fi
 # Deleting dns record
 if [ -n "$DNS_SYSTEM" ] && [ -e "$USER_DATA/dns/$domain.conf" ]; then
 	records=$($BIN/v-list-dns-records "$user" "$domain")
+	# Keep removing deprecated _domainkey policy entries until they are fully retired.
 	dkim_records=$(echo "$records" | grep -E "\s(mail\._domainkey|_domainkey)\s" | cut -f 1 -d ' ')
 	for id in $dkim_records; do
 		$BIN/v-delete-dns-record "$user" "$domain" "$id" 'yes'

--- a/bin/v-list-mail-domain-dkim-dns
+++ b/bin/v-list-mail-domain-dkim-dns
@@ -26,10 +26,6 @@ source_conf "$HESTIA/conf/hestia.conf"
 # JSON list function
 json_list() {
 	echo '{'
-	echo -e "\t\"_domainkey\": {"
-	echo "            \"TTL\": \"3600\","
-	echo "            \"TXT\": \"'t=y; o=~;'\""
-	echo -e "\t},"
 	echo -e "\n\t\"mail._domainkey\": {"
 	echo "            \"TTL\": \"3600\","
 	echo "            \"TXT\": \"'v=DKIM1; k=rsa; p=$pub'\""
@@ -40,20 +36,17 @@ json_list() {
 shell_list() {
 	echo "RECORD            TTL         TYPE      VALUE"
 	echo "------            ---         ----      -----"
-	echo "_domainkey        3600   IN   TXT      \"t=y; o=~;\""
 	echo "mail._domainkey   3600   IN   TXT      \"v=DKIM1; k=rsa; p=$pub\""
 }
 
 # PLAIN list function
 plain_list() {
-	echo -e "_domainkey\t3600\tIN\tTXT\t\"t=y; o=~;\""
 	echo -e "mail._domainkey\t3600\tIN\tTXT\t\"v=DKIM1; k=rsa; p=$pub\""
 }
 
 # CSV list function
 csv_list() {
 	echo "RECORD,TTL,IN,TYPE,VALUE"
-	echo "_domainkey,3600,IN,TXT,\"\"t=y; o=~;\"\""
 	echo "mail._domainkey,3600,IN,TXT,\"\"v=DKIM1; k=rsa; p=$pub\"\""
 }
 

--- a/docs/docs/server-administration/email.md
+++ b/docs/docs/server-administration/email.md
@@ -121,7 +121,7 @@ No, Cloudflare’s Proxy does not work with email. If you use email hosted on yo
 - A record with name **webmail** pointing to your server IP.
 - MX record with name **@** with pointing to `mail.domain.tld`.
 - TXT record with name **@** containing `v=spf1 a mx ip4:your ip; \~all`
-- TXT record with name **mail.\_domainkey** containing `t=y; o=~DKIM key;`
+- TXT record with name **mail.\_domainkey** containing `v=DKIM1; k=rsa; p=<DKIM key>;`
 - TXT record with name **\_dmarc** containing `v=DMARC1; p=quarantine; sp=quarantine; adkim=s; aspf=s;`
 
 The DKIM key and SPF record can be found in the **Mail Domains** list ([documentation](../user-guide/mail-domains#get-dns-records)).

--- a/docs/docs/server-administration/email.md
+++ b/docs/docs/server-administration/email.md
@@ -121,7 +121,6 @@ No, Cloudflare’s Proxy does not work with email. If you use email hosted on yo
 - A record with name **webmail** pointing to your server IP.
 - MX record with name **@** with pointing to `mail.domain.tld`.
 - TXT record with name **@** containing `v=spf1 a mx ip4:your ip; \~all`
-- TXT record with name **\_domainkey** containing `t=y; o=~;`
 - TXT record with name **mail.\_domainkey** containing `t=y; o=~DKIM key;`
 - TXT record with name **\_dmarc** containing `v=DMARC1; p=quarantine; sp=quarantine; adkim=s; aspf=s;`
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -1728,10 +1728,6 @@ function check_ip_not_banned(){
     assert_success
     refute_output
 
-    run grep "RECORD='_domainkey'" "${HESTIA}/data/users/${user}/dns/${domain}.conf"
-    assert_failure
-    refute_output
-
     run grep "RECORD='mail._domainkey'" "${HESTIA}/data/users/${user}/dns/${domain}.conf"
     assert_failure
     refute_output

--- a/test/test.bats
+++ b/test/test.bats
@@ -1738,10 +1738,6 @@ function check_ip_not_banned(){
     assert_success
     refute_output
 
-    run grep "RECORD='_domainkey'" "${HESTIA}/data/users/${user}/dns/${domain}.conf"
-    assert_success
-    assert_output --partial "RECORD='_domainkey' TYPE='TXT'"
-
     run grep "RECORD='mail._domainkey'" "${HESTIA}/data/users/${user}/dns/${domain}.conf"
     assert_success
     assert_output  --partial "RECORD='mail._domainkey' TYPE='TXT'"


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc4870#section-3.7.6 has been superseded by DMARC

Furthermore t=y means testing mode.  

"This domain is testing DomainKeys, and unverified email MUST NOT be treated differently from verified email.  Recipient systems MAY wish to track testing mode results to assist the sender"