### PR TITLE
Fix SpamAssassin service name for Ubuntu 24.04

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1380,7 +1380,12 @@ if [ "$exim" = 'yes' ]; then
 		write_config_value "ANTIVIRUS_SYSTEM" "clamav-daemon"
 	fi
 	if [ "$spamd" = 'yes' ]; then
-		write_config_value "ANTISPAM_SYSTEM" "spamassassin"
+		release_short="$(cut -d '.' -f1 <<< "$release")"
+		if [[ -n "$release_short" ]] && [[ $release_short -lt 24 ]]; then
+			write_config_value "ANTISPAM_SYSTEM" "spamassassin"
+		else
+			write_config_value "ANTISPAM_SYSTEM" "spamd"
+		fi
 	fi
 	if [ "$dovecot" = 'yes' ]; then
 		write_config_value "IMAP_SYSTEM" "dovecot"

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -43,3 +43,11 @@ for netplan_file in /etc/netplan/*hestia*; do
 	echo "[ * ] Setting permissions on '$netplan_file' to 600"
 	chmod 600 "$netplan_file"
 done
+
+# Fix: Hestia can't restart SpamAssassin from the Web UI because it tries to restart
+# the 'spamassassin' service, but in Ubuntu 24.04 the service name is 'spamd'
+release="$(lsb_release -s -r)"
+distid="$(lsb_release -s -i)"
+if [[ "$release" = "24.04" ]] && [[ "$distid" = "Ubuntu" ]] && [[ -n "$ANTISPAM_SYSTEM" ]]; then
+	"$HESTIA"/bin/v-change-sys-config-value "ANTISPAM_SYSTEM" "spamd"
+fi

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -47,12 +47,10 @@ done
 # Fix: Hestia can't restart SpamAssassin from the Web UI because it tries to restart
 # the 'spamassassin' service, but in Ubuntu 24.04 the service name is 'spamd'
 if [[ -n "$ANTISPAM_SYSTEM" ]]; then
-	spam_service="$(systemctl list-unit-files --type=service | grep -E '(^spamd|^spamassassin)\.service')"
-	if grep -q '^spamd\.service' <<< "$spam_service"; then
-		antispam_detected="spamd"
-		"$HESTIA"/bin/v-change-sys-config-value ANTISPAM_SYSTEM "$antispam_detected"
-	elif grep -q '^spamassassin\.service' <<< "$spam_service"; then
-		antispam_detected="spamassassin"
-		"$HESTIA"/bin/v-change-sys-config-value ANTISPAM_SYSTEM "$antispam_detected"
+	installed_services="$(systemctl list-units --type=service 2>&1)"
+	if [[ $installed_services == *spamassassin.service* ]]; then
+		write_config_value "ANTISPAM_SYSTEM" "spamassassin"
+	elif [[ $installed_services == *spamd.service* ]]; then
+		write_config_value "ANTISPAM_SYSTEM" "spamd"
 	fi
 fi

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -46,8 +46,13 @@ done
 
 # Fix: Hestia can't restart SpamAssassin from the Web UI because it tries to restart
 # the 'spamassassin' service, but in Ubuntu 24.04 the service name is 'spamd'
-release="$(lsb_release -s -r)"
-distid="$(lsb_release -s -i)"
-if [[ "$release" = "24.04" ]] && [[ "$distid" = "Ubuntu" ]] && [[ -n "$ANTISPAM_SYSTEM" ]]; then
-	"$HESTIA"/bin/v-change-sys-config-value "ANTISPAM_SYSTEM" "spamd"
+if [[ -n "$ANTISPAM_SYSTEM" ]]; then
+	spam_service="$(systemctl list-unit-files --type=service | grep -E '(^spamd|^spamassassin)\.service')"
+	if grep -q '^spamd\.service' <<< "$spam_service"; then
+		antispam_detected="spamd"
+		"$HESTIA"/bin/v-change-sys-config-value ANTISPAM_SYSTEM "$antispam_detected"
+	elif grep -q '^spamassassin\.service' <<< "$spam_service"; then
+		antispam_detected="spamassassin"
+		"$HESTIA"/bin/v-change-sys-config-value ANTISPAM_SYSTEM "$antispam_detected"
+	fi
 fi


### PR DESCRIPTION
Ubuntu 24.04 renamed the SpamAssassin service from `spamassassin` to `spamd`, preventing Hestia from restarting it via the Web UI.

- Use `spamd` for Ubuntu 24.04+ in installer
- Add migration logic in upgrade script for existing installations
- Preserve `spamassassin` for older Ubuntu versions