### PR TITLE
Remove deprecated wp-password-bcrypt download

### DIFF
--- a/web/src/app/WebApp/Installers/WordPress/WordPressSetup.php
+++ b/web/src/app/WebApp/Installers/WordPress/WordPressSetup.php
@@ -8,8 +8,6 @@ use Hestia\System\Util;
 use Hestia\WebApp\BaseSetup;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 
-use function file_get_contents;
-
 class WordPressSetup extends BaseSetup
 {
     protected array $info = [
@@ -79,17 +77,6 @@ class WordPressSetup extends BaseSetup
             '--locale=' . $options['language'],
             '--path=' . $target->getDocRoot(),
         ]);
-
-        $wpPasswordBcryptContents = file_get_contents(
-            'https://raw.githubusercontent.com/roots/wp-password-bcrypt/master/wp-password-bcrypt.php',
-        );
-
-        $this->appcontext->addDirectory($target->getDocRoot('wp-content/mu-plugins/'));
-
-        $this->appcontext->createFile(
-            $target->getDocRoot('wp-content/mu-plugins/wp-password-bcrypt.php'),
-            $wpPasswordBcryptContents,
-        );
 
         // WordPress CLI seems to have a bug that when site name has a space it will be seen as an
         // extra argument. Even when properly escaped. For now just install with install.php


### PR DESCRIPTION
1: it was causing rate-limit errors from github,
this should resolve https://github.com/hestiacp/hestiacp/issues/5136

2: Since at least 17 February 2025, WP use password_hash internally: https://github.com/WordPress/wordpress-develop/commit/f444639e0852f7c0635a09d0dcee561af22a6515