### PR TITLE
Revert fix-hestia-logrotate

### DIFF
--- a/install/deb/logrotate/hestia
+++ b/install/deb/logrotate/hestia
@@ -6,6 +6,6 @@
     create 0600 root root
     sharedscripts
     postrotate
-        systemctl reload hestia.service >/dev/null 2>&1 || true
+        systemctl restart hestia.service >/dev/null 2>&1 || true
     endscript
 }


### PR DESCRIPTION
Revert last change in #5148

If we use `systemctl reload` it fails, so we must left `systemctl restart`:

```sh
❯ systemctl reload hestia.service
Failed to reload hestia.service: Job type reload is not applicable for unit hestia.service.
```