### PR TITLE
fix: resource limits and disk quota detection in v-add-user

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -75,8 +75,13 @@ pkg_data=$(cat $HESTIA/data/packages/$package.pkg | egrep -v "TIME|DATE")
 
 # Checking shell
 shell_conf=$(echo "$pkg_data" | grep -m1 'SHELL' | cut -f 2 -d \')
-resource_enaled=$(echo "$pkg_data" | grep -m1 'RESOURCES_LIMIT' | cut -f 2 -d \')
-disk_quota_enabled=$(echo "$pkg_data" | grep -m1 'DISK_QUOTA' | cut -f 2 -d \')
+resource_enabled=$(grep -m1 'RESOURCES_LIMIT' "$HESTIA"/conf/hestia.conf | cut -f 2 -d \')
+disk_quota_status=$(echo "$pkg_data" | grep -m1 'DISK_QUOTA' | cut -f 2 -d \')
+if [[ "$disk_quota_status" =~ ^[0-9]+$ ]]; then
+	disk_quota_enabled="yes"
+else
+	disk_quota_enabled="no"
+fi
 shell=$(grep -w "$shell_conf" /etc/shells | head -n1)
 
 # Adding user
@@ -271,7 +276,7 @@ if [ "$disk_quota_enabled" = 'yes' ]; then
 fi
 
 # Update resource limitation (cgroup)
-if [ "$resource_enaled" = 'yes' ]; then
+if [ "$resource_enabled" = 'yes' ]; then
 	$BIN/v-update-user-cgroup "$user"
 fi
 

--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -77,3 +77,14 @@ if [[ -n "$ANTISPAM_SYSTEM" ]]; then
 		write_config_value "ANTISPAM_SYSTEM" "spamd"
 	fi
 fi
+
+# Fix: update quotas and cgroup for existing users
+for user in $("$HESTIA"/bin/v-list-users list); do
+	if [[ "$RESOURCES_LIMIT" == "yes" ]]; then
+		"$HESTIA"/bin/v-update-user-cgroup "$user"
+	fi
+
+	if [[ "$DISK_QUOTA" == "yes" ]]; then
+		"$HESTIA"/bin/v-update-user-quota "$user"
+	fi
+done


### PR DESCRIPTION
While testing native ext4 quotas, I realized that quotas are not being applied to new users. A similar issue occurs when setting resource limits for users.

- Add numeric validation for DISK_QUOTA to properly set quota for user.
- Read `RESOURCES_LIMIT` from global `hestia.conf` instead of package (package does not have this variable set).
- Fix typo: `resource_enaled` -> `resource_enabled`