### PR TITLE
Fix panic log issue caused by default return_path on Ubuntu 22.04 with fresh HestiaCP installation

### DIFF
--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -420,7 +420,22 @@ remote_forwarded_smtp:
   interface = ${if exists{OUTGOING_IP}{${readfile{OUTGOING_IP}}}}
   # modify the envelope from, for mails that we forward
   max_rcpt = 1
-  return_path = ${srs_encode {SRS_SECRET} {$return_path} {$original_domain}}
+  return_path = ${srs_encode {SRS_SECRET} \
+	{${if and{ {def:return_path} {!eq{$return_path}{}} } \
+			{$return_path} \
+			{${if and{ {def:sender_address} {!eq{$sender_address}{}} } \
+				{$sender_address} \
+				{postmaster@$primary_hostname} \
+			}} \
+		}} \
+		{${if and{ {def:original_domain} {!eq{$original_domain}{}} } \
+			{$original_domain} \
+			{${if and{ {def:sender_address_domain} {!eq{$sender_address_domain}{}} } \
+				{$sender_address_domain} \
+				{$primary_hostname} \
+			}} \
+		}} \
+	}
 
 procmail:
   driver = pipe


### PR DESCRIPTION
The default return_path value on Ubuntu 22.04 with a fresh HestiaCP installation causes certain emails to be delivered with a panic log, as I also reported in the forum post below. My modification resolves this issue.

Post: https://forum.hestiacp.com/t/exim4-paniclog-ubuntu-22-04/20663