### PR TITLE
Use ROOT_USER variable instead of hard‑coded admin in restic restore scripts

### DIFF
--- a/bin/v-restore-cron-job-restic
+++ b/bin/v-restore-cron-job-restic
@@ -69,7 +69,7 @@ rm -fr "$tmpdir"
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-cron-job-restic '$user' '$snapshot'/d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-database-restic
+++ b/bin/v-restore-database-restic
@@ -119,7 +119,7 @@ rm -fr $tmpdir
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-database-restic '$user' '$snapshot' '$database' /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-dns-domain-restic
+++ b/bin/v-restore-dns-domain-restic
@@ -142,7 +142,7 @@ rm -fr $tmpdir
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-dns-domain-restic '$user' '$snapshot' '$dns' /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-file-restic
+++ b/bin/v-restore-file-restic
@@ -65,7 +65,7 @@ rm -fr $tmpdir
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-file-restic '$user' '$snapshot' '$file' /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-mail-domain-restic
+++ b/bin/v-restore-mail-domain-restic
@@ -216,7 +216,7 @@ rm -fr $tmpdir
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-mail-domain-restic '$user' '$snapshot' '$mail' /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-user-full-restic
+++ b/bin/v-restore-user-full-restic
@@ -118,7 +118,7 @@ rm -fr $tmpdir
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-user-full-restic '$user' /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-user-restic
+++ b/bin/v-restore-user-restic
@@ -98,7 +98,7 @@ rm -fr "$tmpdir"
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-user-restic '$user' '$snapshot' /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-web-domain-restic
+++ b/bin/v-restore-web-domain-restic
@@ -243,7 +243,7 @@ rm -fr $tmpdir
 
 # Update user counters
 $BIN/v-update-user-counters $user
-$BIN/v-update-user-counters admin
+$BIN/v-update-user-counters "$ROOT_USER"
 $BIN/v-update-sys-ip-counters
 
 sed -i "/v-restore-web-domain-restic '$user' '$snapshot' '$web' /d" $HESTIA/data/queue/backup.pipe


### PR DESCRIPTION
This change updates all `v-restore-*-restic` scripts to replace the hard‑coded `admin` user in `v-update-user-counters` calls with the `ROOT_USER` variable. This makes the restore process respect the configured administrator user.

Fixes #5193