### PR TITLE
v-update-user-qouta bug fix and actual soft-qouta implementation

### DIFF
--- a/bin/v-update-user-quota
+++ b/bin/v-update-user-quota
@@ -35,18 +35,19 @@ is_object_valid 'user' 'USER' "$user"
 
 # Update disk quota
 # Hard quota quals package value. Soft quota equals 90% of package value.
-quota=$(get_user_value '$DISK_QUOTA')
-soft=$(echo "$quota * 1024" | bc | cut -f 1 -d .)
-hard=$(echo "$quota * 1024" | bc | cut -f 1 -d .)
+quota=$(get_user_value 'DISK_QUOTA')
 
-# Searching home mount point
-mnt=$(df -P /home | awk '{print $6}' | tail -n1)
-
-# Checking unlimited quota
-if [ "$quota" = 'unlimited' ]; then
-	setquota $user 0 0 0 0 $mnt 2> /dev/null
+# Checking unlimited quota FIRST
+if [ "$quota" = "unlimited" ]; then
+    mnt=$(df -P /home | awk 'NR==2{print $6}')
+    setquota "$user" 0 0 0 0 "$mnt" 2>/dev/null
 else
-	setquota $user $soft $hard 0 0 $mnt 2> /dev/null
+		#Soft is 90% of the qouta
+    soft=$(( quota * 1024 * 90 / 100 ))
+    #Hard is 100% of the qouta
+    hard=$(( quota * 1024 ))
+    mnt=$(df -P /home | awk 'NR==2{print $6}')
+    setquota "$user" "$soft" "$hard" 0 0 "$mnt" 2>/dev/null
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-update-user-quota
+++ b/bin/v-update-user-quota
@@ -37,16 +37,16 @@ is_object_valid 'user' 'USER' "$user"
 # Hard quota quals package value. Soft quota equals 90% of package value.
 quota=$(get_user_value 'DISK_QUOTA')
 
+mnt=$(df -P /home | awk 'NR==2{print $6}')
+
 # Checking unlimited quota FIRST
 if [ "$quota" = "unlimited" ]; then
-    mnt=$(df -P /home | awk 'NR==2{print $6}')
     setquota "$user" 0 0 0 0 "$mnt" 2>/dev/null
 else
 		#Soft is 90% of the qouta
     soft=$(( quota * 1024 * 90 / 100 ))
     #Hard is 100% of the qouta
     hard=$(( quota * 1024 ))
-    mnt=$(df -P /home | awk 'NR==2{print $6}')
     setquota "$user" "$soft" "$hard" 0 0 "$mnt" 2>/dev/null
 fi
 


### PR DESCRIPTION
This PR addresses some technical debt in the v-update-user-quota script. The main goal was to move away from external binaries for basic math and to properly implement the "Soft Quota" logic which was previously just mirroring the hard limit.

### Changes:

- **Logic**: Implement 90% Soft Limit Previously, both soft and hard quotas were set to the same value.
- **Refactor**: Native Bash Arithmetic Replaced pipe-heavy calculations (echo | bc | cut) with native Bash arithmetic expansion `$((...))`. This reduces process forking and makes the script significantly cleaner.
- **Fix**: Correct get_user_value usage Fixed a bug where the variable key was being passed with a literal `$` (e.g., `'$DISK_QUOTA'`), which caused lookups to fail. It now correctly requests the `DISK_QUOTA` key.
- Improved df parsing Switched the mount point detection to use **NR==2 in awk**. This is a more standard way to grab the data row from `df -P` and avoids issues with empty trailing lines or specific environment aliases for df.


### Testing

- Tested with unlimited users (quota correctly set to 0).
- Tested with numeric limits (verified soft limit is 90% of hard limit).
