### PR TITLE
Update moodle templates

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/moodle.stpl
@@ -72,7 +72,7 @@ server {
 			fastcgi_index index.php;
 			fastcgi_intercept_errors on;
 			fastcgi_param HTTP_EARLY_DATA $rfc_early_data if_not_empty;
-			fastcgi_param PHP_VALUE open_basedir="/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/private/moodledata:/home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt";
+			fastcgi_param PHP_VALUE open_basedir="/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/private/moodledata:/home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt:/proc/loadavg";
 			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 			fastcgi_split_path_info ^(.+\.php)($|/.*);
 

--- a/install/deb/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/moodle.tpl
@@ -61,7 +61,7 @@ server {
 
 			fastcgi_index index.php;
 			fastcgi_intercept_errors on;
-			fastcgi_param PHP_VALUE open_basedir="/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/private/moodledata:/home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt";
+			fastcgi_param PHP_VALUE open_basedir="/home/%user%/web/%domain%/private:/home/%user%/web/%domain%/private/moodledata:/home/%user%/web/%domain%/public_html:/home/%user%/web/%domain%/public_shtml:/home/%user%/tmp:/var/www/html:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/phppgadmin:/etc/roundcube:/var/lib/roundcube:/tmp:/bin:/usr/bin:/usr/local/bin:/usr/share:/opt:/proc/loadavg";
 			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 			fastcgi_split_path_info ^(.+\.php)($|/.*);
 


### PR DESCRIPTION
This fixes a repeated console warning in the latest version of moodle

`PHP message: PHP Warning:  is_readable(): open_basedir restriction in effect. File(/proc/loadavg) is not within the allowed path(s)`