### PR TITLE
Fix php-fpm template to support dynamically generated JS files (e.g. Mautic mtc.js)

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/mautic.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/mautic.stpl
@@ -40,6 +40,14 @@ server {
 		# Uncomment to enable naxsi on this location
 		# include /etc/nginx/naxsi.rules
 
+		location = /mtc.js {
+			try_files $uri /index.php$is_args$args;
+		}
+
+		location = /mtracking.gif {
+			try_files $uri /index.php$is_args$args;
+		}
+
 		location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
 			expires max;
 			fastcgi_hide_header "Set-Cookie";


### PR DESCRIPTION
### Summary
This PR fixes an issue where dynamically generated JavaScript files (such as Mautic's `mtc.js`)
were returning 404 errors due to the Nginx static assets location block.

### Root cause
Some Nginx templates include a static-assets `location` (e.g. `~* \.js$`) that intercepts requests for `mtc.js`.
Since `mtc.js` is dynamically generated by Mautic (not a physical file), the request returns 404.

### Solution
Add exact-match locations for:
- `/mtc.js`
- `/mtracking.gif`

### Impact
- Fixes Mautic tracking (`/mtc.js`)
- Does not affect existing static assets

### Tested
- Nginx config validation
- Mautic tracking script loads successfully