### PR TITLE
Quotes variables for `is_common_format_valid`

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -75,10 +75,10 @@ fi
 args_usage='DOMAIN EMAIL COUNTRY STATE CITY ORG UNIT [ALIASES] [FORMAT]'
 check_args '7' "$#" "$args_usage"
 is_format_valid 'domain' 'aliases' 'format' 'email'
-is_common_format_valid $country "country"
-is_common_format_valid $state "state"
-is_common_format_valid $org "org"
-is_common_format_valid $unit "unit"
+is_common_format_valid "$country" "country"
+is_common_format_valid "$state" "state"
+is_common_format_valid "$org" "org"
+is_common_format_valid "$unit" "unit"
 
 release="$(lsb_release -s -r)"
 


### PR DESCRIPTION
Ensures that the variables passed to the
`is_common_format_valid` function are properly quoted.
This resolves potential issues arising from whitespace
or special characters within the variable values,
preventing unexpected behavior or errors during validation.
