### PR TITLE
fix: Avoid crash during Hestia install

### DIFF
--- a/bin/v-change-user-name
+++ b/bin/v-change-user-name
@@ -31,9 +31,9 @@ check_args '2' "$#" 'USER NAME [LAST_NAME]'
 is_format_valid 'user' 'name'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
-is_common_format_valid "$name" "name"
+is_common_format_spaces_valid "$name" "name"
 if [ -n "$lname" ]; then
-	is_common_format_valid "$lname" "last name"
+	is_common_format_spaces_valid "$lname" "last name"
 fi
 
 # Perform verification if read-only mode is enabled

--- a/bin/v-change-user-name
+++ b/bin/v-change-user-name
@@ -31,8 +31,9 @@ check_args '2' "$#" 'USER NAME [LAST_NAME]'
 is_format_valid 'user' 'name'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
+is_common_format_valid "$name" "name"
 if [ -n "$lname" ]; then
-	is_common_format_valid "$name $lname" "last name"
+	is_common_format_valid "$lname" "last name"
 fi
 
 # Perform verification if read-only mode is enabled

--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -76,6 +76,9 @@ args_usage='DOMAIN EMAIL COUNTRY STATE CITY ORG UNIT [ALIASES] [FORMAT]'
 check_args '7' "$#" "$args_usage"
 is_format_valid 'domain' 'aliases' 'format' 'email'
 is_common_format_valid "$country" "country"
+is_common_format_spaces_valid "$state" "state"
+is_common_format_spaces_valid "$org" "org"
+is_common_format_spaces_valid "$unit" "unit"
 
 release="$(lsb_release -s -r)"
 

--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -76,9 +76,6 @@ args_usage='DOMAIN EMAIL COUNTRY STATE CITY ORG UNIT [ALIASES] [FORMAT]'
 check_args '7' "$#" "$args_usage"
 is_format_valid 'domain' 'aliases' 'format' 'email'
 is_common_format_valid "$country" "country"
-is_common_format_valid "$state" "state"
-is_common_format_valid "$org" "org"
-is_common_format_valid "$unit" "unit"
 
 release="$(lsb_release -s -r)"
 

--- a/bin/v-list-backup-host
+++ b/bin/v-list-backup-host
@@ -113,7 +113,7 @@ is_type_format_valid() {
 #----------------------------------------------------------#
 
 check_args '1' "$#" 'TYPE [FORMAT]'
-is_common_format_valid $type "type"
+is_common_format_valid "$type" "type"
 
 #----------------------------------------------------------#
 #                       Action                             #

--- a/func/main.sh
+++ b/func/main.sh
@@ -911,6 +911,76 @@ is_common_format_valid() {
 	is_no_new_line_format "$1"
 }
 
+# Common format validator for fields that need spaces
+is_common_format_spaces_valid() {
+	# Block injection chars but allow spaces
+	exclude="[!|#|$|^|&|(|)|+|=|{|}|:|<|>|?|/|\|\"|'|;|%|\`]"
+
+	# Block tabs, newlines, carriage returns
+	if [[ "$1" == *$'\t'* || "$1" == *$'\n'* || "$1" == *$'\r'* || "$1" == *$'\v'* || "$1" == *$'\f'* ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No leading/trailing spaces
+	if [[ "$1" == " "* || "$1" == *" " ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No multiple consecutive spaces
+	if [[ "$1" =~ "  " ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# Check excluded chars
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# Max length
+	if [ 400 -le ${#1} ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No @ (except single char)
+	if [[ "$1" =~ @ ]] && [ ${#1} -gt 1 ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No wildcards
+	if [[ "$1" =~ \* ]]; then
+		if [[ "$(echo "$1" | grep -o '\*\.' | wc -l)" -eq 0 ]] && [[ "$1" != '*' ]]; then
+			check_result "$E_INVALID" "invalid $2 format :: $1"
+		fi
+	fi
+
+	# Must end with alphanumeric
+	if [[ $(echo -n "$1" | tail -c 1) =~ [^a-zA-Z0-9] ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No consecutive dots
+	if [[ $(echo -n "$1" | grep -c '\.\.') -gt 0 ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# Must start with alphanumeric
+	if [[ $(echo -n "$1" | head -c 1) =~ [^a-zA-Z0-9] ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No consecutive dashes
+	if [[ $(echo -n "$1" | grep -c '\-\-') -gt 0 ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	# No consecutive underscores
+	if [[ $(echo -n "$1" | grep -c '\_\_') -gt 0 ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+
+	is_no_new_line_format "$1"
+}
+
 is_no_new_line_format() {
 	test=$(echo "$1" | head -n1)
 	if [[ "$test" != "$1" ]]; then


### PR DESCRIPTION
Because of commit #5218, the Hestia installation fails as the self-signed certificate is not created.

```
[ * ] Adding SSL certificate to Hestia Control Panel...
sed: -e expression #1, char 3: unexpected `,'
sed: -e expression #1, char 1: unknown command: `,'
[ * ] Enabling SFTP jail...
[...]
[ * ] Configuring System IP...
Job for apache2.service failed because the control process exited with error code.
See "systemctl status apache2.service" and "journalctl -xeu apache2.service" for details.
Error: apache2 restart failed
Error: can't create test.example.net domain
```

This is because commit #5218 is quoting the variables in the following validations:

```
is_common_format_valid "$state" "state"
is_common_format_valid "$org" "org"
is_common_format_valid "$unit" "unit"
```
State, Organization, and Unit variables can contain (and in this case contain) spaces, so they fail validation and the certificate is not created, causing the crash.

- This PR removes those validations in script `v-generate-ssl-cert`
- Added missing quotes to variable expansion in v-list-backup-host to prevent word splitting.
- It also refined validation logic in `v-change-user-name` by checking first and last names independently.