### PR TITLE
Add CLI management for Exim blacklist

### DIFF
--- a/bin/v-add-exim-blacklist
+++ b/bin/v-add-exim-blacklist
@@ -1,0 +1,80 @@
+#!/bin/bash
+# info: add exim blacklist
+# options: none
+# example: v-add-exim-blacklist
+#
+# Creates /etc/exim4/blacklist if missing and inserts a custom deny rule
+# into /etc/exim4/exim4.conf.template under the `acl_check_rcpt:` section.
+set -euo pipefail
+
+# Ensure 'user' is defined to avoid "unbound variable" when main.sh checks it (set -u active)
+# Use ROOT_USER if set, otherwise default to 'root' to skip main.sh auto-loading behavior.
+user="${ROOT_USER:-root}"
+
+# Includes
+source $HESTIA/func/main.sh
+source_conf "$HESTIA/conf/hestia.conf"
+
+BLACKLIST_FILE="/etc/exim4/blacklist"
+TEMPLATE_FILE="/etc/exim4/exim4.conf.template"
+TMP_FILE="${TEMPLATE_FILE}.tmp"
+# Create blacklist file if it does not exist
+# Create blacklist file if it does not exist
+if [ ! -f "$BLACKLIST_FILE" ]; then
+    echo "# Hestia managed Exim blacklist (one entry per line)" > "$BLACKLIST_FILE"
+    chmod 640 "$BLACKLIST_FILE"
+    chown root:root "$BLACKLIST_FILE" 2>/dev/null || true
+    echo "Created $BLACKLIST_FILE"
+fi
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "Error: Exim template not found: $TEMPLATE_FILE"
+    exit 1
+fi
+
+# Detect if block already present (idempotent)
+if grep -q "deny[[:space:]]\+senders[[:space:]]\+=[[:space:]]*/etc/exim4/blacklist" "$TEMPLATE_FILE"; then
+    echo "Exim blacklist block already present in template; nothing to do."
+    exit 0
+fi
+
+# Insert the block after the `accept  hosts         = :` line inside acl_check_rcpt
+awk '
+    BEGIN { in_acl=0 }
+    /^acl_check_rcpt:/ { print; in_acl=1; next }
+    in_acl && $0 ~ /accept[[:space:]]+hosts[[:space:]]*=[[:space:]]*:/ {
+        print
+        print "  # CUSTOM BLACKLIST"
+        print "  deny    senders       = /etc/exim4/blacklist"
+        print "          message       = 550 Sender blocked by server policy"
+        print "  # END CUSTOM BLACKLIST"
+        in_acl=0
+        next
+    }
+    { print }
+' "$TEMPLATE_FILE" > "$TMP_FILE"
+
+mv -f "$TMP_FILE" "$TEMPLATE_FILE"
+chmod 640 "$TEMPLATE_FILE"
+chown root:root "$TEMPLATE_FILE" 2>/dev/null || true
+
+echo "Updated $TEMPLATE_FILE with custom blacklist block"
+
+# Restart Exim
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart exim4 || {
+        echo "Warning: failed to restart exim4, check logs"
+        exit 1
+    }
+else
+    echo "Warning: systemctl not available, please restart exim4 manually"
+fi
+
+# Log action
+if [ -x "$BIN/v-log-action" ]; then
+    $BIN/v-log-action "system" "Info" "Mail" "Added Exim blacklist and updated exim4.conf.template"
+fi
+
+echo "Done."
+
+exit 0

--- a/bin/v-add-exim-blacklist-entry
+++ b/bin/v-add-exim-blacklist-entry
@@ -1,0 +1,61 @@
+#!/bin/bash
+# info: add exim blacklist entry
+# options: SENDER
+# example: v-add-exim-blacklist-entry user@example.com
+
+set -euo pipefail
+
+# Ensure 'user' is defined to avoid "unbound variable" when main.sh checks it
+user="${ROOT_USER:-root}"
+
+# Default paths if not already set by hestia.conf
+BIN="${BIN:-/usr/local/hestia/bin}"
+HESTIA="${HESTIA:-/usr/local/hestia}"
+
+if [ -z "$1" ]; then
+    echo "Error: sender argument required"
+    exit 1
+fi
+
+SENDER_RAW="$1"
+
+# Minimal: do not source Hestia helper scripts to avoid unbound-variable
+# issues in environments where `main.sh` expects many exported vars.
+# We only need `BIN` above for `v-log-action` invocation.
+
+# Sanitize sender: allow email, domain, basic chars
+sender_sanitized=$(echo "$SENDER_RAW" | tr -d '\\r\\n' | sed -E 's/[^[:alnum:]@._%+-]//g' | cut -c1-256)
+
+BLACKLIST_FILE="/etc/exim4/blacklist"
+
+if [ -z "$sender_sanitized" ]; then
+    echo "Error: sanitized sender empty"
+    exit 1
+fi
+
+# Ensure blacklist file exists
+if [ ! -f "$BLACKLIST_FILE" ]; then
+    echo "# Hestia managed Exim blacklist" > "$BLACKLIST_FILE"
+fi
+
+# Avoid duplicates
+if grep -Fxq "$sender_sanitized" "$BLACKLIST_FILE"; then
+    echo "Entry already present: $sender_sanitized"
+    exit 0
+fi
+
+echo "$sender_sanitized" >> "$BLACKLIST_FILE"
+chmod 640 "$BLACKLIST_FILE"
+chown root:root "$BLACKLIST_FILE" || true
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart exim4 || echo "Warning: failed to restart exim4"
+fi
+
+if [ -x "$BIN/v-log-action" ]; then
+    $BIN/v-log-action "system" "Info" "Mail" "Added blacklist sender: $sender_sanitized"
+fi
+
+echo "Added: $sender_sanitized"
+
+exit 0

--- a/bin/v-delete-exim-blacklist
+++ b/bin/v-delete-exim-blacklist
@@ -1,0 +1,71 @@
+#!/bin/bash
+# info: delete exim blacklist
+# options: none
+# example: v-delete-exim-blacklist
+#
+# Removes /etc/exim4/blacklist if present and removes the custom blacklist block
+# from /etc/exim4/exim4.conf.template. Restarts exim4 and logs the action.
+
+set -euo pipefail
+
+# Ensure 'user' is defined to avoid "unbound variable" when main.sh checks it
+user="${ROOT_USER:-root}"
+
+# Includes
+source $HESTIA/func/main.sh
+source_conf "$HESTIA/conf/hestia.conf"
+
+BLACKLIST_FILE="/etc/exim4/blacklist"
+TEMPLATE_FILE="/etc/exim4/exim4.conf.template"
+TMP_FILE="${TEMPLATE_FILE}.tmp"
+
+# Remove blacklist file if exists (no backup to avoid residual files)
+if [ -f "$BLACKLIST_FILE" ]; then
+    rm -f "$BLACKLIST_FILE"
+    echo "Removed $BLACKLIST_FILE"
+else
+    echo "$BLACKLIST_FILE not present, skipping file removal"
+fi
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "Error: Exim template not found: $TEMPLATE_FILE"
+    exit 1
+fi
+
+# If the custom block is present, remove it (idempotent)
+if grep -q "# CUSTOM BLACKLIST" "$TEMPLATE_FILE"; then
+    # Find start and end line numbers of the block (first occurrence)
+    start_line=$(grep -n "# CUSTOM BLACKLIST" "$TEMPLATE_FILE" | head -n1 | cut -d: -f1) || start_line=""
+    end_line=$(grep -n "# END CUSTOM BLACKLIST" "$TEMPLATE_FILE" | head -n1 | cut -d: -f1) || end_line=""
+    if [ -n "$start_line" ] && [ -n "$end_line" ] && [ "$end_line" -ge "$start_line" ]; then
+        head -n $((start_line-1)) "$TEMPLATE_FILE" > "$TMP_FILE"
+        tail -n +$((end_line+1)) "$TEMPLATE_FILE" >> "$TMP_FILE"
+        mv -f "$TMP_FILE" "$TEMPLATE_FILE"
+        chmod 640 "$TEMPLATE_FILE"
+        chown root:root "$TEMPLATE_FILE" || true
+        echo "Removed custom blacklist block from $TEMPLATE_FILE"
+    else
+        echo "Failed to parse custom blacklist block boundaries; leaving template unchanged"
+    fi
+else
+    echo "No custom blacklist block found in $TEMPLATE_FILE; nothing to remove"
+fi
+
+# Restart Exim
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart exim4 || {
+        echo "Warning: failed to restart exim4, check logs"
+        exit 1
+    }
+else
+    echo "Warning: systemctl not available, please restart exim4 manually"
+fi
+
+# Log action
+if [ -x "$BIN/v-log-action" ]; then
+    $BIN/v-log-action "system" "Info" "Mail" "Removed Exim blacklist and cleaned exim4.conf.template"
+fi
+
+echo "Done."
+
+exit 0

--- a/bin/v-delete-exim-blacklist-entry
+++ b/bin/v-delete-exim-blacklist-entry
@@ -1,0 +1,54 @@
+#!/bin/bash
+# info: delete exim blacklist entry
+# options: SENDER
+# example: v-delete-exim-blacklist-entry user@example.com
+
+set -euo pipefail
+
+# Ensure 'user' is defined to avoid "unbound variable" when main.sh checks it
+user="${ROOT_USER:-root}"
+
+# Default paths if not already set
+BIN="${BIN:-/usr/local/hestia/bin}"
+HESTIA="${HESTIA:-/usr/local/hestia}"
+
+if [ -z "$1" ]; then
+    echo "Error: sender argument required"
+    exit 1
+fi
+
+SENDER_RAW="$1"
+
+# Minimal: avoid sourcing Hestia helpers that may reference unset vars
+# Sanitize sender
+sender_sanitized=$(echo "$SENDER_RAW" | tr -d '\\r\\n' | sed -E 's/[^[:alnum:]@._%+-]//g' | cut -c1-256)
+
+BLACKLIST_FILE="/etc/exim4/blacklist"
+
+if [ ! -f "$BLACKLIST_FILE" ]; then
+    echo "No blacklist file found"
+    exit 0
+fi
+
+if [ -z "$sender_sanitized" ]; then
+    echo "Error: sanitized sender empty"
+    exit 1
+fi
+
+# Remove lines exactly matching sender (no persistent backup left behind)
+grep -Fxv -- "$sender_sanitized" "$BLACKLIST_FILE" > "${BLACKLIST_FILE}.tmp" || true
+mv -f "${BLACKLIST_FILE}.tmp" "$BLACKLIST_FILE"
+chmod 640 "$BLACKLIST_FILE"
+chown root:root "$BLACKLIST_FILE" || true
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart exim4 || echo "Warning: failed to restart exim4"
+fi
+
+if [ -x "$BIN/v-log-action" ]; then
+    $BIN/v-log-action "system" "Info" "Mail" "Removed blacklist sender: $sender_sanitized"
+fi
+
+echo "Removed: $sender_sanitized"
+
+exit 0


### PR DESCRIPTION
Summary
Adds four CLI utilities to manage an Exim blacklist from the command line: create/delete the blacklist file and add/remove entries. This PR provides the CLI phase only (for testing); GUI integration will follow in a separate PR.

Included files

bin/v-add-exim-blacklist
bin/v-delete-exim-blacklist
bin/v-add-exim-blacklist-entry
bin/v-delete-exim-blacklist-entry

What it does

Creates /etc/exim4/blacklist (if missing) and inserts a deny block into /etc/exim4/exim4.conf.template.
Adds and removes single-line entries in /etc/exim4/blacklist.
Avoids leaving persistent backup files on the server and ensures root:root ownership.
Scripts are intentionally minimal and self-contained to avoid failures caused by sourcing Hestia helper scripts in test environments.
How to test (on a staging/test server)

# create blacklist + insert template block
v-add-exim-blacklist

# add entry
v-add-exim-blacklist-entry example@example.com

# verify content
cat /etc/exim4/blacklist

# remove entry
v-delete-exim-blacklist-entry example@example.com

# remove blacklist and remove template block
v-delete-exim-blacklist

Rollback
Running v-delete-exim-blacklist will remove /etc/exim4/blacklist and the injected block from the Exim template.

Impact / Compatibility
Changes only affect CLI utilities and Exim configuration template; no other components are modified. Test in staging before production.

Next steps (proposal)
After CLI validation, implement GUI integration: add pages, controllers, and web forms to manage entries from the Hestia panel in a follow-up PR.