### PR TITLE
Bump phpMyAdmin to version 5.2.3

### DIFF
--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -43,7 +43,7 @@ multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8
 
 # Check if update is required by matching versions if version != current version run update
 # Set version of phpMyAdmin to install during upgrade if not already installed
-pma_v='5.2.2'
+pma_v='5.2.3'
 
 # Set version of phppgadmin to install during upgrade if not already installed
 pga_v='7.14.6'


### PR DESCRIPTION
Some notable fixes in this release include:

- Fixed "Delete" button not asking for confirmation when deleting a row
- Remove the maxlength for routines name
- Fix error 500 when simulating a SET statement
- Fixed PHP 8.4 deprecations in thecodingmachine/safe
- Improved GIS visualization to work with huge tables
- Fix copy to clipboard
- Fixed some PHP 8.4 and PHP 8.5 deprecations
- Add support for "bacon-qr-code" v3, which relates to two-factor authentication
- Fixes for right-to-left languages

Full changelog: https://github.com/phpmyadmin/phpmyadmin/blob/RELEASE_5_2_3/ChangeLog