### PR TITLE
Count custom backend templates (e.g. *-PHP-x_y) in PHP version usage screen

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -575,6 +575,15 @@ function backendtpl_with_webdomains() {
 			if (!empty($domain_details["BACKEND"])) {
 				$backend = $domain_details["BACKEND"];
 				$backend_list[$backend][$user][] = $domain;
+
+				// Also count custom backend template names like YOURNAME-PHP-8_4 under PHP-8_4
+				if (preg_match('/(PHP-\d+_\d+)$/', $backend, $m)) {
+    				// Avoid duplicates when backend already is the base template
+    				if ($backend !== $m[1]) {
+        				$backend_list[$m[1]][$user][] = $domain;
+    				}
+				}
+				
 			}
 		}
 	}

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -578,12 +578,11 @@ function backendtpl_with_webdomains() {
 
 				// Also count custom backend template names like YOURNAME-PHP-8_4 under PHP-8_4
 				if (preg_match('/(PHP-\d+_\d+)$/', $backend, $m)) {
-    				// Avoid duplicates when backend already is the base template
-    				if ($backend !== $m[1]) {
-        				$backend_list[$m[1]][$user][] = $domain;
-    				}
+					// Avoid duplicates when backend already is the base template
+					if ($backend !== $m[1]) {
+						$backend_list[$m[1]][$user][] = $domain;
+					}
 				}
-				
 			}
 		}
 	}


### PR DESCRIPTION
While working with custom PHP-FPM backend templates, I noticed that HestiaCP does not correctly count domains using custom template names in **Configuration > Web server** under the PHP versions usage overview.

In my setup I use custom backend templates derived from the default ones, for example:

- `YOURNAME-PHP-8_4`
- `YOURNAME-PHP-8_3`

Functionally these templates work exactly as expected. However, the Hestia UI does not attribute domains using such templates to their respective PHP version. As a result, the PHP usage overview becomes inaccurate and may suggest that a PHP version is unused even though it is actively serving domains.

The current implementation only counts backend templates when the template name exactly matches the canonical template name such as `PHP-8_4`.

Custom templates that follow the documented naming scheme but contain a prefix are ignored by the PHP usage counter.
The official documentation explicitly allows custom naming using a prefix:

https://hestiacp.com/docs/server-administration/web-templates

> Due to the fact we use multi PHP we need to recognise the PHP version to be used. Therefore we use the following naming scheme: `YOURNAME-PHP-X_Y.tpl`, where X_Y is your PHP version. For example a PHP 8.1 template would be `YOURNAME-PHP-8_1.tpl`.

Therefore templates like `YOURNAME-PHP-8_4.tpl` are valid and expected to behave identically to `PHP-8_4.tpl`.

This PR improves backend template detection in `backendtpl_with_webdomains()` so that custom backend templates ending with `PHP-X_Y` are also counted under the corresponding PHP version. Duplicate counting is avoided when the backend name already equals the canonical template name.