### PR TITLE
Drop python-based yescrypt validation due to crypt removal in Python 3.13

### DIFF
--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -83,10 +83,18 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	if [ "$quota" = 'unlimited' ]; then
 		quota='0'
 	fi
-	str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
-	echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
-	userstr="$account:$account:$user:mail:$HOMEDIR/$user"
-	echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+		userstr="$account:$account:$user:mail:$HOMEDIR/$user/mail/$domain/$account"
+		echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
+	else
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+		userstr="$account:$account:$user:mail:$HOMEDIR/$user"
+		echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
+	fi
 fi
 
 # Create mail account folder (mailbox)

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -85,12 +85,12 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	fi
 	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
 	if [[ "$dovecot_version" = "2.4" ]]; then
-		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${quota}:userdb_quota_storage_size=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 		userstr="$account:$account:$user:mail:$HOMEDIR/$user/mail/$domain/$account"
 		echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
 	else
-		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 		userstr="$account:$account:$user:mail:$HOMEDIR/$user"
 		echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts

--- a/bin/v-change-domain-owner
+++ b/bin/v-change-domain-owner
@@ -231,11 +231,20 @@ if [ -n "$mail_data" ]; then
 			rm -f /etc/dovecot/conf.d/domains/$domain.conf
 		fi
 
-		echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
-		echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
-		echo "  ssl_cert = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
-		echo "  ssl_key = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
-		echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+		dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+		if [[ "$dovecot_version" = "2.4" ]]; then
+			echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "  sssl_server_cert_file = $HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "  ssl_server_key_file = $HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+		else
+			echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "  ssl_cert = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "  ssl_key = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
+			echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+		fi
 
 		# Add domain SSL configuration to exim4
 		# Cleanup symlinks

--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -76,8 +76,14 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 		quota=0
 	fi
 	sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
-	str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
-	echo "$str" >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	else
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	fi
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -78,10 +78,10 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
 	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
 	if [[ "$dovecot_version" = "2.4" ]]; then
-		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${quota}:userdb_quota_storage_size=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 	else
-		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 	fi
 fi

--- a/bin/v-change-mail-account-quota
+++ b/bin/v-change-mail-account-quota
@@ -64,10 +64,10 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	sed -i "/^$account:/d" "$HOMEDIR/$user/conf/mail/$domain/passwd"
 	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
 	if [[ "$dovecot_version" = "2.4" ]]; then
-		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${quota}:userdb_quota_storage_size=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 	else
-		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 	fi
 fi

--- a/bin/v-change-mail-account-quota
+++ b/bin/v-change-mail-account-quota
@@ -62,8 +62,14 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 		quota=0
 	fi
 	sed -i "/^$account:/d" "$HOMEDIR/$user/conf/mail/$domain/passwd"
-	str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
-	echo "$str" >> "$HOMEDIR/$user/conf/mail/$domain/passwd"
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	else
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	fi
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -85,14 +85,7 @@ if [ -z "$salt" ]; then
 fi
 
 if [ "$method" = "yescrypt" ]; then
-	if which python3 > /dev/null; then
-		export PASS="$password" SALT="$shadow"
-		hash=$(python3 -c 'import crypt, os; print(crypt.crypt(os.getenv("PASS"), os.getenv("SALT")))')
-	else
-		# Fall back to mkpasswd as fallback
-		hash=$(mkpasswd "$password" "$shadow")
-	fi
-
+	hash=$(mkpasswd "$password" "$shadow")
 	if [ $? -ne 0 ]; then
 		echo "Error: password missmatch"
 		if [ -z "$return_hash" ]; then

--- a/bin/v-restore-mail-domain-restic
+++ b/bin/v-restore-mail-domain-restic
@@ -154,11 +154,20 @@ for domain in $domains; do
 				rm -f /etc/dovecot/conf.d/domains/$domain.conf
 			fi
 
-			echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "  ssl_cert = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "  ssl_key = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+			dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+			if [[ "$dovecot_version" = "2.4" ]]; then
+				echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  sssl_server_cert_file = $HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  ssl_server_key_file = $HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+			else
+				echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  ssl_cert = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  ssl_key = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+			fi
 
 			if [ ! -d /usr/local/hestia/ssl/mail ]; then
 				mkdir /usr/local/hestia/ssl/mail

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -627,11 +627,20 @@ if [ "$mail" != 'no' ] && [ -n "$MAIL_SYSTEM" ]; then
 				rm -f /etc/dovecot/conf.d/domains/$domain.conf
 			fi
 
-			echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "  ssl_cert = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "  ssl_key = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
-			echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+			dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+			if [[ "$dovecot_version" = "2.4" ]]; then
+				echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  sssl_server_cert_file = $HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  ssl_server_key_file = $HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+			else
+				echo "" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "local_name mail.$domain {" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  ssl_cert = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.pem" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "  ssl_key = <$HOMEDIR/$user/conf/mail/$domain/ssl/$domain.key" >> /etc/dovecot/conf.d/domains/$domain.conf
+				echo "}" >> /etc/dovecot/conf.d/domains/$domain.conf
+			fi
 
 			if [ ! -d /usr/local/hestia/ssl/mail ]; then
 				mkdir /usr/local/hestia/ssl/mail

--- a/bin/v-unsuspend-mail-account
+++ b/bin/v-unsuspend-mail-account
@@ -61,10 +61,10 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
 	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
 	if [[ "$dovecot_version" = "2.4" ]]; then
-		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${quota}:userdb_quota_storage_size=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 	else
-		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}:userdb_quota_rule=*:storage=${quota}M"
 		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 	fi
 fi

--- a/bin/v-unsuspend-mail-account
+++ b/bin/v-unsuspend-mail-account
@@ -59,8 +59,14 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 		quota=0
 	fi
 	sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
-	str="$account:$md5:$user:mail::$HOMEDIR/$user::userdb_quota_rule=*:storage=${quota}M"
-	echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		str="$account:$md5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	else
+		str="$account:$md5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+		echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+	fi
 fi
 
 #----------------------------------------------------------#

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -704,10 +704,18 @@ rebuild_mail_domain_conf() {
 			if [ "$QUOTA" = 'unlimited' ]; then
 				QUOTA=0
 			fi
-			str="$account:$MD5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
-			echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
-			userstr="$account:$account:$user:mail:$HOMEDIR/$user"
-			echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
+			dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+			if [[ "$dovecot_version" = "2.4" ]]; then
+				str="$account:$MD5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
+				echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+				userstr="$account:$account:$user:mail:$HOMEDIR/$user/mail/$domain/$account"
+				echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
+			else
+				str="$account:$MD5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+				echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+				userstr="$account:$account:$user:mail:$HOMEDIR/$user"
+				echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
+			fi
 			for malias in ${ALIAS//,/ }; do
 				echo "$malias@$domain_idn:$account@$domain_idn" >> $dom_aliases
 			done

--- a/install/common/dovecot-24/conf.d/10-auth.conf
+++ b/install/common/dovecot-24/conf.d/10-auth.conf
@@ -1,0 +1,141 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+auth_allow_cleartext = no
+auth_username_format = %{user | lower}
+auth_verbose = yes
+auth_mechanisms = plain login
+!include auth-passwdfile.conf.ext
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+#log_debug=category=auth
+#auth_debug_passwords = yes
+##
+## Authentication processes
+##
+
+# Enable LOGIN command and all other plaintext authentications even if
+# SSL/TLS is not used (LOGINDISABLED capability). Note that if the remote IP
+# matches the local IP (ie. you're connecting from the same computer), the
+# connection is considered secure and plaintext authentication is allowed,
+# unless ssl = required.
+#auth_allow_cleartext = yes
+
+# Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
+# bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.
+#auth_cache_size = 0
+# Time to live for cached data. After TTL expires the cached record is no
+# longer used, *except* if the main database lookup returns internal failure.
+# We also try to handle password changes automatically: If user's previous
+# authentication was successful, but this one wasn't, the cache isn't used.
+# For now this works only with plaintext authentication.
+#auth_cache_ttl = 1 hour
+# TTL for negative hits (user not found, password mismatch).
+# 0 disables caching them completely.
+#auth_cache_negative_ttl = 1 hour
+
+# Space separated list of realms for SASL authentication mechanisms that need
+# them. You can leave it empty if you don't want to support multiple realms.
+# Many clients simply use the first one listed here, so keep the default realm
+# first.
+#auth_realms =
+#
+# Default realm/domain to use if none was specified. This is used for both
+# SASL realms and appending @domain to username in plaintext logins.
+#auth_default_domain =
+
+# List of allowed characters in username. If the user-given username contains
+# a character not listed in here, the login automatically fails. This is just
+# an extra check to make sure user can't exploit any potential quote escaping
+# vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
+# set this value to empty.
+#auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
+
+# Username character translations before it's looked up from databases. The
+# value contains series of from -> to characters. For example "#@/@" means
+# that '#' and '/' characters are translated to '@'.
+#auth_username_translation =
+
+# Username formatting before it's looked up from databases.
+#auth_username_format = %{user|lower}
+#auth_username_format = %{user|username|lower}
+
+# If you want to allow master users to log in by specifying the master
+# username within the normal username string (ie. not using SASL mechanism's
+# support for it), you can specify the separator character here. The format
+# is then <username><separator><master username>. UW-IMAP uses "*" as the
+# separator, so that could be a good choice.
+#auth_master_user_separator =
+
+# Username to use for users logging in with ANONYMOUS SASL mechanism
+#auth_anonymous_username = anonymous
+
+# Host name to use in GSSAPI principal names. The default is to use the
+# name returned by gethostname(). Use "$ALL" (with quotes) to allow all keytab
+# entries.
+#auth_gssapi_hostname =
+
+# Kerberos keytab to use for the GSSAPI mechanism. Will use the system
+# default (usually /etc/krb5.keytab) if not specified. You may need to change
+# the auth service to run as root to be able to read this file.
+#auth_krb5_keytab = 
+
+# Do NTLM and GSS-SPNEGO authentication using Samba's winbind daemon and
+# ntlm_auth helper. <https://doc.dovecot.org/latest/core/config/auth/mechanisms/winbind.html>
+#auth_use_winbind = no
+
+# Path for Samba's ntlm_auth helper binary.
+#auth_winbind_helper_path = /usr/bin/ntlm_auth
+
+# Time to delay before replying to failed authentications.
+#auth_failure_delay = 2 secs
+
+# Require a valid SSL client certificate or the authentication fails.
+#auth_ssl_require_client_cert = no
+
+# Take the username from client's SSL certificate, using 
+# X509_NAME_get_text_by_NID() which returns the subject's DN's
+# CommonName. 
+#auth_ssl_username_from_cert = no
+
+# Space separated list of wanted authentication mechanisms:
+#   plain login digest-md5 cram-md5 ntlm anonymous gssapi
+#   gss-spnego xoauth2 oauthbearer
+# NOTE: See also auth_allow_cleartext setting.
+#auth_mechanisms = plain login 
+
+##
+## Password and user databases
+##
+
+#
+# Password database is used to verify user's password (and nothing more).
+# You can have multiple passdbs and userdbs. This is useful if you want to
+# allow both system users (/etc/passwd) and virtual users to login without
+# duplicating the system users into virtual database.
+#
+# <https://doc.dovecot.org/latest/core/config/auth/passdb.html>
+#
+# User database specifies where mails are located and what user/group IDs
+# own them. For single-UID configuration use "static" userdb.
+#
+# <https://doc.dovecot.org/latest/core/config/auth/userdb.html>
+
+#!include auth-deny.conf.ext
+#!include auth-master.conf.ext
+#!include auth-oauth2.conf.ext
+
+#-#!include auth-system.conf.ext
+#!include auth-sql.conf.ext
+#!include auth-ldap.conf.ext
+#!include auth-passwdfile.conf.ext
+#!include auth-static.conf.ext

--- a/install/common/dovecot-24/conf.d/10-logging.conf
+++ b/install/common/dovecot-24/conf.d/10-logging.conf
@@ -1,0 +1,101 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+log_path = /var/log/dovecot.log
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## Log destination.
+##
+
+# Log file to use for error messages. "syslog" logs to syslog,
+# /dev/stderr logs to stderr.
+#log_path = syslog
+
+# Log file to use for informational messages. Defaults to log_path.
+#info_log_path = 
+# Log file to use for debug messages. Defaults to info_log_path.
+#debug_log_path = 
+
+# Syslog facility to use if you're logging to syslog. Usually if you don't
+# want to use "mail", you'll use local0..local7. Also other standard
+# facilities are supported.
+#syslog_facility = mail
+
+##
+## Logging verbosity and debugging.
+##
+
+# Log unsuccessful authentication attempts and the reasons why they failed.
+#auth_verbose = yes
+
+# In case of password mismatches, log the attempted password. Valid values are
+# no, plain and sha1. sha1 can be useful for detecting brute force password
+# attempts vs. user simply trying the same password over and over again.
+#auth_verbose_passwords = no
+
+# To chain multiple logging conditions you can use,
+# log_debug=$SET:log_debug or category=xxx
+
+# Even more verbose logging for debugging purposes. Shows for example SQL
+# queries.
+#log_debug=category=auth
+#
+# In case of password mismatches, log the passwords and used scheme so the
+# problem can be debugged. Enabling this also enables auth_debug.
+#auth_debug_passwords = yes
+
+# Enable mail process debugging. This can help you figure out why Dovecot
+# isn't finding your mails.
+#log_debug=category=mail
+
+# Show protocol level SSL errors.
+#log_debug=category=ssl
+
+# mail_log plugin provides more event logging for mail processes.
+#mail_plugins {
+#   notify = yes
+#   mail_log = yes
+#}
+# Events to log. Also available: flag_change append
+#mail_log_events = delete undelete expunge copy mailbox_delete mailbox_rename flag_change append
+# Available fields: uid, box, msgid, from, subject, size, vsize, flags
+# size and vsize are available only for expunge and copy events.
+#mail_log_fields = uid box msgid size from subject vsize flags
+# only log cached fields
+#mail_log_cached_only = yes
+
+##
+## Log formatting.
+##
+
+# Prefix for each line written to log file. % codes are in strftime(3)
+# format.
+#log_timestamp = "%b %d %H:%M:%S "
+
+# Space-separated list of elements we want to log. The elements which have
+# a non-empty variable value are joined together to form a comma-separated
+# string.
+#login_log_format_elements = user=<%{user}> method=%{mechanism} rip=%{remote_ip} lip=%{local_ip} mpid=%{mail_pid} %{secured} session=<%{session}>
+
+# Login log format. %{elements} contains login_log_format_elements string, %{message} contains
+# the data we want to log.
+#login_log_format = %{message}: %{elements}
+ 
+# Log prefix for mail processes. See
+# https://doc.dovecot.org/latest/core/settings/variables.html#mail-service-user-variables
+# for list of possible variables.
+#mail_log_prefix = "%{service}(%{user})<%{process:pid}><%{session}>: "
+
+# Format to use for logging mail deliveries. See https://doc.dovecot.org/latest/core/summaries/settings.html#deliver_log_format
+# for list of possible variables.
+#deliver_log_format = msgid=%{msgid}: %{message} (subject=%{subject} from=%{from} size=%{size})

--- a/install/common/dovecot-24/conf.d/10-mail.conf
+++ b/install/common/dovecot-24/conf.d/10-mail.conf
@@ -1,0 +1,439 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+mail_privileged_group = mail
+mail_access_groups = mail
+
+mail_driver = maildir
+mail_home = ~
+mail_path = ~
+
+pop3_uidl_format = %{uid | hex(8)}%{uidvalidity | hex(8)}
+
+mailbox_list_index = yes
+mailbox_idle_check_interval = 30 secs
+
+maildir_copy_with_hardlinks = yes
+
+mail_plugins = quota
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## Mailbox locations and namespaces
+##
+
+# Location for users' mailboxes. The default is empty, which means that Dovecot
+# tries to find the mailboxes automatically. This won't work if the user
+# doesn't yet have any mail, so you should explicitly tell Dovecot the full
+# location.
+#
+# If you're using mbox, giving a path to the INBOX file (eg. /var/mail/%u)
+# isn't enough. You'll also need to tell Dovecot where the other mailboxes are
+# kept. This is called the "root mail directory", and it must be the first
+# path given in the mail_location setting.
+#
+# There are a few special variables you can use, eg.:
+#
+#   %{user} - username
+#   %{user|username} - user part in user@domain, same as %u if there's no domain
+#   %{user|domain} - domain part in user@domain, empty if there's no domain
+#   %{home} - home directory
+#
+# See https://doc.dovecot.org/latest/core/settings/variables.html for full list
+# of variables.
+#
+# Example:
+#  mail_driver = maildir
+#  mail_path = ~/Maildir
+#  mail_inbox_path = ~/Maildir/.INBOX
+#
+
+# Debian defaults
+# Note that upstream considers mbox deprecated and strongly recommends
+# against its use in production environments. See further information
+# at
+# https://doc.dovecot.org/2.4.0/core/config/mailbox/formats/mbox.html
+#-#mail_driver = mbox
+#-#mail_home = /home/%{user|username}
+#-#mail_path = %{home}/mail
+#-#mail_inbox_path = /var/mail/%{user}
+
+# If you need to set multiple mailbox locations or want to change default
+# namespace settings, you can do it by defining namespace sections.
+#
+# You can have private, shared and public namespaces. Private namespaces
+# are for user's personal mails. Shared namespaces are for accessing other
+# users' mailboxes that have been shared. Public namespaces are for shared
+# mailboxes that are managed by sysadmin. If you create any shared or public
+# namespaces you'll typically want to enable ACL plugin also, otherwise all
+# users can access all the shared mailboxes, assuming they have permissions
+# on filesystem level to do so.
+#-#namespace inbox {
+  # Namespace type: private, shared or public
+  #type = private
+
+  # Hierarchy separator to use. You should use the same separator for all
+  # namespaces or some clients get confused. '/' is usually a good one.
+  # The default however depends on the underlying mail storage format.
+  #separator = 
+
+  # Prefix required to access this namespace. This needs to be different for
+  # all namespaces. For example "Public/".
+  #prefix = 
+
+  # Physical location of the mailbox. This is in same format as
+  # mail location, which is also the default for it.
+  # mail_driver = 
+  # mail_path = 
+  #
+  # There can be only one INBOX, and this setting defines which namespace
+  # has it.
+  #-#inbox = yes
+
+  # If namespace is hidden, it's not advertised to clients via NAMESPACE
+  # extension. You'll most likely also want to set list=no. This is mostly
+  # useful when converting from another server with different namespaces which
+  # you want to deprecate but still keep working. For example you can create
+  # hidden namespaces with prefixes "~/mail/", "~%u/mail/" and "mail/".
+  #hidden = no
+
+  # Show the mailboxes under this namespace with LIST command. This makes the
+  # namespace visible for clients that don't support NAMESPACE extension.
+  # "children" value lists child mailboxes, but hides the namespace prefix.
+  #list = yes
+
+  # Namespace handles its own subscriptions. If set to "no", the parent
+  # namespace handles them (empty prefix should always have this as "yes")
+  #subscriptions = yes
+
+  # See 15-mailboxes.conf for definitions of special mailboxes.
+#-#}
+
+# Example shared namespace configuration
+#namespace shared {
+  #type = shared
+  #separator = /
+
+  # Mailboxes are visible under "shared/user@domain/"
+  # $user, $domain and $username are expanded to the destination user.
+  #prefix = shared/$user/
+
+  # Mail location for other users' mailboxes. Note that %{variables} and ~/
+  # expands to the logged in user's data. %{owner_user} and %{owner_home}
+  # destination user's data.
+  #mail_driver = maildir
+  #mail_path = %{owner_home}/Maildir
+  #mail_index_path = ~/Maildir/shared/%{owner_user}
+
+  # Use the default namespace for saving subscriptions.
+  #subscriptions = no
+
+  # List the shared/ namespace only if there are visible shared mailboxes.
+  #list = children
+#}
+# Should shared INBOX be visible as "shared/user" or "shared/user/INBOX"?
+#mail_shared_explicit_inbox = no
+
+# System user and group used to access mails. If you use multiple, userdb
+# can override these by returning uid or gid fields. You can use either numbers
+# or names. <https://doc.dovecot.org/latest/core/config/system_users.html#uids>
+#mail_uid =
+#mail_gid =
+
+#  Group to enable temporarily for privileged operations. Currently this is
+# used only with INBOX when either its initial creation or dotlocking fails.
+# Typically this is set to "mail" to give access to /var/mail.
+#-#mail_privileged_group = mail
+
+# Grant access to these supplementary groups for mail processes. Typically
+# these are used to set up access to shared mailboxes. Note that it may be
+# dangerous to set these if users can create symlinks (e.g. if "mail" group is
+# set here, ln -s /var/mail ~/mail/var could allow a user to delete others'
+# mailboxes, or ln -s /secret/shared/box ~/mail/mybox would allow reading it).
+#mail_access_groups =
+
+# Allow full filesystem access to clients. There's no access checks other than
+# what the operating system does for the active UID/GID. It works with both
+# maildir and mboxes, allowing you to prefix mailboxes names with eg. /path/
+# or ~user/.
+#mail_full_filesystem_access = no
+
+# Dictionary for key=value mailbox attributes. This is used for example by
+# URLAUTH and METADATA extensions.
+#mail_attribute {
+#  dict file {
+#    path = %{home}/Maildir/dovecot-attributes
+#  }
+#}
+
+# A comment or note that is associated with the server. This value is
+# accessible for authenticated users through the IMAP METADATA server
+# entry "/shared/comment". 
+#mail_server_comment = ""
+
+# Indicates a method for contacting the server administrator. According to
+# RFC 5464, this value MUST be a URI (e.g., a mailto: or tel: URL), but that
+# is currently not enforced. Use for example mailto:admin@example.com. This
+# value is accessible for authenticated users through the IMAP METADATA server
+# entry "/shared/admin".
+#mail_server_admin = 
+
+##
+## Mail processes
+##
+
+# Don't use mmap() at all. This is required if you store indexes to shared
+# filesystems (NFS or clustered filesystem).
+#mmap_disable = no
+
+# Rely on O_EXCL to work when creating dotlock files. NFS supports O_EXCL
+# since version 3, so this should be safe to use nowadays by default.
+#dotlock_use_excl = yes
+
+# When to use fsync() or fdatasync() calls:
+#   optimized (default): Whenever necessary to avoid losing important data
+#   always: Useful with e.g. NFS when write()s are delayed
+#   never: Never use it (best performance, but crashes can lose data)
+#mail_fsync = optimized
+
+# Locking method for index files. Alternatives are fcntl, flock and dotlock.
+# Dotlocking uses some tricks which may create more disk I/O than other locking
+# methods. NFS users: flock doesn't work, remember to change mmap_disable.
+#lock_method = fcntl
+
+# Directory where mails can be temporarily stored. Usually it's used only for
+# mails larger than >= 128 kB. It's used by various parts of Dovecot, for
+# example LDA/LMTP while delivering large mails or zlib plugin for keeping
+# uncompressed mails.
+#mail_temp_dir = /tmp
+
+# Valid UID range for users, defaults to 500 and above. This is mostly
+# to make sure that users can't log in as daemons or other system users.
+# Note that denying root logins is hardcoded to dovecot binary and can't
+# be done even if first_valid_uid is set to 0.
+#first_valid_uid = 500
+#last_valid_uid = 0
+
+# Valid GID range for users, defaults to non-root/wheel. Users having
+# non-valid GID as primary group ID aren't allowed to log in. If user
+# belongs to supplementary groups with non-valid GIDs, those groups are
+# not set.
+#first_valid_gid = 1
+#last_valid_gid = 0
+
+# Maximum allowed length for mail keyword name. It's only forced when trying
+# to create new keywords.
+#mail_max_keyword_length = 50
+
+# ':' separated list of directories under which chrooting is allowed for mail
+# processes (ie. /var/mail will allow chrooting to /var/mail/foo/bar too).
+# This setting doesn't affect login_chroot, mail_chroot or auth chroot
+# settings. If this setting is empty, "/./" in home dirs are ignored.
+# WARNING: Never add directories here which local users can modify, that
+# may lead to root exploit. Usually this should be done only if you don't
+# allow shell access for users. <doc/wiki/Chrooting.txt>
+#valid_chroot_dirs = 
+
+# Default chroot directory for mail processes. This can be overridden for
+# specific users in user database by giving /./ in user's home directory
+# (eg. /home/./user chroots into /home). Note that usually there is no real
+# need to do chrooting, Dovecot doesn't allow users to access files outside
+# their mail directory anyway. If your home directories are prefixed with
+# the chroot directory, append "/." to mail_chroot. <doc/wiki/Chrooting.txt>
+#mail_chroot = 
+
+# UNIX socket path to master authentication server to find users.
+# This is used by imap (for shared users) and lda.
+#auth_socket_path = /var/run/dovecot/auth-userdb
+
+# Directory where to look up mail plugins.
+#mail_plugin_dir = /usr/lib/dovecot
+
+# Space separated list of plugins to load for all services. Plugins specific to
+# IMAP, LDA, etc. are added to this list in their own .conf files.
+#mail_plugins =
+#
+# To add plugins, use
+#mail_plugins {
+#  plugin = yes
+#}
+
+##
+## Mailbox handling optimizations
+##
+
+# Mailbox list indexes can be used to optimize IMAP STATUS commands. They are
+# also required for IMAP NOTIFY extension to be enabled.
+#mailbox_list_index = yes
+
+# Trust mailbox list index to be up-to-date. This reduces disk I/O at the cost
+# of potentially returning out-of-date results after e.g. server crashes.
+# The results will be automatically fixed once the folders are opened.
+#mailbox_list_index_very_dirty_syncs = yes
+
+# Should INBOX be kept up-to-date in the mailbox list index? By default it's
+# not, because most of the mailbox accesses will open INBOX anyway.
+#mailbox_list_index_include_inbox = no
+
+# The minimum number of mails in a mailbox before updates are done to cache
+# file. This allows optimizing Dovecot's behavior to do less disk writes at
+# the cost of more disk reads.
+#mail_cache_min_mail_count = 0
+
+# When IDLE command is running, mailbox is checked once in a while to see if
+# there are any new mails or other changes. This setting defines the minimum
+# time to wait between those checks. Dovecot can also use inotify and
+# kqueue to find out immediately when changes occur.
+#mailbox_idle_check_interval = 30 secs
+
+# Save mails with CR+LF instead of plain LF. This makes sending those mails
+# take less CPU, especially with sendfile() syscall with Linux and FreeBSD.
+# But it also creates a bit more disk I/O which may just make it slower.
+# Also note that if other software reads the mboxes/maildirs, they may handle
+# the extra CRs wrong and cause problems.
+#mail_save_crlf = no
+
+# Max number of mails to keep open and prefetch to memory. This only works with
+# some mailbox formats and/or operating systems.
+#mail_prefetch_count = 0
+
+# How often to scan for stale temporary files and delete them (0 = never).
+# These should exist only after Dovecot dies in the middle of saving mails.
+#mail_temp_scan_interval = 1w
+
+# How many slow mail accesses sorting can perform before it returns failure.
+# With IMAP the reply is: NO [LIMIT] Requested sort would have taken too long.
+# The untagged SORT reply is still returned, but it's likely not correct.
+#mail_sort_max_read_count = 0
+
+#-#protocol !indexer-worker {
+  # If folder vsize calculation requires opening more than this many mails from
+  # disk (i.e. mail sizes aren't in cache already), return failure and finish
+  # the calculation via indexer process. Disabled by default. This setting must
+  # be 0 for indexer-worker processes.
+  #mail_vsize_bg_after_count = 0
+#-#}
+
+##
+## Maildir-specific settings
+##
+
+# By default LIST command returns all entries in maildir beginning with a dot.
+# Enabling this option makes Dovecot return only entries which are directories.
+# This is done by stat()ing each entry, so it causes more disk I/O.
+# (For systems setting struct dirent->d_type, this check is free and it's
+# done always regardless of this setting)
+#maildir_stat_dirs = no
+
+# When copying a message, do it with hard links whenever possible. This makes
+# the performance much better, and it's unlikely to have any side effects.
+#maildir_copy_with_hardlinks = yes
+
+# Assume Dovecot is the only MUA accessing Maildir: Scan cur/ directory only
+# when its mtime changes unexpectedly or when we can't find the mail otherwise.
+#maildir_very_dirty_syncs = no
+
+# If enabled, Dovecot doesn't use the S=<size> in the Maildir filenames for
+# getting the mail's physical size, except when recalculating Maildir++ quota.
+# This can be useful in systems where a lot of the Maildir filenames have a
+# broken size. The performance hit for enabling this is very small.
+#maildir_broken_filename_sizes = no
+
+# Always move mails from new/ directory to cur/, even when the \Recent flags
+# aren't being reset.
+#maildir_empty_new = no
+
+##
+## mbox-specific settings
+##
+
+# Which locking methods to use for locking mbox. There are four available:
+#  dotlock: Create <mailbox>.lock file. This is the oldest and most NFS-safe
+#           solution. If you want to use /var/mail/ like directory, the users
+#           will need write access to that directory.
+#  dotlock_try: Same as dotlock, but if it fails because of permissions or
+#               because there isn't enough disk space, just skip it.
+#  fcntl  : Use this if possible. Works with NFS too if lockd is used.
+#  flock  : May not exist in all systems. Doesn't work with NFS.
+#  lockf  : May not exist in all systems. Doesn't work with NFS.
+#
+# You can use multiple locking methods; if you do the order they're declared
+# in is important to avoid deadlocks if other MTAs/MUAs are using multiple
+# locking methods as well. Some operating systems don't allow using some of
+# them simultaneously.
+#mbox_read_locks = fcntl
+#mbox_write_locks = dotlock fcntl
+
+# Maximum time to wait for lock (all of them) before aborting.
+#mbox_lock_timeout = 5 mins
+
+# If dotlock exists but the mailbox isn't modified in any way, override the
+# lock file after this much time.
+#mbox_dotlock_change_timeout = 2 mins
+
+# When mbox changes unexpectedly we have to fully read it to find out what
+# changed. If the mbox is large this can take a long time. Since the change
+# is usually just a newly appended mail, it'd be faster to simply read the
+# new mails. If this setting is enabled, Dovecot does this but still safely
+# fallbacks to re-reading the whole mbox file whenever something in mbox isn't
+# how it's expected to be. The only real downside to this setting is that if
+# some other MUA changes message flags, Dovecot doesn't notice it immediately.
+# Note that a full sync is done with SELECT, EXAMINE, EXPUNGE and CHECK 
+# commands.
+#mbox_dirty_syncs = yes
+
+# Like mbox_dirty_syncs, but don't do full syncs even with SELECT, EXAMINE,
+# EXPUNGE or CHECK commands. If this is set, mbox_dirty_syncs is ignored.
+#mbox_very_dirty_syncs = no
+
+# Delay writing mbox headers until doing a full write sync (EXPUNGE and CHECK
+# commands and when closing the mailbox). This is especially useful for POP3
+# where clients often delete all mails. The downside is that our changes
+# aren't immediately visible to other MUAs.
+#mbox_lazy_writes = yes
+
+# If mbox size is smaller than this (e.g. 100k), don't write index files.
+# If an index file already exists it's still read, just not updated.
+#mbox_min_index_size = 0
+
+# Mail header selection algorithm to use for MD5 POP3 UIDLs when
+# pop3_uidl_format=%m. For backwards compatibility we use apop3d inspired
+# algorithm, but it fails if the first Received: header isn't unique in all
+# mails. An alternative algorithm is "all" that selects all headers.
+#mbox_md5 = apop3d
+
+##
+## mdbox-specific settings
+##
+
+# Maximum dbox file size until it's rotated.
+#mdbox_rotate_size = 10M
+
+# Maximum dbox file age until it's rotated. Typically in days. Day begins
+# from midnight, so 1d = today, 2d = yesterday, etc. 0 = check disabled.
+#mdbox_rotate_interval = 0
+
+# When creating new mdbox files, immediately preallocate their size to
+# mdbox_rotate_size. This setting currently works only in Linux with some
+# filesystems (ext4, xfs).
+#mdbox_preallocate_space = no
+
+# Settings to control adding $HasAttachment or $HasNoAttachment keywords.
+# By default, all MIME parts with Content-Disposition=attachment, or inlines
+# with filename parameter are consired attachments.
+#   add-flags - Add the keywords when saving new mails or when fetching can
+#      do it efficiently.
+#   content-type=type or !type - Include/exclude content type. Excluding will
+#     never consider the matched MIME part as attachment. Including will only
+#     negate an exclusion (e.g. content-type=!foo/* content-type=foo/bar).
+#   exclude-inlined - Exclude any Content-Disposition=inline MIME part.
+#mail_attachment_detection_options =

--- a/install/common/dovecot-24/conf.d/10-master.conf
+++ b/install/common/dovecot-24/conf.d/10-master.conf
@@ -1,0 +1,174 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+service imap-login {
+  inet_listener imap {
+  }
+  inet_listener imaps {
+  }
+}
+service pop3-login {
+  inet_listener pop3 {
+  }
+  inet_listener pop3s {
+  }
+}
+service imap {
+}
+service pop3 {
+}
+
+service auth {
+  user = dovecot
+  extra_groups = mail
+
+  unix_listener auth-client {
+    group = mail
+    mode = 0660
+    user = dovecot
+  }
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+#default_process_limit = 100
+#default_client_limit = 1000
+
+# Default VSZ (virtual memory size) limit for service processes. This is mainly
+# intended to catch and kill processes that leak memory before they eat up
+# everything.
+#default_vsz_limit = 256M
+
+# Login user is internally used by login processes. This is the most untrusted
+# user in Dovecot system. It shouldn't have access to anything at all.
+#default_login_user = dovenull
+
+# Internal user is used by unprivileged processes. It should be separate from
+# login user, so that login processes can't disturb other processes.
+#default_internal_user = dovecot
+
+#-#service imap-login {
+#-#  inet_listener imap {
+    #port = 143
+#-#  }
+#-#  inet_listener imaps {
+    #port = 993
+    #ssl = yes
+#-#  }
+
+  # Number of connections to handle before starting a new process. Typically
+  # the only useful values are 0 (unlimited) or 1. 1 is more secure, but 0
+  # is faster. <d>
+  #service_restart_request_count = 1
+
+  # Number of processes to always keep waiting for more connections.
+  #process_min_avail = 0
+
+  # If you set service_restart_request_count=0, you probably need to grow this.
+  #vsz_limit = 256M # default
+#-#}
+
+#-#service pop3-login {
+#-#  inet_listener pop3 {
+    #port = 110
+#-#  }
+#-#  inet_listener pop3s {
+    #port = 995
+    #ssl = yes
+#-#  }
+#-#}
+
+#-#service submission-login {
+#-#  inet_listener submission {
+    #port = 587
+#-#  }
+#-#  inet_listener submissions {
+    #port = 465
+#-#  }
+#-#}
+
+#-#service lmtp {
+#-#  unix_listener lmtp {
+    #mode = 0666
+#-#  }
+
+  # Create inet listener only if you can't use the above UNIX socket
+  #inet_listener lmtp {
+    # Avoid making LMTP visible for the entire internet
+    #listen = 127.0.0.1
+    #port = 24
+  #}
+#-#}
+
+#-#service imap {
+  # Most of the memory goes to mmap()ing files. You may need to increase this
+  # limit if you have huge mailboxes.
+  #vsz_limit = 256M # default
+
+  # Max. number of IMAP processes (connections)
+  #process_limit = 1024
+#-#}
+
+#-#service pop3 {
+  # Max. number of POP3 processes (connections)
+  #process_limit = 1024
+#-#}
+
+#-#service submission {
+  # Max. number of SMTP Submission processes (connections)
+  #process_limit = 1024
+#-#}
+
+#-#service auth {
+  # auth_socket_path points to this userdb socket by default. It's typically
+  # used by dovecot-lda, doveadm, possibly imap process, etc. Users that have
+  # full permissions to this socket are able to get a list of all usernames and
+  # get the results of everyone's userdb lookups.
+  #
+  # The default 0666 mode allows anyone to connect to the socket, but the
+  # userdb lookups will succeed only if the userdb returns an "uid" field that
+  # matches the caller process's UID. Also if caller's uid or gid matches the
+  # socket's uid or gid the lookup succeeds. Anything else causes a failure.
+  #
+  # To give the caller full permissions to lookup all users, set the mode to
+  # something else than 0666 and Dovecot lets the kernel enforce the
+  # permissions (e.g. 0777 allows everyone full permissions).
+#-#  unix_listener auth-userdb {
+    #mode = 0666
+    #user = 
+    #group = 
+#-#  }
+
+  # Postfix smtp-auth
+  #unix_listener /var/spool/postfix/private/auth {
+  #  mode = 0666
+  #}
+
+  # Auth process is run as this user.
+  #user = $SET:default_internal_user
+#-#}
+
+#-#service auth-worker {
+  # Auth worker process is run as root by default, so that it can access
+  # /etc/shadow. If this isn't necessary, the user should be changed to
+  # $SET:default_internal_user.
+  #user = root
+#-#}
+
+#-#service dict {
+  # If dict proxy is used, mail processes should have access to its socket.
+  # For example: mode=0660, group=vmail and global mail_access_groups=vmail
+#-#  unix_listener dict {
+    #mode = 0600
+    #user = 
+    #group = 
+#-#  }
+#-#}

--- a/install/common/dovecot-24/conf.d/10-metrics.conf
+++ b/install/common/dovecot-24/conf.d/10-metrics.conf
@@ -1,0 +1,143 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+service stats {
+  unix_listener stats-writer {
+    group = mail
+    mode = 0660
+    user = dovecot
+  }
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## Statistics and metrics
+##
+
+# Dovecot supports gathering statistics from events.
+# Currently there are no statistics logged by default, and therefore they must
+# be explicitly added using the metric configuration blocks.
+#
+# Unlike old stats, the new statistics do not require any plugins loaded.
+#
+# See https://doc.dovecot.org/latest/core/config/statistics.html for details
+
+##
+## Example metrics
+##
+
+#metric auth_success {
+#  filter = (event=auth_request_finished AND success=yes)
+#}
+#
+#metric auth_failure {
+#  filter = (event=auth_request_finished AND NOT success=yes)
+## See exporter config later in this file
+## can be used to replace auth_verbose=yes
+#  exporter = log
+#}
+#
+#metric imap_command {
+#  filter = event=imap_command_finished
+#  group_by cmd_name {
+#    method discrete {
+#    }
+#  }
+#  group_by tagged_reply_state {
+#    method discrete {
+#    }
+#  }
+#}
+#
+#metric smtp_command {
+#  filter = event=smtp_server_command_finished and protocol=submission
+#  group_by cmd_name {
+#     method discrete {
+#    }
+#  }
+#  group_by status_code {
+#     method discrete {
+#    }
+#  }
+#  group_by duration {
+#     method exponential {
+#       base = 10
+#       min_magnitude = 1
+#       max_magnitude = 5
+#    }
+#  }
+#}
+#
+#metric lmtp_command {
+#  filter = event=smtp_server_command_finished and protocol=lmtp
+#  group_by cmd_name {
+#     method discrete {
+#    }
+#  }
+#  group_by status_code {
+#     method discrete {
+#    }
+#  }
+#  group_by duration {
+#     method exponential {
+#       base = 10
+#       min_magnitude = 1
+#       max_magnitude = 5
+#    }
+#  }
+#}
+#
+#metric mail_delivery {
+#  filter = event=mail_delivery_finished
+#  group_by duration {
+#     method exponential {
+#       base = 10
+#       min_magnitude = 1
+#       max_magnitude = 5
+#     }
+#  }
+#}
+
+##
+## Prometheus
+##
+
+# To allow access to statistics with Prometheus, enable http listener
+# on stats process. Stats will be available on /metrics path.
+#
+# See https://doc.dovecot.org/latest/core/config/statistics.html#openmetrics for more
+# details.
+
+#service stats {
+#  inet_listener http {
+#    port = 9900
+#  }
+#}
+
+##
+## Event exporting
+##
+
+# You can also export individual events.
+#
+# See https://doc.dovecot.org/configuration_manual/event_export/ for more
+# details.
+
+#event_exporter log {
+#  format = json
+#  time_format = rfc3339
+#}
+#
+#metric imap_commands {
+#  exporter = log
+#  filter = event=imap_command_finished
+#}

--- a/install/common/dovecot-24/conf.d/10-ssl.conf
+++ b/install/common/dovecot-24/conf.d/10-ssl.conf
@@ -1,0 +1,77 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+ssl = yes
+ssl_cipher_list = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA256
+ssl_min_protocol = TLSv1.2
+ssl_server_prefer_ciphers = client
+ssl_server_cert_file = /usr/local/hestia/ssl/certificate.crt
+ssl_server_key_file = /usr/local/hestia/ssl/certificate.key
+ssl_server_dh_file = /etc/ssl/dhparam.pem
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## SSL settings
+##
+
+# SSL/TLS support: yes, no, required. <https://doc.dovecot.org/latest/core/config/ssl.html>
+#-#ssl = yes
+
+# PEM encoded X.509 SSL/TLS certificate and private key.  By default, Debian
+# installs a self-signed certificate.  This is useful for testing, but you
+# should obtain a real certificate from a recognized certificate authority.
+#
+# These files are opened before dropping root privileges, so keep the key file
+# unreadable by anyone but root. Included /usr/share/dovecot/mkcert.sh can be
+# used to easily generate self-signed certificate, just make sure to update the
+# domains in dovecot-openssl.cnf
+# 
+# Preferred permissions: root:root 0444
+#-#ssl_server_cert_file = /etc/dovecot/private/dovecot.pem
+# Preferred permissions: root:root 0400
+#-#ssl_server_key_file = /etc/dovecot/private/dovecot.key
+
+# If key file is password protected, give the password here. Alternatively
+# give it when starting dovecot with -p parameter. Since this file is often
+# world-readable, you may want to place this setting instead to a different
+# root owned 0600 file by using ssl_key_password = <path.
+#ssl_server_key_password =
+
+# PEM encoded trusted certificate authority. Set this only if you intend to use
+# ssl_request_client_cert=yes. The file should contain the CA certificate(s)
+# followed by the matching CRL(s). (e.g. ssl_server_ca_file = /etc/ssl/certs/ca.pem)
+#ssl_server_ca_file = 
+
+# Require that CRL check succeeds for client certificates.
+#ssl_server_require_crl = yes
+
+# Request client to send a certificate. If you also want to require it, set
+# auth_ssl_require_client_cert=yes in auth section.
+#ssl_server_request_client_cert = no
+
+# Which field from certificate to use for username. commonName and
+# x500UniqueIdentifier are the usual choices. You'll also need to set
+# auth_ssl_username_from_cert=yes.
+#ssl_server_cert_username_field = commonName
+
+# SSL protocols to use.  Debian systems specify TLSv1.2 by default, which should
+# be reasonbly secure and compatible with existing clients.
+#-#ssl_min_protocol = TLSv1.2
+# Diffie-Hellman parameters are no longer required and should be phased out.
+# They do not work with ECDH(E) and require DH(E) ciphers.
+#ssl_server_dh_file = /etc/dovecot/dh.pem
+
+# SSL ciphers to use
+#ssl_cipher_list = ALL:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
+
+# SSL crypto device to use, for valid values run "openssl engine"
+#ssl_crypto_device = /dev/crypto

--- a/install/common/dovecot-24/conf.d/15-lda.conf
+++ b/install/common/dovecot-24/conf.d/15-lda.conf
@@ -1,0 +1,66 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+protocol lda {
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## LDA specific settings (also used by LMTP)
+##
+
+# Address to use when sending rejection mails.
+# Default is postmaster@%d. %d expands to recipient domain.
+#postmaster_address =
+
+# Hostname to use in various parts of sent mails (e.g. in Message-Id) and
+# in LMTP replies. Default is the system's real hostname@domain.
+#hostname = 
+
+# If user is over quota, return with temporary failure instead of
+# bouncing the mail.
+#quota_full_tempfail = no
+
+# Binary to use for sending mails.
+#sendmail_path = /usr/sbin/sendmail
+
+# If non-empty, send mails via this SMTP host[:port] instead of sendmail.
+#submission_host =
+
+# Subject: header to use for rejection mails. You can use the same variables
+# as for rejection_reason below.
+#rejection_subject = Rejected: %s
+
+# Human readable error message for rejection mails. You can use variables:
+#  %n = CRLF, %r = reason, %s = original subject, %t = recipient
+#rejection_reason = Your message to <%t> was automatically rejected:%n%r
+
+# Delimiter character between local-part and detail in email address.
+#recipient_delimiter = +
+
+# Header where the original recipient address (SMTP's RCPT TO: address) is taken
+# from if not available elsewhere. With dovecot-lda -a parameter overrides this. 
+# A commonly used header for this is X-Original-To.
+#lda_original_recipient_header =
+
+# Should saving a mail to a nonexistent mailbox automatically create it?
+#lda_mailbox_autocreate = no
+
+# Should automatically created mailboxes be also automatically subscribed?
+#lda_mailbox_autosubscribe = no
+
+#-#protocol lda {
+  # Boolean list of plugins to load
+  #mail_plugins {
+  #   sieve = yes
+  #}
+#-#}

--- a/install/common/dovecot-24/conf.d/15-mailboxes.conf
+++ b/install/common/dovecot-24/conf.d/15-mailboxes.conf
@@ -1,0 +1,143 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+namespace inbox {
+    type = private
+    separator = /
+    inbox = yes
+    list = yes
+
+    mailbox Archive {
+        auto = subscribe
+        special_use = \Archive
+    }
+    mailbox Drafts {
+        auto = subscribe
+        special_use = \Drafts
+    }
+    mailbox Trash {
+        auto = subscribe
+        special_use = \Trash
+    }
+    mailbox "Deleted Messages" {
+        auto = no
+        special_use = \Trash
+    }
+    mailbox Spam {
+        auto = subscribe
+        special_use = \Junk
+    }
+    mailbox Junk {
+        auto = no
+        special_use = \Junk
+    }
+    mailbox Sent {
+        auto = subscribe
+        special_use = \Sent
+    }
+    mailbox "Sent Mail" {
+        auto = no
+        special_use = \Sent
+    }
+    mailbox "Sent Messages" {
+        auto = no
+        special_use = \Sent
+    }
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## Mailbox definitions
+##
+
+# Each mailbox is specified in a separate mailbox section. The section name
+# specifies the mailbox name. If it has spaces, you can put the name
+# "in quotes". These sections can contain the following mailbox settings:
+#
+# auto:
+#   Indicates whether the mailbox with this name is automatically created
+#   implicitly when it is first accessed. The user can also be automatically
+#   subscribed to the mailbox after creation. The following values are
+#   defined for this setting:
+# 
+#     no        - Never created automatically.
+#     create    - Automatically created, but no automatic subscription.
+#     subscribe - Automatically created and subscribed.
+#  
+# special_use:
+#   A space-separated list of SPECIAL-USE flags (RFC 6154) to use for the
+#   mailbox. There are no validity checks, so you could specify anything
+#   you want in here, but it's not a good idea to use flags other than the
+#   standard ones specified in the RFC:
+#
+#     \All       - This (virtual) mailbox presents all messages in the
+#                  user's message store.
+#     \Archive   - This mailbox is used to archive messages.
+#     \Drafts    - This mailbox is used to hold draft messages.
+#     \Flagged   - This (virtual) mailbox presents all messages in the
+#                  user's message store marked with the IMAP \Flagged flag.
+#     \Important - This (virtual) mailbox presents all messages in the
+#                  user's message store deemed important to user.
+#     \Junk      - This mailbox is where messages deemed to be junk mail
+#                  are held.
+#     \Sent      - This mailbox is used to hold copies of messages that
+#                  have been sent.
+#     \Trash     - This mailbox is used to hold messages that have been
+#                  deleted.
+#
+# comment:
+#   Defines a default comment or note associated with the mailbox. This
+#   value is accessible through the IMAP METADATA mailbox entries
+#   "/shared/comment" and "/private/comment". Users with sufficient
+#   privileges can override the default value for entries with a custom
+#   value.
+
+# NOTE: Assumes "namespace inbox" has been defined in 10-mail.conf.
+#-#namespace inbox {
+  # These mailboxes are widely used and could perhaps be created automatically:
+#-#  mailbox Drafts {
+#-#    special_use = \Drafts
+#-#  }
+#-#  mailbox Junk {
+#-#    special_use = \Junk
+#-#  }
+#-#  mailbox Trash {
+#-#    special_use = \Trash
+#-#  }
+
+  # For \Sent mailboxes there are two widely used names. We'll mark both of
+  # them as \Sent. User typically deletes one of them if duplicates are created.
+#-#  mailbox Sent {
+#-#    special_use = \Sent
+#-#  }
+#-#  mailbox "Sent Messages" {
+#-#    special_use = \Sent
+#-#  }
+
+  # If you have a virtual "All messages" mailbox:
+  #mailbox virtual/All {
+  #  special_use = \All
+  #  comment = All my messages
+  #}
+
+  # If you have a virtual "Flagged" mailbox:
+  #mailbox virtual/Flagged {
+  #  special_use = \Flagged
+  #  comment = All my flagged messages
+  #}
+
+  # If you have a virtual "Important" mailbox:
+  #mailbox virtual/Important {
+  #  special_use = \Important
+  #  comment = All my important messages
+  #}
+#-#}

--- a/install/common/dovecot-24/conf.d/20-imap.conf
+++ b/install/common/dovecot-24/conf.d/20-imap.conf
@@ -1,0 +1,125 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+protocol imap {
+    mail_plugins = mail_compress quota imap_quota
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## IMAP specific settings
+##
+
+# If nothing happens for this long while client is IDLEing, move the connection
+# to imap-hibernate process and close the old imap process. This saves memory,
+# because connections use very little memory in imap-hibernate process. The
+# downside is that recreating the imap process back uses some resources.
+#imap_hibernate_timeout = 0
+
+# Maximum IMAP command line length. Some clients generate very long command
+# lines with huge mailboxes, so you may need to raise this if you get
+# "Too long argument" or "IMAP command line too large" errors often.
+#imap_max_line_length = 64k
+
+# IMAP logout format string:
+#  %{input} - total number of bytes read from client
+#  %{output} - total number of bytes sent to client
+#  %{fetch_hdr_count} - Number of mails with mail header data sent to client
+#  %{fetch_hdr_bytes} - Number of bytes with mail header data sent to client
+#  %{fetch_body_count} - Number of mails with mail body data sent to client
+#  %{fetch_body_bytes} - Number of bytes with mail body data sent to client
+#  %{deleted} - Number of mails where client added \Deleted flag
+#  %{expunged} - Number of mails that client expunged, which does not
+#                include automatically expunged mails
+#  %{autoexpunged} - Number of mails that were automatically expunged after
+#                    client disconnected
+#  %{trashed} - Number of mails that client copied/moved to the
+#               special_use=\Trash mailbox.
+#  %{appended} - Number of mails saved during the session
+#imap_logout_format = in=%i out=%o deleted=%{deleted} expunged=%{expunged} \
+#  trashed=%{trashed} hdr_count=%{fetch_hdr_count} \
+#  hdr_bytes=%{fetch_hdr_bytes} body_count=%{fetch_body_count} \
+#  body_bytes=%{fetch_body_bytes}
+
+# Amend or override the IMAP capability response. To override, set the value
+# with imap_capability = 
+# 
+# To amend, you can use a boolean list to specify which capabilities to turn
+# on and off
+#imap_capability {
+#  SPECIAL-USE = yes
+#  "LITERAL+" = no
+#}
+
+# How long to wait between "OK Still here" notifications when client is
+# IDLEing.
+#imap_idle_notify_interval = 2 mins
+
+# ID field names and values to send to clients. Using * as the value makes
+# Dovecot use the default value. The following fields have default values
+# currently: name, version, os, os-version, support-url, support-email,
+# revision.
+#imap_id_send = 
+
+# Use imap_id_received event to log IMAP id
+
+# Workarounds for various client bugs:
+#   delay-newmail:
+#     Send EXISTS/RECENT new mail notifications only when replying to NOOP
+#     and CHECK commands. Some clients ignore them otherwise, for example OSX
+#     Mail (<v2.1). Outlook Express breaks more badly though, without this it
+#     may show user "Message no longer in server" errors. Note that OE6 still
+#     breaks even with this workaround if synchronization is set to
+#     "Headers Only".
+#   tb-extra-mailbox-sep:
+#     Thunderbird gets somehow confused with LAYOUT=fs (mbox and dbox) and
+#     adds extra '/' suffixes to mailbox names. This option causes Dovecot to
+#     ignore the extra '/' instead of treating it as invalid mailbox name.
+#   tb-lsub-flags:
+#     Show \Noselect flags for LSUB replies with LAYOUT=fs (e.g. mbox).
+#     This makes Thunderbird realize they aren't selectable and show them
+#     greyed out, instead of only later giving "not selectable" popup error.
+#
+# This is a boolean list
+#imap_client_workarounds {
+#  delay-newmail = yes
+#}
+
+# Host allowed in URLAUTH URLs sent by client. "*" allows all.
+#imap_urlauth_host =
+
+# Enable IMAP LITERAL- extension (replaces LITERAL+)
+#imap_literal_minus = no
+
+# What happens when FETCH fails due to some internal error:
+#   disconnect-immediately:
+#     The FETCH is aborted immediately and the IMAP client is disconnected.
+#   disconnect-after:
+#     The FETCH runs for all the requested mails returning as much data as
+#     possible. The client is finally disconnected without a tagged reply.
+#   no-after:
+#     Same as disconnect-after, but tagged NO reply is sent instead of
+#     disconnecting the client. If the client attempts to FETCH the same failed
+#     mail more than once, the client is disconnected. This is to avoid clients
+#     from going into infinite loops trying to FETCH a broken mail.
+#imap_fetch_failure = disconnect-immediately
+
+#-#protocol imap {
+  # Space separated list of plugins to load (default is global mail_plugins).
+  #mail_plugins {
+  #  imap_sieve = yes
+  #}
+
+  # Maximum number of IMAP connections allowed for a user from each IP address.
+  # NOTE: The username is compared case-sensitively.
+  #mail_max_userip_connections = 10
+#-#}

--- a/install/common/dovecot-24/conf.d/20-pop3.conf
+++ b/install/common/dovecot-24/conf.d/20-pop3.conf
@@ -1,0 +1,118 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+protocol pop3 {
+  mail_plugins = mail_compress quota
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## POP3 specific settings
+##
+
+# Don't try to set mails non-recent or seen with POP3 sessions. This is
+# mostly intended to reduce disk I/O. With maildir it doesn't move files
+# from new/ to cur/, with mbox it doesn't write Status-header.
+#pop3_no_flag_updates = no
+
+# Support LAST command which exists in old POP3 specs, but has been removed
+# from new ones. Some clients still wish to use this though. Enabling this
+# makes RSET command clear all \Seen flags from messages.
+#pop3_enable_last = no
+
+# If mail has X-UIDL header, use it as the mail's UIDL.
+#pop3_reuse_xuidl = no
+
+# Allow only one POP3 session to run simultaneously for the same user.
+#pop3_lock_session = no
+
+# POP3 requires message sizes to be listed as if they had CR+LF linefeeds.
+# Many POP3 servers violate this by returning the sizes with LF linefeeds,
+# because it's faster to get. When this setting is enabled, Dovecot still
+# tries to do the right thing first, but if that requires opening the
+# message, it fallbacks to the easier (but incorrect) size.
+#pop3_fast_size_lookups = no
+
+# POP3 UIDL (unique mail identifier) format to use. You can use following
+# variables with variable extension as described in
+# https://doc.dovecot.org/latest/core/settings/variables.html
+#
+#  %{uidvalidity} - Mailbox's IMAP UIDVALIDITY
+#  %{uid} - Mail's IMAP UID
+#  %{md5} - MD5 sum of the mailbox headers in hex (mbox only)
+#  %{filename} - filename (maildir only)
+#  %{guid} - Mail's GUID
+#
+# If you want UIDL compatibility with other POP3 servers, use:
+#  UW's ipop3d         : %{uid | hex(8)}%{uidvalidity | hex(8)}
+#  Courier             : %{filename} or %{uidvalidity}-%{uid} (both might be used simultaneously)
+#  Cyrus (<= 2.1.3)    : %{uid}
+#  Cyrus (>= 2.1.4)    : %{uidvalidity}.%{uid}
+#  Dovecot v0.99.x     : %{uidvalidity}.%{uid}
+#  tpop3d              : %{filename|md5}
+#
+# Note that Outlook 2003 seems to have problems with %{uidvalidity}.%{uid} format which was
+# Dovecot's default, so if you're building a new server it would be a good
+# idea to change this. %{uid | hex(8)}%{uidvalidity | hex(8)} should be pretty fail-safe.
+#
+#pop3_uidl_format = %{uid | hex(8)}%{uidvalidity | hex(8)}
+
+# Permanently save UIDLs sent to POP3 clients, so pop3_uidl_format changes
+# won't change those UIDLs. Currently this works only with Maildir.
+#pop3_save_uidl = no
+
+# What to do about duplicate UIDLs if they exist?
+#   allow: Show duplicates to clients.
+#   rename: Append a temporary -2, -3, etc. counter after the UIDL.
+#pop3_uidl_duplicates = allow
+
+# This option changes POP3 behavior so that it's not possible to actually
+# delete mails via POP3, only hide them from future POP3 sessions. The mails
+# will still be counted towards user's quota until actually deleted via IMAP.
+# Use e.g. "$POP3Deleted" as the value (it will be visible as IMAP keyword).
+# Make sure you can legally archive mails before enabling this setting.
+#pop3_deleted_flag =
+
+# POP3 logout format string:
+# %{input} - Bytes read from the client
+# %{output} - Bytes sent to the client
+# %{top_count} - Number of TOP commands run
+# %{top_bytes} - Bytes sent to the client because of TOP commands
+# %{retr_count} - Number of RETR commands run
+# %{retr_bytes} - Bytes sent to the client because of RETR commands
+# %{deleted_count} - Number of deleted messages
+# %{deleted_bytes} - Number of bytes in deleted messages
+# %{message_count} - Number of messages before deletion
+# %{message_bytes} - Mailbox size, in bytes, before deletion
+# %{uidl_change} - The old and the new UIDL hash (which can be useful for identifying unexpected changes in UIDLs)
+#pop3_logout_format = top=%{top_count}/%{top_bytes}, retr=%{retr_count}/%{retr_bytes}, del=%{deleted_count}/%{deleted_bytes}, size=%{message_bytes}
+
+# Workarounds for various client bugs:
+#   outlook-no-nuls:
+#     Outlook and Outlook Express hang if mails contain NUL characters.
+#     This setting replaces them with 0x80 character.
+#   oe-ns-eoh:
+#     Outlook Express and Netscape Mail breaks if end of headers-line is
+#     missing. This option simply sends it if it's missing.
+#pop3_client_workarounds {
+#  outlook-no-nuls = yes
+#}
+
+#-#protocol pop3 {
+  # Space separated list of plugins to load (default is global mail_plugins).
+  #mail_plugins {
+  #}
+
+  # Maximum number of POP3 connections allowed for a user from each IP address.
+  # NOTE: The username is compared case-sensitively.
+  #mail_max_userip_connections = 10
+#-#}

--- a/install/common/dovecot-24/conf.d/90-quota.conf
+++ b/install/common/dovecot-24/conf.d/90-quota.conf
@@ -1,0 +1,95 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+quota "User quota" {
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## Quota configuration.
+##
+
+# Note that you also have to enable quota plugin in mail_plugins setting.
+## <https://doc.dovecot.org/latest/core/plugins/quota.html>
+
+##
+## Quota limits
+##
+
+# Quota limits are set using "quota_rule" parameters. To get per-user quota
+# limits, you can set/override them by returning "quota_rule" extra field
+# from userdb. It's also possible to give mailbox-specific limits, for example
+# to give additional 100 MB when saving to Trash:
+
+#mail_plugins {
+#  quota = yes
+#}
+
+#quota "User quota" {
+#   storage_size = 1G
+#}
+#
+#namespace inbox {
+#   mailbox Trash {
+#     quota_storage_extra = 100M
+#   }
+#}
+
+##
+## Quota warnings
+##
+
+# You can execute a given command when user exceeds a specified quota limit.
+# Each quota root has separate limits. Only the command for the first
+# exceeded limit is excecuted, so put the highest limit first.
+# The commands are executed via script service by connecting to the named
+# UNIX socket (quota-warning below).
+# Note that % needs to be escaped as %%, otherwise "% " expands to empty.
+
+#quota "User quota" {
+#  warning warn-95 {
+#    quota_storage_percentage = 95
+#    execute quota-warning {
+#      args = 95 %{user}
+#    }
+#  }
+#  warning warn-80 {
+#    quota_storage_percentage = 80
+#    execute quota-warning {
+#      args = 80 %{user}
+#    }
+#  }
+#}
+
+# Example quota-warning service. The unix listener's permissions should be
+# set in a way that mail processes can connect to it. Below example assumes
+# that mail processes run as vmail user. If you use mode=0666, all system users
+# can generate quota warnings to anyone.
+#service quota-warning {
+#  executable = script /usr/local/bin/quota-warning.sh
+#  user = dovecot
+#  unix_listener quota-warning {
+#    user = vmail
+#  }
+#}
+
+##
+## Quota backends
+##
+
+# Multiple backends are supported:
+#   count: Default and recommended, quota driver tracks the quota internally within Dovecot's index files.
+#   maildir: Maildir++ quota
+#   fs: Read-only support for filesystem quota
+#quota "User quota" {
+#  driver = count
+#}

--- a/install/common/dovecot-24/conf.d/auth-passwdfile.conf.ext
+++ b/install/common/dovecot-24/conf.d/auth-passwdfile.conf.ext
@@ -1,0 +1,46 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+passdb passwd-file {
+  driver = passwd-file
+  default_password_scheme = BLF-CRYPT
+  auth_username_format = %{ user | username }
+  passwd_file_path = /etc/exim4/domains/%{ user | domain }/passwd
+}
+
+userdb passwd-file {
+  driver = passwd-file
+  auth_username_format = %{ user | username }
+  passwd_file_path = /etc/exim4/domains/%{ user | domain }/passwd
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+# Authentication for passwd-file users. Included from auth.conf.
+#
+# passwd-like file with specified location.
+# <https://doc.dovecot.org/latest/core/config/auth/databases/passwd_file.html>
+
+#passdb passwd-file {
+#  default_password_scheme = crypt
+#  auth_username_format = %{user}
+#  passwd_file_path = /etc/dovecot/users
+#}
+
+#userdb passwd-file {
+#  auth_username_format=%{user}
+#  passwd_file_path = /etc/dovecot/users
+
+#  fields {
+#    quota_rule:default=*:storage=1G
+#    home=/home/virtual/%{user}
+#  }
+#}

--- a/install/common/dovecot-24/dovecot.conf
+++ b/install/common/dovecot-24/dovecot.conf
@@ -1,0 +1,117 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+dovecot_config_version = 2.4.1
+dovecot_storage_version = 2.4.1
+
+protocols = imap pop3
+
+base_dir = /run/dovecot/
+state_dir = /var/lib/dovecot
+
+default_login_user = dovecot
+
+listen = *, ::
+
+login_greeting = Mail Delivery Agent
+
+!include conf.d/*.conf
+!include_try conf.d/domains/*.conf
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+## Dovecot configuration file
+
+# If you're in a hurry, see https://doc.dovecot.org/latest/core/config/guides/quick.html
+
+# "doveconf -n" command gives a clean output of the changed settings. Use it
+# instead of copy&pasting files when posting to the Dovecot mailing list.
+
+# '#' character and everything after it is treated as comments. Extra spaces
+# and tabs are ignored. If you want to use either of these explicitly, put the
+# value inside quotes, eg.: key = "# char and trailing whitespace  "
+
+# Default values are shown for each setting, it's not required to uncomment
+# those. These are exceptions to this though: No sections (e.g. namespace {})
+# or plugin settings are added by default, they're listed only as examples.
+# Paths are also just examples with the real defaults being based on configure
+# options. The paths listed here are for configure --prefix=/usr/local
+# --sysconfdir=/usr/local/etc --localstatedir=/var
+
+#-#dovecot_config_version = 2.4.0
+#-#dovecot_storage_version = 2.4.0
+
+# Protocols we want to be serving.
+#protocols = imap pop3 lmtp
+#-#!include_try /usr/share/dovecot/protocols.d/*.protocol
+
+# A comma separated list of IPs or hosts where to listen in for connections. 
+# "*" listens in all IPv4 interfaces, "::" listens in all IPv6 interfaces.
+# If you want to specify non-default ports or anything more complex,
+# edit conf.d/master.conf.
+#listen = *, ::
+
+# Base directory where to store runtime data.
+#base_dir = /var/run/dovecot/
+
+# Name of this instance. In multi-instance setup doveadm and other commands
+# can use -i <instance_name> to select which instance is used (an alternative
+# to -c <config_path>). The instance name is also added to Dovecot processes
+# in ps output.
+#instance_name = dovecot
+
+# Greeting message for clients.
+#login_greeting = Dovecot ready.
+
+# Space separated list of trusted network ranges. Connections from these
+# IPs are allowed to override their IP addresses and ports (for logging and
+# for authentication checks). disable_plaintext_auth is also ignored for
+# these networks, unless ssl=required.
+# Typically you'd specify your IMAP proxy servers here.
+#login_trusted_networks =
+
+# With proxy_maybe=yes if proxy destination matches any of these IPs, don't do
+# proxying. This isn't necessary normally, but may be useful if the destination
+# IP is e.g. a load balancer's IP.
+#auth_proxy_self =
+
+# Show more verbose process titles (in ps). Currently shows user name and
+# IP address. Useful for seeing who are actually using the IMAP processes
+# (eg. shared mailboxes or if same uid is used for multiple accounts).
+#verbose_proctitle = yes
+
+# Should all processes be killed when Dovecot master process shuts down.
+# Setting this to "no" means that Dovecot can be upgraded without
+# forcing existing client connections to close (although that could also be
+# a problem if the upgrade is e.g. because of a security fix).
+#shutdown_clients = yes
+
+# If non-zero, run mail commands via this many connections to doveadm server,
+# instead of running them directly in the same process.
+#doveadm_worker_count = 0
+# UNIX socket or host:port used for connecting to doveadm server
+#doveadm_socket_path = doveadm-server
+
+# Space separated list of environment variables that are preserved on Dovecot
+# startup and passed down to all of its child processes. You can also give
+# key=value pairs to always set specific settings.
+#import_environment {
+#  TZ=%{env:TZ}
+#}
+
+# Most of the actual configuration gets included below. The filenames are
+# first sorted by their ASCII value and parsed in that order. The 00-prefixes
+# in filenames are intended to make it easier to understand the ordering.
+#-#!include conf.d/*.conf
+
+# A config file can also tried to be included without giving an error if
+# it's not found:
+#-#!include_try local.conf

--- a/install/common/dovecot-24/sieve/20-managesieve.conf
+++ b/install/common/dovecot-24/sieve/20-managesieve.conf
@@ -1,0 +1,101 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+service managesieve-login {
+  inet_listener sieve {
+    port = 4190
+  }
+}
+protocol sieve {
+  managesieve_max_line_length = 65536
+  managesieve_implementation_string = Dovecot Pigeonhole
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## ManageSieve specific settings
+##
+
+# Uncomment to enable managesieve protocol:
+#-#protocols {
+#-#  sieve = yes
+#-#}
+
+# Service definitions
+
+#-#service managesieve-login {
+#-#  inet_listener sieve {
+#-#    port = 4190
+#-#  }
+
+#-#  inet_listener sieve_deprecated {
+#-#    port = 2000
+#-#  }
+
+  # Number of connections to handle before starting a new process. Typically
+  # the only useful values are 0 (unlimited) or 1. 1 is more secure, but 0
+  # is faster. <https://doc.dovecot.org/latest/core/admin/login_processes.html>
+  #service_restart_request_count = 1
+
+  # Number of processes to always keep waiting for more connections.
+  #process_min_avail = 0
+
+  # If you set service_restart_request_count=0, you probably need to grow this.
+  #vsz_limit = 64M
+#-#}
+
+#-#service managesieve {
+  # Max. number of ManageSieve processes (connections)
+  #process_limit = 1024
+#-#}
+
+# Service configuration
+
+#-#protocol sieve {
+  # Maximum ManageSieve command line length in bytes. ManageSieve usually does
+  # not involve overly long command lines, so this setting will not normally
+  # need adjustment
+  #managesieve_max_line_length = 65536
+
+  # Maximum number of ManageSieve connections allowed for a user from each IP
+  # address.
+  # NOTE: The username is compared case-sensitively.
+  #mail_max_userip_connections = 10
+
+  # Space separated list of plugins to load (none known to be useful so far).
+  # Do NOT try to load IMAP plugins here.
+  #mail_plugins =
+
+  # MANAGESIEVE logout format string:
+  #managesieve_logout_format = bytes=%{input}/%{output}
+
+  # To fool ManageSieve clients that are focused on CMU's timesieved you can
+  # specify the IMPLEMENTATION capability that Dovecot reports to clients.
+  # For example: 'Cyrus timsieved v2.2.13'
+  #managesieve_implementation_string = 'Cyrus timsieved v2.2.13'
+
+  # Explicitly specify the SIEVE and NOTIFY capability reported by the server
+  # before login. If left unassigned these will be reported dynamically
+  # according to what the Sieve interpreter supports by default (after login
+  # this may differ depending on the user).
+  #managesieve_sieve_capability {
+  #}
+  #managesieve_notify_capability {
+  #}
+
+  # The maximum number of compile errors that are returned to the client upon
+  # script upload or script verification.
+  #managesieve_max_compile_errors = 5
+
+  # Refer to 90-sieve.conf for script quota configuration and configuration of
+  # Sieve execution limits.
+#-#}

--- a/install/common/dovecot-24/sieve/90-sieve-extprograms.conf
+++ b/install/common/dovecot-24/sieve/90-sieve-extprograms.conf
@@ -1,0 +1,41 @@
+# Sieve Extprograms plugin configuration
+
+# Don't forget to add the sieve_extprograms plugin to the sieve_plugins setting.
+# Also enable the extensions you need (one or more of vnd.dovecot.pipe,
+# vnd.dovecot.filter and vnd.dovecot.execute) by adding these	to the
+# sieve_extensions or sieve_global_extensions settings. Restricting these
+# extensions to a global context using sieve_global_extensions is recommended.
+
+# The directory where the program sockets are located for the
+# vnd.dovecot.pipe, vnd.dovecot.filter and vnd.dovecot.execute extension
+# respectively. The name of each unix socket contained in that directory
+# directly maps to a program-name referenced from the Sieve script.
+#sieve_pipe_socket_dir = sieve-pipe
+#sieve_filter_socket_dir = sieve-filter
+#sieve_execute_socket_dir = sieve-execute
+
+# The directory where the scripts are located for direct execution by the
+# vnd.dovecot.pipe, vnd.dovecot.filter and vnd.dovecot.execute extension
+# respectively. The name of each script contained in that directory
+# directly maps to a program-name referenced from the Sieve script.
+#sieve_pipe_bin_dir = /usr/lib/dovecot/sieve-pipe
+#sieve_filter_bin_dir = /usr/lib/dovecot/sieve-filter
+#sieve_execute_bin_dir = /usr/lib/dovecot/sieve-execute
+
+# An example program service called 'do-something' to pipe messages to
+#service do-something {
+  # Define the executed script as parameter to the sieve service
+  #executable = script /usr/lib/dovecot/sieve-pipe/do-something.sh
+
+  # Use some unprivileged user for executing the program
+  #user = dovenull
+
+  # The unix socket located in the sieve_pipe_socket_dir (as defined in the 
+  # plugin {} section above)
+  #unix_listener sieve-pipe/do-something {
+    # LDA/LMTP must have access
+  #  user = vmail  
+  #  mode = 0600
+  #}
+#}
+

--- a/install/common/dovecot-24/sieve/90-sieve.conf
+++ b/install/common/dovecot-24/sieve/90-sieve.conf
@@ -1,0 +1,142 @@
+########################################
+# Dovecot conf file modified by Hestia #
+########################################
+
+sieve_plugins = sieve_imapsieve sieve_extprograms
+sieve_pipe_bin_dir = /etc/dovecot/sieve
+sieve_vacation_send_from_recipient = yes
+sieve_global_extensions = vnd.dovecot.pipe vnd.dovecot.environment
+
+sieve_script personal {
+  driver = file
+  path = ~/sieve
+  active_path = ~/dovecot.sieve
+}
+
+sieve_script global {
+  sieve_script_type = global
+  path = /etc/dovecot/sieve
+}
+
+##############################################
+# Original distribution files are located in #
+# /usr/share/dovecot/                        #
+#                                            #
+# Below is a copy of the original file.      #
+# All lines starting with #-# were already   #
+# uncommented in the original version        #
+##############################################
+
+##
+## Settings for the Sieve interpreter
+##
+
+# Do not forget to enable the Sieve plugin in 15-lda.conf and 20-lmtp.conf
+# by adding it to the respective mail_plugins { sieve = yes } settings.
+
+# See https://doc.dovecot.org/latest/core/plugins/sieve.html
+
+# Personal sieve script location
+#sieve_script personal {
+#  driver = file
+#  path = ~/sieve
+#  active_path = ~/.dovecot.sieve
+#}
+
+# Default sieve script location
+#sieve_script default {
+#  type = default
+#  name = default
+#  driver = file
+#  path = /etc/dovecot/sieve/default/
+#}
+
+
+# Which Sieve language extensions are available to users. By default, all
+# supported extensions are available, except for deprecated extensions or
+# those that are still under development. Some system administrators may want
+# to disable certain Sieve extensions or enable those that are not available
+# by default. This setting can use 'yes' and 'no' to specify differences relative
+# to the default. For example `imapflags = yes' will enable the
+# deprecated imapflags extension in addition to all extensions were already
+# enabled by default.
+#sieve_extensions {
+#  mboxmetadata = yes
+#  vnd.dovecot.debug = yes
+#}
+
+# Which Sieve language extensions are ONLY available in global scripts. This
+# can be used to restrict the use of certain Sieve extensions to administrator
+# control, for instance when these extensions can cause security concerns.
+# This setting has higher precedence than the `sieve_extensions' setting
+# (above), meaning that the extensions enabled with this setting are never
+# available to the user's personal script no matter what is specified for the
+# `sieve_extensions' setting. The syntax of this setting is similar to the
+# `sieve_extensions' setting, with the difference that extensions are
+# enabled or disabled for exclusive use in global scripts. Currently, no
+# extensions are marked as such by default.
+#sieve_global_extensions =
+
+# The Pigeonhole Sieve interpreter can have plugins of its own. Using this
+# setting, the used plugins can be specified. Check the Dovecot documentation
+# https://doc.dovecot.org/latest/core/plugins/sieve.html
+
+#sieve_plugins = sieve_imapsieve sieve_extprograms
+#sieve_pipe_bin_dir    = /usr/share/dovecot-pigeonhole/sieve
+#sieve_execute_bin_dir = /usr/share/dovecot-pigeonhole/sieve
+#sieve_global_extensions {
+#  vnd.dovecot.pipe = yes
+#  vnd.dovecot.execute = yes
+#}
+#imapsieve_url = 
+
+# The separator that is expected between the :user and :detail
+# address parts introduced by the subaddress extension. This may
+# also be a sequence of characters (e.g. '--'). The current
+# implementation looks for the separator from the left of the
+# localpart and uses the first one encountered. The :user part is
+# left of the separator and the :detail part is right. This setting
+# is also used by Dovecot's LMTP service.
+#recipient_delimiter = +-_
+
+# The maximum size of a Sieve script. The compiler will refuse to compile any
+# script larger than this limit. If set to 0, no limit on the script size is
+# enforced.
+#sieve_max_script_size = 1M
+
+# The maximum number of actions that can be performed during a single script
+# execution. If set to 0, no limit on the total number of actions is enforced.
+#sieve_max_actions = 32
+
+# The maximum number of redirect actions that can be performed during a single
+# script execution. If set to 0, no redirect actions are allowed.
+#sieve_max_redirects = 4
+
+# The maximum number of personal Sieve scripts a single user can have. If set
+# to 0, no limit on the number of scripts is enforced.
+# (Currently only relevant for ManageSieve)
+#sieve_quota_script_count = 0
+
+# The maximum amount of disk storage a single user's scripts may occupy. If
+# set to 0, no limit on the used amount of disk storage is enforced.
+# (Currently only relevant for ManageSieve)
+#sieve_quota_storage_size = 0
+
+
+#mailbox Spam {
+## From elsewhere to Spam folder
+#  sieve_script report-spam {
+#    type = before
+#    cause = copy
+#    path = /etc/dovecot/report-spam.sieve
+#  }
+#}
+
+## From Spam folder to elsewhere
+#imapsieve_from Spam {
+#  sieve_script report-ham {
+#    type = before
+#    cause = copy
+#    path = /etc/dovecot/report-ham.sieve
+#  }
+#}

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -31,7 +31,7 @@ HESTIA_COMMON_DIR="$HESTIA/install/common"
 VERBOSE='no'
 
 # Define software versions
-HESTIA_INSTALL_VER='1.10.0~alpha'
+HESTIA_INSTALL_VER='1.9.4'
 # Supported PHP versions
 multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" "8.3" "8.4")
 # One of the following PHP versions is required for Roundcube / phpmyadmin
@@ -39,9 +39,9 @@ multiphp_required=("7.3" "7.4" "8.0" "8.1" "8.2" "8.3")
 # Default PHP version if none supplied
 fpm_v="8.3"
 # MariaDB version
-mariadb_v="11.8"
+mariadb_v="11.4"
 # Node.js version
-node_v="24"
+node_v="20"
 
 # Defining software pack for all distros
 software="acl apache2 apache2-suexec-custom apache2-utils at awstats bc bind9 bsdmainutils bsdutils
@@ -865,7 +865,7 @@ fi
 
 # Installing HestiaCP repo
 echo "[ * ] Hestia Control Panel"
-echo "#deb [arch=$ARCH signed-by=/usr/share/keyrings/hestia-keyring.gpg] https://$RHOST/ $codename main" > $apt/hestia.list
+echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/hestia-keyring.gpg] https://$RHOST/ $codename main" > $apt/hestia.list
 gpg --no-default-keyring --keyring /usr/share/keyrings/hestia-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A189E93654F0B0E5 > /dev/null 2>&1
 
 # Installing Node.js repo
@@ -889,25 +889,22 @@ echo
 # Updating system
 echo -ne "Updating currently installed packages, please wait... "
 apt-get -qq update
-apt-get -y upgrade
-
-# For now don't hide the out put
-#>> $LOG &
-#BACK_PID=$!
+apt-get -y upgrade >> $LOG &
+BACK_PID=$!
 
 # Check if package installation is done, print a spinner
-#spin_i=1
-#while kill -0 $BACK_PID > /dev/null 2>&1; do
-#	printf "\b${spinner:spin_i++%${#spinner}:1}"
-#	sleep 0.5
-#done
+spin_i=1
+while kill -0 $BACK_PID > /dev/null 2>&1; do
+	printf "\b${spinner:spin_i++%${#spinner}:1}"
+	sleep 0.5
+done
 
 # Do a blank echo to get the \n back
-echo "Jaap"
+echo
 
 # Check Installation result
-#wait $BACK_PID
-#check_result $? 'apt-get upgrade failed'
+wait $BACK_PID
+check_result $? 'apt-get upgrade failed'
 
 #----------------------------------------------------------#
 #                         Backup                           #
@@ -1104,23 +1101,22 @@ chmod a+x /usr/sbin/policy-rc.d
 echo "The installer is now downloading and installing all required packages."
 echo -ne "NOTE: This process may take 10 to 15 minutes to complete, please wait... "
 echo
-apt-get -y install $software
-#> $LOG
-#BACK_PID=$!
+apt-get -y install $software > $LOG
+BACK_PID=$!
 
 # Check if package installation is done, print a spinner
-#spin_i=1
-#while kill -0 $BACK_PID > /dev/null 2>&1; do
-#	printf "\b${spinner:spin_i++%${#spinner}:1}"
-#	sleep 0.5
-#done
+spin_i=1
+while kill -0 $BACK_PID > /dev/null 2>&1; do
+	printf "\b${spinner:spin_i++%${#spinner}:1}"
+	sleep 0.5
+done
 
 # Do a blank echo to get the \n back
 echo
 
 # Check Installation result
-#wait $BACK_PID
-#check_result $? "apt-get install failed"
+wait $BACK_PID
+check_result $? "apt-get install failed"
 
 echo
 echo "========================================================================"
@@ -1482,7 +1478,7 @@ echo "[ * ] Configuring OpenSSL to improve TLS performance..."
 tls13_ciphers="TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384"
 if [ "$release" = "11" ]; then
 	sed -i '/^system_default = system_default_sect$/a system_default = hestia_openssl_sect\n\n[hestia_openssl_sect]\nCiphersuites = '"$tls13_ciphers"'\nOptions = PrioritizeChaCha' /etc/ssl/openssl.cnf
-else
+elif [ "$release" = "12" ] || [ "$release" = "13" ]; then
 	if ! grep -qw "^ssl_conf = ssl_sect$" /etc/ssl/openssl.cnf 2> /dev/null; then
 		sed -i '/providers = provider_sect$/a ssl_conf = ssl_sect' /etc/ssl/openssl.cnf
 	fi
@@ -1499,12 +1495,12 @@ $HESTIA/bin/v-generate-ssl-cert $(hostname) '' 'US' 'California' \
 	'San Francisco' 'Hestia Control Panel' 'IT' > /tmp/hst.pem
 
 crt_end=$(grep -n "END CERTIFICATE-" /tmp/hst.pem | cut -f 1 -d:)
-if [ "$release" = "11" ]; then
-	key_start=$(grep -n "BEGIN RSA" /tmp/hst.pem | cut -f 1 -d:)
-	key_end=$(grep -n "END RSA" /tmp/hst.pem | cut -f 1 -d:)
-else
+if [ "$release" = "12" ] || [ "$release" = "13" ]; then
 	key_start=$(grep -n "BEGIN PRIVATE KEY" /tmp/hst.pem | cut -f 1 -d:)
 	key_end=$(grep -n "END PRIVATE KEY" /tmp/hst.pem | cut -f 1 -d:)
+else
+	key_start=$(grep -n "BEGIN RSA" /tmp/hst.pem | cut -f 1 -d:)
+	key_end=$(grep -n "END RSA" /tmp/hst.pem | cut -f 1 -d:)
 fi
 
 # Adding SSL certificate
@@ -1742,7 +1738,7 @@ if [ "$proftpd" = 'yes' ]; then
 		fi
 	fi
 
-	if [ "$release" -eq 12 ] || [ "$release" -eq 13 ]; then
+	if [ "$release" -eq 12 ]; then
 		systemctl disable --now proftpd.socket
 		systemctl enable --now proftpd.service
 	fi
@@ -1944,10 +1940,6 @@ if [ "$named" = 'yes' ]; then
 			systemctl restart apparmor >> $LOG
 		fi
 	fi
-	# Debian 13 removed the named.conf.default-zones file if doesn't exsists remove it from the config file
-	if [ ! -f /etc/bind/named.conf.default-zones ]; then
-		sed -i "/^include.*named.conf.default-zones/d" /etc/bind/named.conf
-	fi
 	update-rc.d bind9 defaults > /dev/null 2>&1
 	systemctl start bind9
 	check_result $? "bind9 start failed"
@@ -2015,28 +2007,30 @@ fi
 #----------------------------------------------------------#
 
 if [ "$dovecot" = 'yes' ]; then
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
 	echo "[ * ] Configuring Dovecot POP/IMAP mail server..."
 	gpasswd -a dovecot mail > /dev/null 2>&1
-	if [ $release = "13" ]; then
-		# Debian Trixie uses 2.4.1
-		cp -rf $HESTIA_COMMON_DIR/dovecot/2.4.1 /etc/dovecot/
+	mkdir -p /etc/dovecot/conf.d/
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		cp -f $HESTIA_COMMON_DIR/dovecot-24/dovecot.conf /etc/dovecot/
+		cp -f $HESTIA_COMMON_DIR/dovecot-24/conf.d/* /etc/dovecot/conf.d/
 	else
-		cp -rf $HESTIA_COMMON_DIR/dovecot/2.3 /etc/dovecot/
+		cp -f $HESTIA_COMMON_DIR/dovecot/dovecot.conf /etc/dovecot/
+		cp -f $HESTIA_COMMON_DIR/dovecot/conf.d/* /etc/dovecot/conf.d/
+		rm -f /etc/dovecot/conf.d/15-mailboxes.conf
 	fi
 	cp -f $HESTIA_INSTALL_DIR/logrotate/dovecot /etc/logrotate.d/
-	rm -f /etc/dovecot/conf.d/15-mailboxes.conf
 	chown -R root:root /etc/dovecot*
 	touch /var/log/dovecot.log
 	chown -R dovecot:mail /var/log/dovecot.log
 	chmod 660 /var/log/dovecot.log
 	# Alter config for 2.2
-	if [ "$version" = "2.2" ]; then
+	if [ "$dovecot_version" = "2.2" ]; then
 		echo "[ * ] Downgrade dovecot config to sync with 2.2 settings"
 		sed -i 's|#ssl_dh_parameters_length = 4096|ssl_dh_parameters_length = 4096|g' /etc/dovecot/conf.d/10-ssl.conf
 		sed -i 's|ssl_dh = </etc/ssl/dhparam.pem|#ssl_dh = </etc/ssl/dhparam.pem|g' /etc/dovecot/conf.d/10-ssl.conf
 		sed -i 's|ssl_min_protocol = TLSv1.2|ssl_protocols = !SSLv3 !TLSv1 !TLSv1.1|g' /etc/dovecot/conf.d/10-ssl.conf
 	fi
-
 	update-rc.d dovecot defaults
 	systemctl start dovecot >> $LOG
 	check_result $? "dovecot start failed"
@@ -2183,19 +2177,35 @@ if [ "$sieve" = 'yes' ]; then
 
 	echo "[ * ] Installing Sieve Mail Filter..."
 
-	# dovecot.conf install
-	sed -i "s/namespace/service stats \{\n  unix_listener stats-writer \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}\n\nnamespace/g" /etc/dovecot/dovecot.conf
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		# dovecot conf files
+		# dovecot.conf install
+		sed -i -E 's/protocols = imap/protocols = sieve imap/' /etc/dovecot/dovecot.conf
+		#  10-master.conf
+		sed -i -E -z 's/    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\n  unix_listener auth-master {\n    group = mail\n    mode = 0660\n    user = dovecot\n  }\n\}/' /etc/dovecot/conf.d/10-master.conf
+		#  15-lda.conf
+		sed -i '/^protocol lda {$/a\  mail_plugins = mail_compress quota sieve' /etc/dovecot/conf.d/15-lda.conf
+		#  20-imap.conf
+		sed -i "s/quota imap_quota/quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+		# replace dovecot-sieve config files
+		cp -f "$HESTIA_COMMON_DIR"/dovecot-24/sieve/* /etc/dovecot/conf.d
 
-	# Dovecot conf files
-	#  10-master.conf
-	sed -i -E -z "s/  }\n  user = dovecot\n}/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
-	#  15-lda.conf
-	sed -i "s/\#mail_plugins = \\\$mail_plugins/mail_plugins = \$mail_plugins quota sieve\n  auth_socket_path = \/var\/run\/dovecot\/auth-master/g" /etc/dovecot/conf.d/15-lda.conf
-	#  20-imap.conf
-	sed -i "s/mail_plugins = quota imap_quota/mail_plugins = quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+	else
+		# dovecot.conf install
+		sed -i "s/namespace/service stats \{\n  unix_listener stats-writer \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}\n\nnamespace/g" /etc/dovecot/dovecot.conf
 
-	# Replace dovecot-sieve config files
-	cp -f $HESTIA_COMMON_DIR/dovecot/sieve/* /etc/dovecot/conf.d
+		# Dovecot conf files
+		#  10-master.conf
+		sed -i -E -z "s/  }\n  user = dovecot\n}/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
+		#  15-lda.conf
+		sed -i "s/\#mail_plugins = \\\$mail_plugins/mail_plugins = \$mail_plugins quota sieve\n  auth_socket_path = \/var\/run\/dovecot\/auth-master/g" /etc/dovecot/conf.d/15-lda.conf
+		#  20-imap.conf
+		sed -i "s/mail_plugins = quota imap_quota/mail_plugins = quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+
+		# Replace dovecot-sieve config files
+		cp -f $HESTIA_COMMON_DIR/dovecot/sieve/* /etc/dovecot/conf.d
+	fi
 
 	# Dovecot default file install
 	echo -e "require [\"fileinto\"];\n# rule:[SPAM]\nif header :contains \"X-Spam-Flag\" \"YES\" {\n    fileinto \"INBOX.Spam\";\n}\n" > /etc/dovecot/sieve/default

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -2212,6 +2212,7 @@ if [ "$sieve" = 'yes' ]; then
 	fi
 
 	# Dovecot default file install
+	mkdir -p /etc/dovecot/sieve/
 	echo -e "require [\"fileinto\"];\n# rule:[SPAM]\nif header :contains \"X-Spam-Flag\" \"YES\" {\n    fileinto \"INBOX.Spam\";\n}\n" > /etc/dovecot/sieve/default
 
 	# exim4 install

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -6,7 +6,7 @@
 # https://www.hestiacp.com/
 #
 # Currently Supported Versions:
-# Ubuntu 20.04, 22.04, 24.04 LTS
+# Ubuntu 22.04, 24.04 LTS
 #
 # ======================================================== #
 
@@ -31,7 +31,7 @@ HESTIA_COMMON_DIR="$HESTIA/install/common"
 VERBOSE='no'
 
 # Define software versions
-HESTIA_INSTALL_VER='1.9.4'
+HESTIA_INSTALL_VER='1.10.0~alpha'
 # Supported PHP versions
 multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" "8.3" "8.4")
 # One of the following PHP versions is required for Roundcube / phpmyadmin
@@ -39,9 +39,9 @@ multiphp_required=("7.3" "7.4" "8.0" "8.1" "8.2" "8.3")
 # Default PHP version if none supplied
 fpm_v="8.3"
 # MariaDB version
-mariadb_v="11.4"
+mariadb_v="11.8"
 # Node.js version
-node_v="20"
+node_v="24"
 
 # Defining software pack for all distros
 software="acl apache2 apache2.2-common apache2-suexec-custom apache2-utils apparmor-utils at awstats bc bind9 bsdmainutils bsdutils
@@ -1060,9 +1060,6 @@ if [ -d "$withdebs" ]; then
 	software=$(echo "$software" | sed -e "s/hestia-web-terminal//")
 	software=$(echo "$software" | sed -e "s/hestia=${HESTIA_INSTALL_VER}//")
 fi
-if [ "$release" = '20.04' ]; then
-	software=$(echo "$software" | sed -e "s/libzip4/libzip5/")
-fi
 if [ "$release" = '24.04' ]; then
 	software=$(echo "$software" | sed -e "s/libzip4/libzip4t64/")
 fi
@@ -1501,16 +1498,7 @@ $HESTIA/bin/v-change-sys-hostname $servername > /dev/null 2>&1
 # Configuring global OpenSSL options
 echo "[ * ] Configuring OpenSSL to improve TLS performance..."
 tls13_ciphers="TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384"
-if [ "$release" = "20.04" ]; then
-	if ! grep -qw "^openssl_conf = default_conf$" /etc/ssl/openssl.cnf 2> /dev/null; then
-		sed -i '/^oid_section		= new_oids$/a \\n# System default\nopenssl_conf = default_conf' /etc/ssl/openssl.cnf
-	fi
-	if ! grep -qw "^[default_conf]$" /etc/ssl/openssl.cnf 2> /dev/null; then
-		sed -i '$a [default_conf]\nssl_conf = ssl_sect\n\n[ssl_sect]\nsystem_default = hestia_openssl_sect\n\n[hestia_openssl_sect]\nCiphersuites = '"$tls13_ciphers"'\nOptions = PrioritizeChaCha' /etc/ssl/openssl.cnf
-	elif grep -qw "^system_default = system_default_sect$" /etc/ssl/openssl.cnf 2> /dev/null; then
-		sed -i '/^system_default = system_default_sect$/a system_default = hestia_openssl_sect\n\n[hestia_openssl_sect]\nCiphersuites = '"$tls13_ciphers"'\nOptions = PrioritizeChaCha' /etc/ssl/openssl.cnf
-	fi
-elif [ "$release" = "22.04" ]; then
+if [ "$release" = "22.04" ]; then
 	sed -i '/^system_default = system_default_sect$/a system_default = hestia_openssl_sect\n\n[hestia_openssl_sect]\nCiphersuites = '"$tls13_ciphers"'\nOptions = PrioritizeChaCha' /etc/ssl/openssl.cnf
 elif [ "$release" = "24.04" ]; then
 	if ! grep -qw "^ssl_conf = ssl_sect$" /etc/ssl/openssl.cnf 2> /dev/null; then
@@ -1530,13 +1518,8 @@ $HESTIA/bin/v-generate-ssl-cert $(hostname) '' 'US' 'California' \
 
 # Parsing certificate file
 crt_end=$(grep -n "END CERTIFICATE-" /tmp/hst.pem | cut -f 1 -d:)
-if [ "$release" != "20.04" ]; then
-	key_start=$(grep -n "BEGIN PRIVATE KEY" /tmp/hst.pem | cut -f 1 -d:)
-	key_end=$(grep -n "END PRIVATE KEY" /tmp/hst.pem | cut -f 1 -d:)
-else
-	key_start=$(grep -n "BEGIN RSA" /tmp/hst.pem | cut -f 1 -d:)
-	key_end=$(grep -n "END RSA" /tmp/hst.pem | cut -f 1 -d:)
-fi
+key_start=$(grep -n "BEGIN PRIVATE KEY" /tmp/hst.pem | cut -f 1 -d:)
+key_end=$(grep -n "END PRIVATE KEY" /tmp/hst.pem | cut -f 1 -d:)
 
 # Adding SSL certificate
 echo "[ * ] Adding SSL certificate to Hestia Control Panel..."
@@ -1762,21 +1745,9 @@ if [ "$proftpd" = 'yes' ]; then
 	cp -f $HESTIA_INSTALL_DIR/proftpd/proftpd.conf /etc/proftpd/
 	cp -f $HESTIA_INSTALL_DIR/proftpd/tls.conf /etc/proftpd/
 
-	# Disable TLS 1.3 support for ProFTPD versions older than v1.3.7a
-	if [ "$release" = '20.04' ]; then
-		sed -i 's/TLSProtocol                             TLSv1.2 TLSv1.3/TLSProtocol                             TLSv1.2/' /etc/proftpd/tls.conf
-	fi
-
 	update-rc.d proftpd defaults > /dev/null 2>&1
 	systemctl start proftpd >> $LOG
 	check_result $? "proftpd start failed"
-
-	if [ "$release" != '20.04' ]; then
-		unit_files="$(systemctl list-unit-files | grep proftpd)"
-		if [[ "$unit_files" =~ "disabled" ]]; then
-			systemctl enable proftpd
-		fi
-	fi
 fi
 
 #----------------------------------------------------------#

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -2188,6 +2188,7 @@ if [ "$sieve" = 'yes' ]; then
 	fi
 
 	# Dovecot default file install
+	mkdir -p /etc/dovecot/sieve/
 	echo -e "require [\"fileinto\"];\n# rule:[SPAM]\nif header :contains \"X-Spam-Flag\" \"YES\" {\n    fileinto \"INBOX.Spam\";\n}\n" > /etc/dovecot/sieve/default
 
 	# exim4 install

--- a/install/upgrade/manual/install_sieve.sh
+++ b/install/upgrade/manual/install_sieve.sh
@@ -2,7 +2,7 @@
 # info: Install / remove  sieve / manage-sieve for Dovecot
 #
 # Thos function installs manage-sieve functionality for dovecot.
-
+#shellcheck disable=SC1091
 #----------------------------------------------------------#
 #                    Variable&Function                     #
 #----------------------------------------------------------#
@@ -11,50 +11,66 @@
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
-source $HESTIA/func/main.sh
+source "$HESTIA"/func/main.sh
 # load config file
-source_conf "$HESTIA/conf/hestia.conf"
-source_conf "$HESTIA/install/upgrade/upgrade.conf"
+source_conf "$HESTIA"/conf/hestia.conf
+source_conf "$HESTIA"/install/upgrade/upgrade.conf
+remove="$1"
 
 #----------------------------------------------------------#
 #                    Verifications                         #
 #----------------------------------------------------------#
 
 #check if string already exists
-if grep "dovecot_virtual_delivery" /etc/exim4/exim4.conf.template; then
-	echo "Plugin allready enabled"
-	exit 0
+if [[ "$remove" != "remove" ]]; then
+	if grep -q "dovecot_virtual_delivery" /etc/exim4/exim4.conf.template; then
+		echo "Dovecot virtual delivery already enabled in Exim4"
+		echo "You can force uninstallation using the argument: remove"
+		echo "Example: $0 remove"
+		exit 0
+	fi
 fi
-
 #----------------------------------------------------------#
 #                       Action                             #
 #----------------------------------------------------------#
 
-HAS_DOVECOT_SIEVE_INSTALLED=$(dpkg --get-selections dovecot-sieve | grep dovecot-sieve | wc -l)
+HAS_DOVECOT_SIEVE_INSTALLED=$(dpkg --get-selections dovecot-managesieved | grep -c dovecot-managesieved)
 
 # Folder paths
 RC_INSTALL_DIR="/var/lib/roundcube"
 RC_CONFIG_DIR="/etc/roundcube"
+dovecot_version="$(dovecot --version | cut -d '.' -f1,2)"
 
 # If we want to install sieve
 if [ "$HAS_DOVECOT_SIEVE_INSTALLED" = "0" ]; then
-
+	echo "[*] Installing and configuring Sieve and ManageSieve"
 	# if sieve is not installed... install it.
-	apt-get -qq install dovecot-sieve dovecot-managesieved -y
-
-	# dovecot.conf install
-	sed -i "s/namespace/service stats \{\n  unix_listener stats-writer \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}\n\nnamespace/g" /etc/dovecot/dovecot.conf
-
-	# dovecot conf files
-	#  10-master.conf
-	sed -i -E -z "s/  }\n  user = dovecot\n}/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
-	#  15-lda.conf
-	sed -i "s/\#mail_plugins = \\\$mail_plugins/mail_plugins = \$mail_plugins quota sieve\n  auth_socket_path = \/var\/run\/dovecot\/auth-master/g" /etc/dovecot/conf.d/15-lda.conf
-	#  20-imap.conf
-	sed -i "s/mail_plugins = quota imap_quota/mail_plugins = quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
-
-	# replace dovecot-sieve config files
-	cp -f $HESTIA_COMMON_DIR/dovecot/sieve/* /etc/dovecot/conf.d
+	apt-get -qq install dovecot-sieve dovecot-managesieved -y > /dev/null
+	if [[ "$dovecot_version" = "2.4" ]]; then
+		# dovecot conf files
+		# dovecot.conf install
+		sed -i -E 's/protocols = imap/protocols = sieve imap/' /etc/dovecot/dovecot.conf
+		#  10-master.conf
+		sed -i -E -z 's/    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\n  unix_listener auth-master {\n    group = mail\n    mode = 0660\n    user = dovecot\n  }\n\}/' /etc/dovecot/conf.d/10-master.conf
+		#  15-lda.conf
+		sed -i '/^protocol lda {$/a\  mail_plugins = mail_compress quota sieve' /etc/dovecot/conf.d/15-lda.conf
+		#  20-imap.conf
+		sed -i "s/quota imap_quota/quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+		# replace dovecot-sieve config files
+		cp -f "$HESTIA_COMMON_DIR"/dovecot-24/sieve/* /etc/dovecot/conf.d
+	else
+		# dovecot.conf install
+		sed -i "s/namespace/service stats \{\n  unix_listener stats-writer \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}\n\nnamespace/g" /etc/dovecot/dovecot.conf
+		# dovecot conf files
+		#  10-master.conf
+		sed -i -E -z "s/  }\n  user = dovecot\n}/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
+		#  15-lda.conf
+		sed -i "s/\#mail_plugins = \\\$mail_plugins/mail_plugins = \$mail_plugins quota sieve\n  auth_socket_path = \/var\/run\/dovecot\/auth-master/g" /etc/dovecot/conf.d/15-lda.conf
+		#  20-imap.conf
+		sed -i "s/mail_plugins = quota imap_quota/mail_plugins = quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+		# replace dovecot-sieve config files
+		cp -f "$HESTIA_COMMON_DIR"/dovecot/sieve/* /etc/dovecot/conf.d
+	fi
 
 	# dovecot default file install
 	mkdir -p /etc/dovecot/sieve
@@ -62,20 +78,19 @@ if [ "$HAS_DOVECOT_SIEVE_INSTALLED" = "0" ]; then
 
 	# exim4 install
 	sed -i "s/\stransport = local_delivery/ transport = dovecot_virtual_delivery/" /etc/exim4/exim4.conf.template
-
 	sed -i "s/address_pipe:/dovecot_virtual_delivery:\n  driver = pipe\n  command = \/usr\/lib\/dovecot\/dovecot-lda -e -d \${extract{1}{:}{\${lookup{\$local_part}lsearch{\/etc\/exim4\/domains\/\${lookup{\$domain}dsearch{\/etc\/exim4\/domains\/}}\/accounts}}}}@\${lookup{\$domain}dsearch{\/etc\/exim4\/domains\/}}\n  delivery_date_add\n  envelope_to_add\n  return_path_add\n  log_output = true\n  log_defer_output = true\n  user = \${extract{2}{:}{\${lookup{\$local_part}lsearch{\/etc\/exim4\/domains\/\${lookup{\$domain}dsearch{\/etc\/exim4\/domains\/}}\/passwd}}}}\n  group = mail\n  return_output\n\naddress_pipe:/g" /etc/exim4/exim4.conf.template
 
 	# roundcube install
-	mkdir -p $RC_CONFIG_DIR/plugins/managesieve
+	mkdir -p "$RC_CONFIG_DIR"/plugins/managesieve
 
-	cp -f $HESTIA_COMMON_DIR/roundcube/plugins/config_managesieve.inc.php $RC_CONFIG_DIR/plugins/managesieve/config.inc.php
-	ln -s $RC_CONFIG_DIR/plugins/managesieve/config.inc.php $RC_INSTALL_DIR/plugins/managesieve/config.inc.php
+	cp -f "$HESTIA_COMMON_DIR"/roundcube/plugins/config_managesieve.inc.php "$RC_CONFIG_DIR"/plugins/managesieve/config.inc.php
+	ln -s "$RC_CONFIG_DIR"/plugins/managesieve/config.inc.php "$RC_INSTALL_DIR"/plugins/managesieve/config.inc.php
 
 	# permission changes
 	chown -R dovecot:mail /var/log/dovecot.log
 	chmod 660 /var/log/dovecot.log
 
-	chown -R root:www-data $RC_CONFIG_DIR/
+	chown -R hestiamail:www-data "$RC_CONFIG_DIR"/
 	chmod 751 -R $RC_CONFIG_DIR
 
 	chmod 644 $RC_CONFIG_DIR/plugins/managesieve/config.inc.php
@@ -87,19 +102,34 @@ if [ "$HAS_DOVECOT_SIEVE_INSTALLED" = "0" ]; then
 	systemctl restart exim4 > /dev/null 2>&1
 else
 	# Uninstall sieve if it exist
+	echo "[*] Uninstalling Sieve configuration and ManageSieve"
 	if [ -f "/etc/dovecot/conf.d/90-sieve.conf" ]; then
+		if [[ "$dovecot_version" = "2.4" ]]; then
+			# dovecot conf files
+			# dovecot.conf install
+			sed -i -E 's/protocols = sieve imap/protocols = imap/' /etc/dovecot/dovecot.conf
+			#  10-master.conf
+			sed -i -E -z 's/    user = dovecot\n  \}\n\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\}/' /etc/dovecot/conf.d/10-master.conf
+			#sed -i -E -z "s/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
+			#  15-lda.conf
+			sed -i '/.*mail_plugins = quota sieve/d' /etc/dovecot/conf.d/15-lda.conf
+			#sed -i -E -z "s/mail_plugins = \\\$mail_plugins sieve\n  auth_socket_path = \/run\/dovecot\/auth-master/\#mail_plugins = \$mail_plugins/g" /etc/dovecot/conf.d/15-lda.conf
+			#  20-imap.conf
+			sed -i "s/quota imap_quota imap_sieve/quota imap_quota/" /etc/dovecot/conf.d/20-imap.conf
+			#sed -i "s/mail_plugins = quota imap_quota imap_sieve/mail_plugins = quota imap_quota/g" /etc/dovecot/conf.d/20-imap.conf
+		else
+			# dovecot.conf multiline sed
+			sed -i -E -z "s/service stats \{\n  unix_listener stats-writer \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}\n\n//g" /etc/dovecot/dovecot.conf
 
-		# dovecot.conf multiline sed
-		sed -i -E -z "s/service stats \{\n  unix_listener stats-writer \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n\}\n\n//g" /etc/dovecot/dovecot.conf
+			# dovecot conf files
+			#  10-master.conf
+			sed -i -E -z "s/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
+			#  15-lda.conf
+			sed -i -E -z "s/mail_plugins = \\\$mail_plugins sieve\n  auth_socket_path = \/run\/dovecot\/auth-master/\#mail_plugins = \$mail_plugins/g" /etc/dovecot/conf.d/15-lda.conf
+			#  20-imap.conf
+			sed -i "s/mail_plugins = quota imap_quota imap_sieve/mail_plugins = quota imap_quota/g" /etc/dovecot/conf.d/20-imap.conf
 
-		# dovecot conf files
-		#  10-master.conf
-		sed -i -E -z "s/  \}\n  unix_listener auth-master \{\n    group = mail\n    mode = 0660\n    user = dovecot\n  \}\n  user = dovecot\n\}/  \}\n  user = dovecot\n\}/g" /etc/dovecot/conf.d/10-master.conf
-		#  15-lda.conf
-		sed -i -E -z "s/mail_plugins = \\\$mail_plugins sieve\n  auth_socket_path = \/run\/dovecot\/auth-master/\#mail_plugins = \$mail_plugins/g" /etc/dovecot/conf.d/15-lda.conf
-		#  20-imap.conf
-		sed -i "s/mail_plugins = quota imap_quota imap_sieve/mail_plugins = quota imap_quota/g" /etc/dovecot/conf.d/20-imap.conf
-
+		fi
 		# Delete dovecot-sieve config files
 		rm -f /etc/dovecot/conf.d/20-managesieve.conf
 		rm -f /etc/dovecot/conf.d/90-sieve-extprograms.conf
@@ -109,12 +139,14 @@ else
 		rm -r -f /etc/dovecot/sieve
 
 		# If sieve is installed... remove it.
-		apt-get -qq remove --purge dovecot-sieve -y
-
+		if [[ "$dovecot_version" = "2.4" ]]; then
+			apt-get -qq remove --purge dovecot-managesieved -y > /dev/null
+		else
+			apt-get -qq remove --purge dovecot-sieve -y > /dev/null
+		fi
 		# Exim4
 		sed -i "s/\stransport = dovecot_virtual_delivery/ transport = local_delivery/" /etc/exim4/exim4.conf.template
-		sed -i "s/dovecot_virtual_delivery:\n  driver = pipe\n  command = \/usr\/lib\/dovecot\/dovecot-lda -e -d \${extract{1}{:}{\${lookup{\$local_part}lsearch{\/etc\/exim4\/domains\/\${lookup{\$domain}dsearch{\/etc\/exim4\/domains/}}\/accounts}}}}@\${lookup{\$domain}dsearch{\/etc\/exim4\/domains\/}}\n  delivery_date_add\n  envelope_to_add\n  return_path_add\n  log_output = true\n  log_defer_output = true\n  user = \${extract{2}{:}{\${lookup{\$local_part}lsearch{\/etc\/exim4\/domains\/\${lookup{\$domain}dsearch{\/etc\/exim4\/domains\/}}\/passwd}}}}\n  group = mail\n  return_output\n//g" /etc/exim4/exim4.conf.template
-
+		sed -i -z "s|dovecot_virtual_delivery:\n  driver = pipe\n  command = /usr/lib/dovecot/dovecot-lda -e -d \${extract{1}{:}{\${lookup{\$local_part}lsearch{/etc/exim4/domains/\${lookup{\$domain}dsearch{/etc/exim4/domains/}}/accounts}}}}@\${lookup{\$domain}dsearch{/etc/exim4/domains/}}\n  delivery_date_add\n  envelope_to_add\n  return_path_add\n  log_output = true\n  log_defer_output = true\n  user = \${extract{2}{:}{\${lookup{\$local_part}lsearch{/etc/exim4/domains/\${lookup{\$domain}dsearch{/etc/exim4/domains/}}/passwd}}}}\n  group = mail\n  return_output\n||g" /etc/exim4/exim4.conf.template
 		# Roundcube
 		rm -f -r $RC_CONFIG_DIR/plugins/managesieve
 		rm -f $RC_INSTALL_DIR/plugins/managesieve/config.inc.php

--- a/install/upgrade/versions/1.x.x.sh
+++ b/install/upgrade/versions/1.x.x.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.x.x
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### upgrade_config_set_value only accepts true or false.                    #######
+#######                                                                         #######
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+
+if [ -f /etc/os-release ]; then
+	source /etc/os-release
+fi
+
+# If Dovecot is version 2.4 and Debian is Trixie (13), replace Dovecot's configuration and rebuild users
+dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+if [[ "$ID" == "debian" && "$VERSION_ID" == "13" && "$dovecot_version" = "2.4" ]]; then
+	if grep -q 'modified by Hestia' /etc/dovecot/dovecot.conf \
+		&& grep -q 'ssl_server_cert_file = /usr/local/hestia' /etc/dovecot/conf.d/10-ssl.conf; then
+		# as Dovecot is already using the new conf, do nothing"
+		upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
+	else
+		cp -f "$HESTIA_COMMON_DIR"/dovecot-24/dovecot.conf /etc/dovecot/
+		cp -f "$HESTIA_COMMON_DIR"/dovecot-24/conf.d/* /etc/dovecot/conf.d/
+		# rebuild users to apply new dovecot conf
+		upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'true'
+		# if sieve is installed, replace dovecot conf files
+		HAS_DOVECOT_SIEVE_INSTALLED=$(dpkg --get-selections dovecot-managesieved | grep -c dovecot-managesieved)
+		if [ "$HAS_DOVECOT_SIEVE_INSTALLED" = "0" ]; then
+			# dovecot.conf install
+			sed -i -E 's/protocols = imap/protocols = sieve imap/' /etc/dovecot/dovecot.conf
+			#  10-master.conf
+			sed -i -E -z 's/    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\n  unix_listener auth-master {\n    group = mail\n    mode = 0660\n    user = dovecot\n  }\n\}/' /etc/dovecot/conf.d/10-master.conf
+			#  15-lda.conf
+			sed -i '/^protocol lda {$/a\  mail_plugins = mail_compress quota sieve' /etc/dovecot/conf.d/15-lda.conf
+			#  20-imap.conf
+			sed -i "s/quota imap_quota/quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+			# replace dovecot-sieve config files
+			cp -f "$HESTIA_COMMON_DIR"/dovecot-24/sieve/* /etc/dovecot/conf.d
+		fi
+		chown -R root:root /etc/dovecot/
+	fi
+else
+	upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
+fi

--- a/install/upgrade/versions/1.x.x.sh
+++ b/install/upgrade/versions/1.x.x.sh
@@ -40,7 +40,7 @@ if [[ "$ID" == "debian" && "$VERSION_ID" == "13" && "$dovecot_version" = "2.4" ]
 		upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'true'
 		# if sieve is installed, replace dovecot conf files
 		HAS_DOVECOT_SIEVE_INSTALLED=$(dpkg --get-selections dovecot-managesieved | grep -c dovecot-managesieved)
-		if [ "$HAS_DOVECOT_SIEVE_INSTALLED" = "0" ]; then
+		if [ "$HAS_DOVECOT_SIEVE_INSTALLED" = "1" ]; then
 			# dovecot.conf install
 			sed -i -E 's/protocols = imap/protocols = sieve imap/' /etc/dovecot/dovecot.conf
 			#  10-master.conf


### PR DESCRIPTION
Remove the python3-based yescrypt hash validation since the crypt module was removed in Python 3.13, and switch to using mkpasswd for password verification instead.