### PR TITLE
rename old admin user under delete user notification test

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -514,7 +514,7 @@ function check_ip_not_banned(){
   assert_output --partial "1,\"Test message\",\"Message\",yes"
 }
 @test "User: Delete user notification" {
-  run v-delete-user-notification admin 1
+  run v-delete-user-notification $user 1
   assert_success
   refute_output
 }


### PR DESCRIPTION
User notification test uses old hard coden 'admin' user to test. On newer systems with other admin user than 'admin' this test fails: False positive
