### PR TITLE
Adjustment under 'Add domain record SRV' test after 'harden dns record validation' #5197

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -1412,13 +1412,13 @@ function check_ip_not_banned(){
 
 @test "DNS: Add domain record SRV" {
     run v-delete-dns-record $user $domain 50
-    run v-add-dns-record $user $domain '_test_domain' SRV mx.hestiacp.com  '' 50
+    run v-add-dns-record $user $domain '_test_domain' SRV '10 5 443 mx.hestiacp.com'  '' 50
     assert_success
     refute_output
 
     assert_file_contains "$HOMEDIR/$user/conf/dns/${domain}.db" "mx.hestiacp.com."
 
-    run v-change-dns-record $user $domain 50 '_test.domain' SRV mx.hestia.com
+    run v-change-dns-record $user $domain 50 '_test.domain' SRV '10 5 443 mx.hestia.com'
     assert_success
     refute_output
 


### PR DESCRIPTION
After commit a74babb 'harden dns record validation' #5197 the test 'DNS: Add domain record SRV' fails due to wrong call parameters. This PR corrects the call parameters under test/test.bats
Idea and implementing by sahsanu. PR by asmcc
