### PR TITLE
Fix FileGator 7.13.4 session migrate incompatibility in Hestia

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
+++ b/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
@@ -29,7 +29,7 @@ class SessionStorage implements Service, SessionStorageInterface {
 		if (!$this->getSession()) {
 			$handler = $config["handler"];
 			$session = new Session($handler());
-			//$session->setName('filegator');
+			//$session->setName("filegator");
 			$this->setSession($session);
 		}
 	}
@@ -60,5 +60,9 @@ class SessionStorage implements Service, SessionStorageInterface {
 
 	private function getSession(): ?Session {
 		return $this->request->getSession();
+	}
+
+	public function migrate($destroy = false, $lifetime = null): bool {
+		return $this->request->getSession()->migrate($destroy, $lifetime);
 	}
 }

--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -60,7 +60,7 @@ sm_v='2.38.2'
 # UPGRADE_UPDATE_FILEMANAGER_CONFIG: Updates only the configuration file if changes are made but now new issue has been issued!
 UPGRADE_UPDATE_FILEMANAGER_CONFIG='false'
 # Set version of File manager to update during upgrade if not already installed
-fm_v='7.13.0'
+fm_v='7.13.4'
 
 # Backblaze
 b2_v='3.6.0'


### PR DESCRIPTION
FileGator 7.13.4 introduced the migrate() method on the session storage, and Hestia’s bundled SessionStorage adapter was not updated accordingly. As a result, FileGator attempted to call migrate() on the storage, which did not exist in Hestia’s version, causing a 500 Internal Server Error.

This commit adds the missing migrate($destroy = false, $lifetime = null) method to the SessionStorage adapter and proxies the call to the underlying Session instance, restoring compatibility with FileGator 7.13.4 and preventing the 500 error.

Fixes #5240