### PR TITLE
fix(filemanager): avoid blocked sudo chmod and grant .ssh traversal for hestiaweb

### DIFF
--- a/bin/v-add-user-sftp-key
+++ b/bin/v-add-user-sftp-key
@@ -38,6 +38,7 @@ check_hestia_demo_mode
 PRVKEY_FILE="$HOMEDIR/$user/.ssh/hst-filemanager-key"
 PUBKEY_FILE="$HOMEDIR/$user/.ssh/hst-filemanager-key.pub"
 AUTHKEY_FILE="$HOMEDIR/$user/.ssh/authorized_keys"
+SSH_DIR="$HOMEDIR/$user/.ssh"
 
 [ -z "$(readlink -f "$PRVKEY_FILE" | egrep "^$HOMEDIR/$user/.ssh/")" ] && check_result "$E_FORBIDEN" "Invalid private key file path"
 [ -z "$(readlink -f "$PUBKEY_FILE" | egrep "^$HOMEDIR/$user/.ssh/")" ] && check_result "$E_FORBIDEN" "Invalid public key file path"
@@ -71,6 +72,14 @@ fi
 #
 chown ${user}: "${AUTHKEY_FILE}"
 chown "hestiaweb": "${PRVKEY_FILE}"
+
+# Ensure file manager service account can traverse user's .ssh folder
+# to read the dedicated private key.
+if command -v setfacl > /dev/null 2>&1; then
+	setfacl -m u:hestiaweb:--x "${SSH_DIR}" > /dev/null 2>&1
+else
+	chmod o+x "${SSH_DIR}"
+fi
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-add-user-sftp-key
+++ b/bin/v-add-user-sftp-key
@@ -78,7 +78,8 @@ chown "hestiaweb": "${PRVKEY_FILE}"
 if command -v setfacl > /dev/null 2>&1; then
 	setfacl -m u:hestiaweb:--x "${SSH_DIR}" > /dev/null 2>&1
 else
-	chmod o+x "${SSH_DIR}"
+	echo "Error: 'setfacl' is not available."
+	exit 1
 fi
 
 #----------------------------------------------------------#

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -186,9 +186,6 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 			$output,
 			$return_var,
 		);
-		// filemanager also requires .ssh chmod o+x ... hopefully we can improve it to g+x or u+x someday
-		// current minimum for filemanager: chmod 0701 .ssh
-		shell_exec("sudo chmod o+x " . quoteshellarg("/home/" . basename($v_user) . "/.ssh"));
 	}
 
 	if (!isset($_SESSION["SFTP_PORT"])) {


### PR DESCRIPTION
 ## Summary

  This PR fixes a File Manager SFTP failure that can surface as `Unknown error` in the UI (`/fm/?r=/getdir` returning 500).

  ## Problem

  In File Manager config, when key is missing, it runs:

  - `sudo /usr/local/hestia/bin/v-add-user-sftp-key ...`
  - `sudo chmod o+x /home/<user>/.ssh`

  But default Hestia sudoers for `hestiaweb` allows only `/usr/local/hestia/bin/*`, so `sudo chmod ...` is denied (`command not allowed`), and SFTP login may fail.

  ## Changes

  1. Removed blocked sudo call from:
  - `install/deb/filemanager/filegator/configuration.php`
    - removed `shell_exec("sudo chmod o+x ...")`

  2. Moved traversal permission handling into Hestia script:
  - `bin/v-add-user-sftp-key`
    - after key creation/ownership:
      - use `setfacl -m u:hestiaweb:--x "$HOMEDIR/$user/.ssh"` when available
      - fallback to `chmod o+x "$HOMEDIR/$user/.ssh"` when ACL tool is unavailable

  ## Why this is safer

  - Keeps privilege changes inside Hestia-managed scripts (already allowed by sudoers).
  - Grants minimum traverse permission for `hestiaweb` to reach the FM key path.
  - Avoids runtime sudo failures from File Manager PHP code.

  ## Validation

  - Bash syntax check passed for `v-add-user-sftp-key`.
  - Runtime verification: SFTP login succeeds with FM key; directory listing works where it previously failed with 500.