### PR TITLE
fix(filemanager): implement SessionStorage::migrate for compatibility

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
+++ b/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
@@ -54,6 +54,10 @@ class SessionStorage implements Service, SessionStorageInterface {
 		$this->getSession()->invalidate();
 	}
 
+	public function migrate($destroy = false, $lifetime = null): bool {
+		return $this->getSession()->migrate($destroy, $lifetime);
+	}
+
 	private function setSession(Session $session) {
 		return $this->request->setSession($session);
 	}


### PR DESCRIPTION
## Summary

  This PR adds the missing `migrate()` implementation to File Manager session storage.

  `SessionStorage` implements `SessionStorageInterface` but did not implement `migrate($destroy = false, $lifetime = null): bool`, which can cause fatal errors depending on dependency/runtime combinations.

  ## Changes

  - Added:
    - `install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php`
      - `public function migrate($destroy = false, $lifetime = null): bool`
      - Delegates to `$this->getSession()->migrate(...)`

  ## Why

  Without this method, File Manager can fail at runtime with interface/abstract method compatibility errors.

  ## Validation

  - PHP lint passed on modified file.
  - Reproduced issue and verified File Manager no longer fails on this class-compatibility point.