### PR TITLE
Fix: handle missing session gracefully in SessionStorage

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
+++ b/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
@@ -59,7 +59,11 @@ class SessionStorage implements Service, SessionStorageInterface {
 	}
 
 	private function getSession(): ?Session {
-		return $this->request->getSession();
+		try {
+			return $this->request->getSession();
+		} catch (\Symfony\Component\HttpFoundation\Exception\SessionNotFoundException $e) {
+			return null;
+		}
 	}
 
 	public function migrate($destroy = false, $lifetime = null): bool {

--- a/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
+++ b/install/deb/filemanager/filegator/backend/Services/Session/Adapters/SessionStorage.php
@@ -29,7 +29,7 @@ class SessionStorage implements Service, SessionStorageInterface {
 		if (!$this->getSession()) {
 			$handler = $config["handler"];
 			$session = new Session($handler());
-			//$session->setName('filegator');
+			//$session->setName("filegator");
 			$this->setSession($session);
 		}
 	}
@@ -60,5 +60,9 @@ class SessionStorage implements Service, SessionStorageInterface {
 
 	private function getSession(): ?Session {
 		return $this->request->getSession();
+	}
+
+	public function migrate($destroy = false, $lifetime = null): bool {
+		return $this->request->getSession()->migrate($destroy, $lifetime);
 	}
 }

--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -60,7 +60,7 @@ sm_v='2.38.2'
 # UPGRADE_UPDATE_FILEMANAGER_CONFIG: Updates only the configuration file if changes are made but now new issue has been issued!
 UPGRADE_UPDATE_FILEMANAGER_CONFIG='false'
 # Set version of File manager to update during upgrade if not already installed
-fm_v='7.13.0'
+fm_v='7.13.4'
 
 # Backblaze
 b2_v='3.6.0'


### PR DESCRIPTION
Wrap `getSession()` call in a try-catch to handle `SessionNotFoundException`, returning null instead of throwing when no session is available.
    
Without this fix, trying to access filemanager gives this error:
    
```
2026/03/10 07:30:45 [error] 774#0: *3 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Symfony\Component\HttpFoundation\Exception\SessionNotFoundException: Session has not been set. in /usr/local/hestia/web/fm/vendor/symfony/http-foundation/Request.php:758
Stack trace:
#0 /usr/local/hestia/web/fm/backend/Services/Session/Adapters/SessionStorage.php(62): Symfony\Component\HttpFoundation\Request->getSession()
#1 /usr/local/hestia/web/fm/backend/Services/Session/Adapters/SessionStorage.php(29): Filegator\Services\Session\Adapters\SessionStorage->getSession()
#2 /usr/local/hestia/web/fm/backend/App.php(33): Filegator\Services\Session\Adapters\SessionStorage->init()
#3 /usr/local/hestia/web/fm/dist/index.php(50): Filegator\App->__construct()
#4 {main}
  thrown in /usr/local/hestia/web/fm/vendor/symfony/http-foundation/Request.php on line 758" while reading response header from upstream, client: 192.168.2.3, server: _, request: "GET /fm/ HTTP/2.0", upstream: "fastcgi://unix:/run/hestia-php.sock:", host: "192.168.2.201:8083", referrer: "https://192.168.2.201:8083/list/user/"
```
    
Maybe it should be fixed in `backend/Services/Auth/Adapters/HestiaAuth.php` but my PHP knowdledge is 0 and this fix works fine with Symfony 8 and compiling Hestia with PHP 8.4.
    
Related PR #5241
