### PR TITLE
Configure Nginx to handle Livewire v3 asset requests

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/laravel.stpl
@@ -44,6 +44,11 @@ server {
 	location / {
 		try_files $uri $uri/ /index.php?$args;
 
+		location ~* ^/livewire-[^/]+/.*\.(js|css)$ {
+				expires off;
+				try_files $uri $uri/ /index.php?$query_string;
+		}
+
 		location ~* ^.+\.(ogg|ogv|svg|svgz|swf|eot|otf|woff|woff2|mov|mp3|mp4|webm|flv|ttf|rss|atom|jpg|jpeg|gif|png|webp|ico|bmp|mid|midi|wav|rtf|css|js|jar)$ {
 			expires 30d;
 			fastcgi_hide_header "Set-Cookie";

--- a/install/deb/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/laravel.tpl
@@ -38,6 +38,11 @@ server {
 			expires 30d;
 			fastcgi_hide_header "Set-Cookie";
 		}
+		
+		location ~* ^/livewire-[^/]+/.*\.(js|css)$ {
+				expires off;
+				try_files $uri $uri/ /index.php?$query_string;
+		}
 
 		location = /livewire/livewire.js {
 				expires off;

--- a/install/deb/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/laravel.tpl
@@ -38,17 +38,17 @@ server {
 			expires 30d;
 			fastcgi_hide_header "Set-Cookie";
 		}
-		
-		location ~* ^/livewire-[^/]+/.*\.(js|css)$ {
-				expires off;
-				try_files $uri $uri/ /index.php?$query_string;
-		}
 
 		location = /livewire/livewire.js {
 				expires off;
 				try_files $uri $uri/ /index.php?$query_string;
 		}
 		location = /livewire/livewire.min.js {
+				expires off;
+				try_files $uri $uri/ /index.php?$query_string;
+		}
+
+		location ~* ^/livewire-[^/]+/.*\.(js|css)$ {
 				expires off;
 				try_files $uri $uri/ /index.php?$query_string;
 		}


### PR DESCRIPTION
Add location block for dynamic Livewire v3 assets in Nginx config. This block needs to be placed before the static assets.