### PR TITLE
Bump Nginx, PHP and build dependency versions

### DIFF
--- a/src/deb/nginx/control
+++ b/src/deb/nginx/control
@@ -1,7 +1,7 @@
 Source: hestia-nginx
 Package: hestia-nginx
 Priority: optional
-Version: 1.27.4
+Version: 1.28.2
 Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com

--- a/src/deb/php/control
+++ b/src/deb/php/control
@@ -1,7 +1,7 @@
 Source: hestia-php
 Package: hestia-php
 Priority: optional
-Version: 8.3.17
+Version: 8.4.18
 Section: admin
 Maintainer: HestaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -217,9 +217,9 @@ fi
 echo "Build version $BUILD_VER, with Nginx version $NGINX_V, PHP version $PHP_V and Web Terminal version $WEB_TERMINAL_V"
 
 HESTIA_V="${BUILD_VER}_${BUILD_ARCH}"
-OPENSSL_V='3.4.0'
-PCRE_V='10.44'
-ZLIB_V='1.3.1'
+OPENSSL_V='3.4.4'
+PCRE_V='10.47'
+ZLIB_V='1.3.2'
 
 # Create build directories
 if [ "$KEEPBUILD" != 'true' ]; then


### PR DESCRIPTION
Update bundled component versions used in the build process:

- Nginx: 1.27.4 → 1.28.2
- PHP: 8.3.17 → 8.4.18
- OpenSSL: 3.4.0 → 3.4.4
- PCRE: 10.44 → 10.47
- Zlib: 1.3.1 → 1.3.2

PHP is upgraded to the 8.4 branch to meet the requirements of Symfony 8.