### PR TITLE
Fix security vulnerabilities, typos, and shell quoting bugs

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -111,7 +111,7 @@ if [ "$type" = 'ftp' ]; then
 	ftp_result=$(ftpc "mkdir $ftmpdir" "rm $ftmpdir" | grep -v Trying)
 	if [ -n "$ftp_result" ]; then
 		echo "$ftp_result"
-		rm -rf $tmpdir
+		rm -rf "$tmpdir"
 		echo "Error: can't create $ftmpdir folder on the ftp"
 		log_event "$E_FTP" "$ARGUMENTS"
 		exit "$E_FTP"

--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -723,7 +723,7 @@ for backup_type in $(echo -e "${BACKUP_SYSTEM//,/\\n}"); do
 done
 
 # Removing tmpdir
-rm -rf $tmpdir
+rm -rf "$tmpdir"
 if [[ "$errorcode" != "0" ]]; then
 	if [[ "$BACKUP_SYSTEM" =~ "local" ]]; then
 		echo -e "$(date "+%F %T") *** Local backup was successfully executed. Remote backup failed ***" \

--- a/bin/v-change-database-owner
+++ b/bin/v-change-database-owner
@@ -113,7 +113,7 @@ case $TYPE in
 esac
 
 # Deleting tmpdir
-rm -rf $tmpdir
+rm -rf "$tmpdir"
 
 # Remove old database
 $BIN/v-unsuspend-database "$owner" "$database" > /dev/null 2>&1

--- a/bin/v-delete-fastcgi-cache
+++ b/bin/v-delete-fastcgi-cache
@@ -46,14 +46,14 @@ parse_object_kv_list $(grep "DOMAIN='$domain'" $USER_DATA/web.conf)
 
 # Remove FastCGI cache configuration
 if [ -f "$HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.fastcgi_cache.conf" ]; then
-	rm -rf $HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.fastcgi_cache.conf
+	rm -rf "$HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.fastcgi_cache.conf"
 fi
 
 conf='/etc/nginx/conf.d/fastcgi_cache_pool.conf'
 if [ -f "$conf" ]; then
 	sed -i "/ keys_zone=$domain/d" $conf
 	if [ ! -s "$conf" ]; then
-		rm -rf $conf
+		rm -rf "$conf"
 	fi
 fi
 

--- a/bin/v-delete-mail-account
+++ b/bin/v-delete-mail-account
@@ -60,7 +60,7 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/accounts
 	sed -i "/^$account$/d" $HOMEDIR/$user/conf/mail/$domain/fwd_only
 	sed -i "/^$account@$domain_idn:/d" $HOMEDIR/$user/conf/mail/$domain/limits
-	rm -rf $HOMEDIR/$user/mail/$domain_idn/$account
+	rm -rf "$HOMEDIR/$user/mail/$domain_idn/$account"
 fi
 
 #----------------------------------------------------------#

--- a/bin/v-delete-mail-domain
+++ b/bin/v-delete-mail-domain
@@ -54,8 +54,8 @@ accounts=$(wc -l "$USER_DATA/mail/$domain.conf" | cut -f 1 -d ' ')
 # Deleting exim configuration files
 if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	rm -f /etc/$MAIL_SYSTEM/domains/$domain_idn
-	rm -rf $HOMEDIR/$user/conf/mail/$domain
-	rm -rf $HOMEDIR/$user/mail/$domain_idn
+	rm -rf "$HOMEDIR/$user/conf/mail/$domain"
+	rm -rf "$HOMEDIR/$user/mail/$domain_idn"
 fi
 
 # Deleting dkim dns record

--- a/bin/v-delete-user
+++ b/bin/v-delete-user
@@ -103,11 +103,11 @@ fi
 
 # Deleting user directories
 chattr -i $HOMEDIR/$user/conf > /dev/null 2>&1
-rm -rf $HOMEDIR/$user
+rm -rf "$HOMEDIR/$user"
 rm -f /var/spool/mail/$user
 rm -f /var/spool/cron/$user
 rm -f /var/spool/cron/crontabs/$user
-rm -rf $USER_DATA
+rm -rf "$USER_DATA"
 
 # Updating admin counter
 if [ "$user" != "$ROOT_USER" ]; then

--- a/bin/v-delete-web-domain
+++ b/bin/v-delete-web-domain
@@ -112,8 +112,8 @@ rm -f /var/log/$WEB_SYSTEM/domains/$domain.bytes
 rm -f /var/log/$WEB_SYSTEM/domains/$domain.error*
 
 # Deleting directory
-rm -rf $HOMEDIR/$user/web/$domain
-rm -rf $HOMEDIR/$user/conf/web/$domain
+rm -rf "$HOMEDIR/$user/web/$domain"
+rm -rf "$HOMEDIR/$user/conf/web/$domain"
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-restore-dns-domain-restic
+++ b/bin/v-restore-dns-domain-restic
@@ -69,7 +69,7 @@ for domain in $domains; do
 		if [ -z "$check_config" ]; then
 			check_new=$(is_domain_new 'dns' "$domain")
 			if [ "$check_new" = "yes" ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="$domain belongs to another user"
 				echo "$error" | $SENDMAIL -s "$subj" "$email" "$notify"
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-mail-domain-restic
+++ b/bin/v-restore-mail-domain-restic
@@ -77,7 +77,7 @@ for domain in $domains; do
 		if [ -z "$check_config" ]; then
 			check_new=$(is_domain_new 'mail' $domain)
 			if [ "$check_new" = 'yes' ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="$domain belongs to another user"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -169,7 +169,7 @@ if [ "$create_user" = 'yes' ]; then
 	# Unpacking user container
 	tar xf "$BACKUP/$backup" -C "$tmpdir" --no-wildcards "./$backup_system" 2> /dev/null
 	if [ "$?" -ne 0 ]; then
-		rm -rf $tmpdir
+		rm -rf "$tmpdir"
 		echo "Can't unpack user container" | $SENDMAIL -s "$subj" $email $notify
 		sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
 		check_result "$E_PARSING" "Can't unpack user container"
@@ -189,7 +189,7 @@ fi
 chown "$user" "$tmpdir"
 tar xf $BACKUP/$backup -C $tmpdir ./pam
 if [ "$?" -ne 0 ]; then
-	rm -rf $tmpdir
+	rm -rf "$tmpdir"
 	echo "Can't unpack PAM container" | $SENDMAIL -s "$subj" $email $notify
 	sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
 	check_result "$E_PARSING" "Can't unpack PAM container"
@@ -229,7 +229,7 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
 		if [ -z "$check_config" ]; then
 			check_new=$(is_domain_new 'web' $domain)
 			if [ -n "$check_new" ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="$domain belongs to another user"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -240,7 +240,7 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
 		# Unpacking domain container
 		tar xf $BACKUP/$backup -C $tmpdir ./web/$domain
 		if [ "$?" -ne 0 ]; then
-			rm -rf $tmpdir
+			rm -rf "$tmpdir"
 			error="Can't unpack $domain web container"
 			echo "$error" | $SENDMAIL -s "$subj" $email $notify
 			sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -363,7 +363,7 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
 
 		# Restoring web domain data
 		if [ -d "$HOMEDIR/$user/web/$domain/public_html" ]; then
-			rm -rf $HOMEDIR/$user/web/$domain/public_html/*
+			rm -rf "$HOMEDIR/$user/web/$domain/public_html/*"
 		fi
 		chmod u+w "$HOMEDIR/$user/web/$domain"
 		[[ -d $HOMEDIR/$user/web/$domain/stats ]] && chmod u+w "$HOMEDIR/$user/web/$domain/stats"
@@ -381,7 +381,7 @@ if [ "$web" != 'no' ] && [ -n "$WEB_SYSTEM" ]; then
 		fi
 
 		if [ "$?" -ne 0 ]; then
-			rm -rf $tmpdir
+			rm -rf "$tmpdir"
 			error="Can't unpack $domain data tarball"
 			echo "$error" | $SENDMAIL -s "$subj" $email $notify
 			sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -438,7 +438,7 @@ if [ "$dns" != 'no' ] && [ -n "$DNS_SYSTEM" ]; then
 		if [ -z "$check_config" ]; then
 			check_new=$(is_domain_new 'dns' $domain)
 			if [ -n "$check_new" ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="$domain belongs to another user"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -449,7 +449,7 @@ if [ "$dns" != 'no' ] && [ -n "$DNS_SYSTEM" ]; then
 		# Unpacking domain container
 		tar xf $BACKUP/$backup -C $tmpdir ./dns/$domain
 		if [ "$?" -ne 0 ]; then
-			rm -rf $tmpdir
+			rm -rf "$tmpdir"
 			error="Can't unpack $domain dns container"
 			echo "$error" | $SENDMAIL -s "$subj" $email $notify
 			sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -545,7 +545,7 @@ if [ "$mail" != 'no' ] && [ -n "$MAIL_SYSTEM" ]; then
 		if [ -z "$check_config" ]; then
 			check_new=$(is_domain_new 'mail' $domain)
 			if [ -n "$check_new" ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="$domain belongs to another user"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -557,7 +557,7 @@ if [ "$mail" != 'no' ] && [ -n "$MAIL_SYSTEM" ]; then
 		tar xf $BACKUP/$backup -C $tmpdir ./mail/$domain
 
 		if [ "$?" -ne 0 ]; then
-			rm -rf $tmpdir
+			rm -rf "$tmpdir"
 			error="Can't unpack $domain mail container"
 			echo "$error" | $SENDMAIL -s "$subj" $email $notify
 			sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -672,7 +672,7 @@ if [ "$mail" != 'no' ] && [ -n "$MAIL_SYSTEM" ]; then
 			if [ -e "$tmpdir/mail/$domain/accounts.tar.zst" ]; then
 				$BIN/v-extract-fs-archive "$user" "$tmpdir/mail/$domain/accounts.tar.zst" "$HOMEDIR/$user/mail/$domain_idn/"
 				if [ "$?" -ne 0 ]; then
-					rm -rf $tmpdir
+					rm -rf "$tmpdir"
 					error="Can't unpack $domain mail account container"
 					echo "$error" | $SENDMAIL -s "$subj" $email $notify
 					sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -687,7 +687,7 @@ if [ "$mail" != 'no' ] && [ -n "$MAIL_SYSTEM" ]; then
 			if [ -e "$tmpdir/mail/$domain/accounts.tar.gz" ]; then
 				$BIN/v-extract-fs-archive "$user" "$tmpdir/mail/$domain/accounts.tar.gz" "$HOMEDIR/$user/mail/$domain_idn/"
 				if [ "$?" -ne 0 ]; then
-					rm -rf $tmpdir
+					rm -rf "$tmpdir"
 					error="Can't unpack $domain mail account container"
 					echo "$error" | $SENDMAIL -s "$subj" $email $notify
 					sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -746,7 +746,7 @@ if [ "$db" != 'no' ] && [ -n "$DB_SYSTEM" ]; then
 		# Unpacking database container
 		tar xf $BACKUP/$backup -C $tmpdir ./db/$database
 		if [ "$?" -ne 0 ]; then
-			rm -rf $tmpdir
+			rm -rf "$tmpdir"
 			error="Can't unpack $database database container"
 			echo "$error" | $SENDMAIL -s "$subj" $email $notify
 			sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -805,7 +805,7 @@ if [ "$cron" != 'no' ] && [ -n "$CRON_SYSTEM" ]; then
 	# Unpacking cron container
 	tar xf $BACKUP/$backup -C $tmpdir ./cron
 	if [ "$?" -ne 0 ]; then
-		rm -rf $tmpdir
+		rm -rf "$tmpdir"
 		error="Can't unpack cron container"
 		echo "$error" | $SENDMAIL -s "$subj" $email $notify
 		sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -869,7 +869,7 @@ if [ "$udir" != 'no' ]; then
 				tar xf "$BACKUP/$backup" -C "$tmpdir" --no-wildcards "./user_dir/$user_dir.tar.gz"
 			fi
 			if [ "$?" -ne 0 ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="Can't unpack $user_dir user dir container"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -887,7 +887,7 @@ if [ "$udir" != 'no' ]; then
 			cmdstatus="$?"
 			chown root:root "$HOMEDIR/$user"
 			if [ "$cmdstatus" -ne 0 ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="Can't unpack $user_dir user dir container"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -919,7 +919,7 @@ cat $tmpdir/restore.log | $SENDMAIL -s "$subj" $email $notify
 $BIN/v-add-user-notification "$user" "Backup restored successfully" "<p><span class='u-text-bold'>Archive:</span> <code>$backup</code></p>"
 
 # Deleting temporary data
-rm -rf $tmpdir
+rm -rf "$tmpdir"
 
 # Cleaning restore queue
 sed -i "/v-restore-user $user /d" $HESTIA/data/queue/backup.pipe

--- a/bin/v-restore-web-domain-restic
+++ b/bin/v-restore-web-domain-restic
@@ -77,7 +77,7 @@ for domain in $domains; do
 		if [ -z "$check_config" ]; then
 			check_new=$(is_domain_new 'web' $domain)
 			if [ "$check_new" = 'yes' ]; then
-				rm -rf $tmpdir
+				rm -rf "$tmpdir"
 				error="$domain belongs to another user"
 				echo "$error" | $SENDMAIL -s "$subj" $email $notify
 				sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
@@ -204,7 +204,7 @@ for domain in $domains; do
 		rebuild_web_domain_conf
 
 		if [ -d "$HOMEDIR/$user/web/$domain/public_html" ]; then
-			rm -rf $HOMEDIR/$user/web/$domain/public_html/*
+			rm -rf "$HOMEDIR/$user/web/$domain/public_html/*"
 		fi
 
 		[[ -d $HOMEDIR/$user/web/$domain/stats ]] && chmod u+w "$HOMEDIR/$user/web/$domain/stats"

--- a/bin/v-update-sys-hestia-git
+++ b/bin/v-update-sys-hestia-git
@@ -139,7 +139,7 @@ BUILD_VER=$(curl -s https://raw.githubusercontent.com/$fork/hestiacp/$branch/src
 HESTIA_V="${BUILD_VER}_${BUILD_ARCH}"
 
 # Create build directories
-rm -rf $BUILD_DIR
+rm -rf "$BUILD_DIR"
 mkdir -p $DEB_DIR
 mkdir -p $ARCHIVE_DIR
 
@@ -174,7 +174,7 @@ install_build() {
 	done
 	unset $answer
 	# Remove temporary files
-	rm -rf $BUILD_DIR
+	rm -rf "$BUILD_DIR"
 }
 
 # Set install flags
@@ -263,7 +263,7 @@ if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIA" ]; then
 fi
 
 cd $BUILD_DIR
-rm -rf $BUILD_DIR/hestiacp-$branch_dash
+rm -rf "$BUILD_DIR/hestiacp-$branch_dash"
 # Download and unpack source files
 if [ "$use_src_folder" == 'true' ]; then
 	[ "$HESTIA_DEBUG" ] && echo DEBUG: cp -rf "$SRC_DIR/" $BUILD_DIR/hestiacp-$branch_dash
@@ -330,7 +330,7 @@ else
 	else
 		echo "Installation of development build aborted."
 		echo "Removing temporary files..."
-		rm -rf $BUILD_DIR
+		rm -rf "$BUILD_DIR"
 		unset "$answer"
 		echo ""
 	fi

--- a/func/backup.sh
+++ b/func/backup.sh
@@ -30,11 +30,11 @@ local_backup() {
 	# Checking disk space
 	disk_usage=$(df $BACKUP | tail -n1 | tr ' ' '\n' | grep % | cut -f 1 -d %)
 	if [ "$disk_usage" -ge "$BACKUP_DISK_LIMIT" ]; then
-		rm -rf $tmpdir
+		rm -rf "$tmpdir"
 		rm -f $BACKUP/$user.log
 		sed -i "/ $user /d" $HESTIA/data/queue/backup.pipe
 		echo "Not enough disk space" | $SENDMAIL -s "$subj" "$email" "yes"
-		check_result "$E_DISK" "Not enough dsk space"
+		check_result "$E_DISK" "Not enough disk space"
 	fi
 
 	# Creating final tarball

--- a/func/db.sh
+++ b/func/db.sh
@@ -61,7 +61,7 @@ mysql_connect() {
 			echo "user='$USER'" >> $mycnf
 			echo "password='$PASSWORD'" >> $mycnf
 			echo "port='$PORT'" >> $mycnf
-			chmod 660 $mycnf
+			chmod 600 $mycnf
 		fi
 	fi
 	mysql_out=$(mktemp)
@@ -115,7 +115,7 @@ mysql_dump() {
 	if [ '0' -ne "$?" ]; then
 		$mysqldmp --defaults-extra-file=$mycnf --single-transaction --routines -r $1 $2 2> $err
 		if [ '0' -ne "$?" ]; then
-			rm -rf $tmpdir
+			rm -rf "$tmpdir"
 			if [ "$notify" != 'no' ]; then
 				email=$(grep CONTACT "$HESTIA/data/users/$ROOT_USER/user.conf" | cut -f 2 -d \')
 				subj="MySQL error on $(hostname)"
@@ -166,7 +166,7 @@ psql_query() {
 psql_dump() {
 	pg_dump -h $HOST -U $USER -c --inserts -O -x -f $1 $2 2> /tmp/e.psql
 	if [ '0' -ne "$?" ]; then
-		rm -rf $tmpdir
+		rm -rf "$tmpdir"
 		if [ "$notify" != 'no' ]; then
 			email=$(grep CONTACT "$HESTIA/data/users/$ROOT_USER/user.conf" | cut -f 2 -d \')
 			subj="PostgreSQL error on $(hostname)"

--- a/func/main.sh
+++ b/func/main.sh
@@ -189,7 +189,7 @@ check_result() {
 check_args() {
 	if [ "$1" -gt "$2" ]; then
 		echo "Usage: $(basename $0) $3"
-		check_result "$E_ARGS" "not enought arguments" > /dev/null
+		check_result "$E_ARGS" "not enough arguments" > /dev/null
 	fi
 }
 

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -564,7 +564,7 @@ case $architecture in
 		echo -e "\e[91mInstallation aborted\e[0m"
 		echo "===================================================================="
 		echo -e "\e[33mERROR: $architecture is currently not supported!\e[0m"
-		echo -e "\e[33mPlease verify the achitecture used is currenlty supported\e[0m"
+		echo -e "\e[33mPlease verify the architecture used is currently supported\e[0m"
 		echo ""
 		echo -e "\e[33mhttps://github.com/hestiacp/hestiacp/blob/main/README.md\e[0m"
 		echo ""

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -553,7 +553,7 @@ case $architecture in
 		echo -e "\e[91mInstallation aborted\e[0m"
 		echo "===================================================================="
 		echo -e "\e[33mERROR: $architecture is currently not supported!\e[0m"
-		echo -e "\e[33mPlease verify the achitecture used is currenlty supported\e[0m"
+		echo -e "\e[33mPlease verify the architecture used is currently supported\e[0m"
 		echo ""
 		echo -e "\e[33mhttps://github.com/hestiacp/hestiacp/blob/main/README.md\e[0m"
 		echo ""

--- a/install/upgrade/manual/migrate_jailkit_to_bubblewrap.sh
+++ b/install/upgrade/manual/migrate_jailkit_to_bubblewrap.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # info: Removes Jailkit and migrates to Bubblewrap
 #
-# Jailkit was availble for a short period in 1.9.0 Beta releases
-# How ever it has been replaced by Bubblewrap
+# Jailkit was available for a short period in 1.9.0 Beta releases
+# However it has been replaced by Bubblewrap
 
 #----------------------------------------------------------#
 #                    Variable&Function                     #

--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -6,26 +6,29 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+$type = "";
 if ($_GET["type"] == "access") {
 	$type = "access";
 }
 if ($_GET["type"] == "error") {
 	$type = "error";
 }
+
+if (empty($type)) {
+	http_response_code(400);
+	echo "Error: Invalid log type";
+	exit();
+}
+
+$v_domain = $_GET["domain"];
+$safe_filename = preg_replace('/[^a-zA-Z0-9._-]/', '_', $v_domain);
 
 header("Cache-Control: public");
 header("Content-Description: File Transfer");
-header("Content-Disposition: attachment; filename=" . $_GET["domain"] . "." . $type . "-log.txt");
+header("Content-Disposition: attachment; filename=" . $safe_filename . "." . $type . "-log.txt");
 header("Content-Type: application/octet-stream; ");
 header("Content-Transfer-Encoding: binary");
 
-$v_domain = $_GET["domain"];
-if ($_GET["type"] == "access") {
-	$type = "access";
-}
-if ($_GET["type"] == "error") {
-	$type = "error";
-}
 $cmd = implode(" ", [
 	"/usr/bin/sudo " . quoteshellarg(HESTIA_DIR_BIN . "v-list-web-domain-" . $type . "log"),
 	// $user is already shell-escaped

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -34,13 +34,17 @@ if (isset($_SESSION["user"])) {
 					HESTIA_CMD .
 						"v-log-action " .
 						$v_impersonator .
-						" 'Info' 'Security' 'Logged in as another user (User: $v_user)'",
+						" 'Info' 'Security' 'Logged in as another user' " .
+						$v_user,
 					$output,
 					$return_var,
 				);
 				exec(
 					HESTIA_CMD .
-						"v-log-action system 'Warning' 'Security' 'User impersonation session started (User: $v_user, Administrator: $v_impersonator)'",
+						"v-log-action system 'Warning' 'Security' 'User impersonation session started' " .
+						$v_user .
+						" " .
+						$v_impersonator,
 					$output,
 					$return_var,
 				);
@@ -49,8 +53,11 @@ if (isset($_SESSION["user"])) {
 				unset($_SESSION["_sf2_meta"]);
 				if (!empty($_GET["edit_link"])) {
 					$edit_link = urldecode($_GET["edit_link"]);
-					$url = $edit_link . "&token=" . $_SESSION["token"];
-					header("Location: " . $url);
+					// Only allow relative paths to prevent open redirect
+					if (strpos($edit_link, '/') === 0 && !preg_match('/^\/\//', $edit_link)) {
+						$url = $edit_link . "&token=" . $_SESSION["token"];
+						header("Location: " . $url);
+					}
 					die();
 				}
 				header("Location: /login/");


### PR DESCRIPTION
## Security Fixes

1. **Shell quoting bug in login impersonation** (`web/login/index.php`) — `$v_user` and `$v_impersonator` (already `quoteshellarg`-wrapped) were interpolated inside single-quoted shell strings in `v-log-action` calls, breaking the shell quoting structure. Refactored to pass them as separate properly-quoted arguments.

2. **Open redirect vulnerability** (`web/login/index.php`) — The `edit_link` GET parameter was used directly in a `header("Location: ...")` after only `urldecode()`, allowing an attacker to redirect administrators to external malicious sites. Now validates that the path starts with `/` and does not begin with `//`.

3. **MySQL config file permissions** (`func/db.sh:64`) — The `.mysql.$HOST` config file containing database credentials was created with `chmod 600` but updated with `chmod 660`, exposing passwords to group read/write access. Fixed to consistently use `600`.

4. **Header injection in web-log download** (`web/download/web-log/index.php`) — User-supplied `$_GET["domain"]` was placed directly in a `Content-Disposition` header without sanitization, allowing potential HTTP header injection. Now sanitizes with a regex whitelist.

5. **Uninitialized variable and duplicate code** (`web/download/web-log/index.php`) — `$type` was not initialized before use, and the type-checking logic was duplicated. Added initialization, validation for invalid types, and removed the duplicate block.

## Bug Fixes — Unquoted `rm -rf`

Quoted `$tmpdir` and path variables in `rm -rf` commands across **14 scripts** to prevent word splitting and glob expansion:
- `func/backup.sh`, `func/db.sh`
- `bin/v-change-database-owner`, `bin/v-add-backup-host`, `bin/v-delete-user`, `bin/v-delete-mail-account`, `bin/v-delete-mail-domain`, `bin/v-delete-web-domain`, `bin/v-delete-fastcgi-cache`, `bin/v-backup-user`, `bin/v-restore-user`, `bin/v-restore-web-domain-restic`, `bin/v-restore-dns-domain-restic`, `bin/v-restore-mail-domain-restic`, `bin/v-update-sys-hestia-git`

## Typo Fixes

- `"Not enough dsk space"` → `"Not enough disk space"` (`func/backup.sh`)
- `"not enought arguments"` → `"not enough arguments"` (`func/main.sh`)
- `"achitecture"` → `"architecture"`, `"currenlty"` → `"currently"` (both install scripts)
- `"availble"` → `"available"`, `"How ever"` → `"However"` (migration script)