### PR TITLE
Upgrade RoundCube version to 1.6.14

### DIFF
--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -50,7 +50,7 @@ pga_v='7.14.6'
 
 # Set version of RoundCube (Webmail) to update during upgrade if not already installed
 # Note: only applies to "non-apt installs >= 1.4.0 or manually phased out"
-rc_v='1.6.13'
+rc_v='1.6.14'
 
 # Set version of SnappyMail (Webmail) to update during upgrade if not already installed
 sm_v='2.38.2'


### PR DESCRIPTION
Updated RoundCube version to 1.6.14 in upgrade configuration.

https://github.com/roundcube/roundcubemail/releases/tag/1.6.14