### PR TITLE
Fix: resolve undefined array key "look" warnings in main.php

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -78,7 +78,7 @@ if (isset($_SESSION["user"])) {
 		$_SESSION["token"] = $token;
 	}
 	$username = $_SESSION["user"];
-	if ($_SESSION["look"] != "") {
+	if (!empty($_SESSION["look"])) {
 		$username = $_SESSION["look"];
 	}
 
@@ -137,7 +137,7 @@ if (isset($_SESSION["look"]) && $_SESSION["look"] != "" && $_SESSION["userContex
 if (empty($user_plain)) {
 	$user_plain = "";
 }
-if (empty($_SESSION["look"])) {
+if (!isset($_SESSION["look"])) {
 	$_SESSION["look"] = "";
 }
 


### PR DESCRIPTION
This PR fixes multiple `PHP Warning: Undefined array key "look"` in `web/inc/main.php` when running on PHP 8.x.

Log example:
```
2026/03/30 20:47:52 [error] 2397#0: *3085 FastCGI sent in stderr: "PHP message: PHP Warning:  Undefined array key "look" in /usr/local/hestia/web/inc/main.php on line 104" while reading response header from upstream, client: 203.0.113.1, server: hestia.example.net, request: "GET /list/user/ HTTP/2.0", upstream: "fastcgi://unix:/run/hestia-php.sock:", host: "hestia.example.net:8083", referrer: "https://hestia.example.net:8083/edit/mail/?domain=example.com&account=test&token=81fd67cfdaf4256a228a1abd8d2b4101"
```

In PHP 8, accessing a non-existent array key triggers a Warning. In HestiaCP, the `$_SESSION["look"]` key is only set when an administrator impersonates another user. On regular sessions, this key is undefined, causing multiple warnings throughout the dashboard.

- **Line 81**: Replaced direct comparison `$_SESSION["look"] != ""` with `!empty($_SESSION["look"])`.
- **Line 140**: Changed `empty()` check to `!isset()` to safely initialize the session key without triggering a warning.

These changes ensure full compatibility with PHP 8.0+ while maintaining existing logic.

---
CC: @divinity76 

PHP is not my strongest suit, so I would really appreciate it if you could take a look at these changes to ensure they follow HestiaCP's best practices and don't have any side effects. Thank you!