### PR TITLE
Fix: prevent session conflict in File Manager configuration

### DIFF
--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -1,7 +1,9 @@
 <?php
 use function Hestiacp\quoteshellarg\quoteshellarg;
+if (session_status() === PHP_SESSION_ACTIVE) {
+	session_write_close();
+}
 $dist_config = require __DIR__ . "/configuration_sample.php";
-session_start();
 $dist_config["public_path"] = "/fm/";
 $dist_config["frontend_config"]["app_name"] = "File Manager - Hestia Control Panel";
 $dist_config["frontend_config"]["logo"] = "../images/logo.svg";


### PR DESCRIPTION
This PR resolves a PHP Warning in the File Manager: `ini_set(): Session ini settings cannot be changed when a session is active`.

Log example:
```
2026/03/30 22:42:32 [error] 2397#0: *3810 FastCGI sent in stderr: "PHP message: PHP Warning:  ini_set(): Session ini settings cannot be changed when a session is active in /usr/local/hestia/web/fm/vendor/symfony/http-foundation/Session/Storage/Handler/NativeFileSessionHandler.php on line 53" while reading response header from upstream, client: 203.0.113.1, server: hestia.example.net, request: "POST /fm/?r=/getdir HTTP/2.0", upstream: "fastcgi://unix:/run/hestia-php.sock:", host: "hestia.example.net:8083", referrer: "https://hestia.example.net:8083/fm/"
```

HestiaCP starts a global session in `web/inc/main.php`. When the File Manager (FileGator) is loaded, its Symfony components attempt to modify session settings via `ini_set()`. PHP forbids changing these settings if a session is already active.

- Added `session_write_close()` in `web/fm/configuration.php` if a session is active.
- Removed the redundant `session_start()` call at the beginning of the file.
- This allows the File Manager's Symfony kernel to re-configure session settings (like `save_path`) without conflicts.
- The session is automatically resumed by the File Manager kernel, preserving user authentication.

---
CC: @divinity76 

PHP is not my strongest suit, so I would really appreciate it if you could take a look at these changes to ensure they follow HestiaCP's best practices and don't have any side effects. Thank you!