### PR TITLE
Accept invalid hostname for CNAME records

### DIFF
--- a/func/internal/dns_record_validator.php
+++ b/func/internal/dns_record_validator.php
@@ -76,11 +76,13 @@ if (!in_array($rtype, $known_types, true)) {
 	if (!$valid) {
 		$error_message = "invalid AAAA record format";
 	}
-} elseif ($rtype === "NS" || $rtype === "CNAME" || $rtype === "PTR") {
+} elseif ($rtype === "NS" || $rtype === "PTR") {
 	$valid = $validateDomain($record);
 	if (!$valid) {
 		$error_message = "invalid $rtype record format";
 	}
+} elseif ($rtype === "CNAME") {
+	$valid = filter_var(rtrim($record, "."), FILTER_VALIDATE_DOMAIN);
 } elseif ($rtype === "MX") {
 	$valid = $validateDomain($record);
 	if (!$valid) {

--- a/func/internal/dns_record_validator.php
+++ b/func/internal/dns_record_validator.php
@@ -83,6 +83,9 @@ if (!in_array($rtype, $known_types, true)) {
 	}
 } elseif ($rtype === "CNAME") {
 	$valid = filter_var(rtrim($record, "."), FILTER_VALIDATE_DOMAIN);
+	if (!$valid) {
+		$error_message = "invalid CNAME record format";
+	}
 } elseif ($rtype === "MX") {
 	$valid = $validateDomain($record);
 	if (!$valid) {

--- a/func/internal/dns_record_validator.php
+++ b/func/internal/dns_record_validator.php
@@ -44,8 +44,12 @@ $validateInt = static function ($value, $min, $max) {
 		"options" => ["min_range" => $min, "max_range" => $max],
 	]);
 };
-$validateDomain = static function ($value) {
-	return filter_var(rtrim($value, "."), FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+$validateDomain = static function ($value, $filter_flag_hostname = true) {
+	if ($filter_flag_hostname == true) {
+		return filter_var(rtrim($value, "."), FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+	} else {
+		return filter_var(rtrim($value, "."), FILTER_VALIDATE_DOMAIN);
+	}
 };
 $validateHex = static function ($value) {
 	return preg_match('/^[A-Fa-f0-9]+$/', $value) === 1;
@@ -82,9 +86,9 @@ if (!in_array($rtype, $known_types, true)) {
 		$error_message = "invalid $rtype record format";
 	}
 } elseif ($rtype === "CNAME") {
-	$valid = filter_var(rtrim($record, "."), FILTER_VALIDATE_DOMAIN);
+	$valid = $validateDomain($record, false);
 	if (!$valid) {
-		$error_message = "invalid CNAME record format";
+		$error_message = "invalid $rtype record format";
 	}
 } elseif ($rtype === "MX") {
 	$valid = $validateDomain($record);

--- a/web/inc/composer.lock
+++ b/web/inc/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d75dd082b587a517bf30598cfbcefb90",
+    "content-hash": "fad6bd8a45b9a059be7fc0bbdf1f1168",
     "packages": [
         {
             "name": "divinity76/cloudflare-ip-validator",


### PR DESCRIPTION
Outlook 365 uses _ for CNAME value when using DKIM

Also other ASCII characters are accepted for DNS value by Cloudflare / Google DNS.. 

To stream line it with them Hestia should also support them.

