### PR TITLE
SOA to comply with checks and RIPE

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -567,8 +567,8 @@ update_domain_zone() {
                                             $SERIAL
                                             14400
                                             $refresh
-                                            1209600
-                                            300 )
+                                            3600000
+                                            3600 )
 " > "$zn_conf"
 
 	while IFS= read -r line; do

--- a/func/domain.sh
+++ b/func/domain.sh
@@ -565,10 +565,10 @@ update_domain_zone() {
 	echo "\$TTL $zone_ttl
 @    IN    SOA    $SOA.    root.$domain_idn. (
                                             $SERIAL
-                                            7200
+                                            14400
                                             $refresh
                                             1209600
-                                            180 )
+                                            300 )
 " > "$zn_conf"
 
 	while IFS= read -r line; do


### PR DESCRIPTION
The minimum and refresh TTL is too low. Adjusted to comply with recommended values.

Still does not match all RIPE recommended SOA values, but should pass more checks and be more production ready.

The `minimum` does not meet the 2 days recommendation, instead I set it to 3600 which is a normal value.
The `refresh` does not meet the 1 day recommendation, 14400s is an average value and should pass most checks.
The expire value is set to 1000h which is the same as the RIPE recommendation.

An odd thing: The script have a `$refresh` variable which actually sets the SOA `retry` value. It should be lower than `refresh` and currently it is.
Currently the script sets it based on TLDs (de, cz, pl, pt are set to 1800), the 'default' is 3600 which is the minimum it should be.