### PR TITLE
exim: add sender rate-limit whitelist support

### DIFF
--- a/install/deb/exim/exim4.conf.4.95.template
+++ b/install/deb/exim/exim4.conf.4.95.template
@@ -147,12 +147,15 @@ acl_check_rcpt:
   accept  hosts         = :
 
 # Limit per email account for SMTP auhenticated users
+  warn    set acl_c_msg_limit  = ${if exists{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{${lookup {$authenticated_id} lsearch{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{$value}{${readfile{/etc/exim4/limit.conf}}}}}{${readfile{/etc/exim4/limit.conf}}} }
+
   deny    message       = Email account $authenticated_id is sending too many emails - rate overlimit = $sender_rate / $sender_rate_period
-          set acl_c_msg_limit  = ${if exists{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{${lookup {$authenticated_id} lsearch{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{$value}{${readfile{/etc/exim4/limit.conf}}}}}{${readfile{/etc/exim4/limit.conf}}} }
+          !senders      = ${if exists{/etc/exim4/ratelimit_whitelist}{/etc/exim4/ratelimit_whitelist}{}}
           ratelimit     = $acl_c_msg_limit / 1h / strict/ $authenticated_id
 
-  warn    ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id
-  log_message           = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period
+  warn    !senders      = ${if exists{/etc/exim4/ratelimit_whitelist}{/etc/exim4/ratelimit_whitelist}{}}
+          ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id
+          log_message   = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period
 
   deny    message       = Restricted characters in address
           domains       = +local_domains

--- a/install/deb/exim/exim4.conf.template
+++ b/install/deb/exim/exim4.conf.template
@@ -145,12 +145,15 @@ acl_check_rcpt:
   accept  hosts         = :
 
 # Limit per email account for SMTP auhenticated users
+  warn    set acl_c_msg_limit  = ${if exists{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{${lookup {$authenticated_id} lsearch{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{$value}{${readfile{/etc/exim4/limit.conf}}}}}{${readfile{/etc/exim4/limit.conf}}} }
+
   deny    message       = Email account $authenticated_id is sending too many emails - rate overlimit = $sender_rate / $sender_rate_period
-      set acl_c_msg_limit  = ${if exists{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{${lookup {$authenticated_id} lsearch{/etc/exim4/domains/${lookup{${domain:$authenticated_id}}dsearch{/etc/exim4/domains/}}/limits}{$value}{${readfile{/etc/exim4/limit.conf}}}}}{${readfile{/etc/exim4/limit.conf}}} }
+          !senders      = ${if exists{/etc/exim4/ratelimit_whitelist}{/etc/exim4/ratelimit_whitelist}{}}
           ratelimit     = $acl_c_msg_limit / 1h / strict/ $authenticated_id
 
-  warn    ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id
-          log_message           = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period
+  warn    !senders      = ${if exists{/etc/exim4/ratelimit_whitelist}{/etc/exim4/ratelimit_whitelist}{}}
+          ratelimit     = ${eval:$acl_c_msg_limit / 2} / 1h / strict / $authenticated_id
+          log_message   = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period
 
   deny    message       = Restricted characters in address
           domains       = +local_domains

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -1973,6 +1973,7 @@ if [ "$exim" = 'yes' ]; then
 	cp -f $HESTIA_INSTALL_DIR/exim/limit.conf /etc/exim4/
 	cp -f $HESTIA_INSTALL_DIR/exim/system.filter /etc/exim4/
 	touch /etc/exim4/white-blocks.conf
+	touch /etc/exim4/ratelimit_whitelist
 
 	if [ "$spamd" = 'yes' ]; then
 		sed -i "s/#SPAM/SPAM/g" /etc/exim4/exim4.conf.template

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1987,6 +1987,7 @@ if [ "$exim" = 'yes' ]; then
 	cp -f $HESTIA_INSTALL_DIR/exim/limit.conf /etc/exim4/
 	cp -f $HESTIA_INSTALL_DIR/exim/system.filter /etc/exim4/
 	touch /etc/exim4/white-blocks.conf
+	touch /etc/exim4/ratelimit_whitelist
 
 	if [ "$spamd" = 'yes' ]; then
 		sed -i "s/#SPAM/SPAM/g" /etc/exim4/exim4.conf.template


### PR DESCRIPTION
Adds /etc/exim4/ratelimit_whitelist, a plain-text file (one sender address per line) that exempts specific senders from the per-account hourly SMTP rate limit.

Problem
-------
The existing rate limit applies uniformly to all authenticated senders with no escape hatch. Legitimate high-volume senders — monitoring systems, notification services, mailing list relays — hit the limit and have no recourse short of editing the Exim template directly, which is overwritten on upgrades.

Solution
--------
Before the deny and the warn/log blocks in acl_check_rcpt, check the sender address against /etc/exim4/ratelimit_whitelist using Exim's built-in !senders condition. If the file doesn't exist the check is skipped safely (${if exists{...}} guard), so existing installs are unaffected until an admin creates the file.

The set acl_c_msg_limit assignment is also moved from a condition on the deny verb into a preceding warn block. This ensures the variable is always populated before the warn/log statement that references it, preventing an Exim expansion error when a whitelisted sender causes the deny (and its inline set) to be skipped.

To exempt a sender, an admin simply appends their address:
  echo "noreply@example.com" >> /etc/exim4/ratelimit_whitelist
  update-exim4.conf && systemctl restart exim4

Changes
-------
- exim4.conf.template and exim4.conf.4.95.template: restructured acl_check_rcpt rate-limit block with warn/set, deny/!senders, and warn/!senders/log in that order
- hst-install-debian.sh, hst-install-ubuntu.sh: touch /etc/exim4/ratelimit_whitelist on install so the file exists empty by default