### PR TITLE
Run bats testsuite on Github pull requests

### DIFF
--- a/.github/docker/files/netplan.01-docker.yaml
+++ b/.github/docker/files/netplan.01-docker.yaml
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: true

--- a/.github/docker/files/ssh.service.10-docker.conf
+++ b/.github/docker/files/ssh.service.10-docker.conf
@@ -1,0 +1,2 @@
+[Unit]
+StartLimitIntervalSec=0

--- a/.github/docker/hestia-ci.Dockerfile
+++ b/.github/docker/hestia-ci.Dockerfile
@@ -1,0 +1,69 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV container=docker
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends eatmydata \
+	&& EATMYDATA_SO="$(ldconfig -p | awk '/libeatmydata.so/{print $NF; exit}')" \
+	&& [ -n "${EATMYDATA_SO}" ] \
+	&& echo "${EATMYDATA_SO}" > /etc/ld.so.preload \
+	&& apt-get full-upgrade -y \
+	&& apt-get install -y --no-install-recommends \
+		apt-utils \
+		apt-transport-https \
+		ca-certificates \
+		curl \
+		dbus \
+		fail2ban \
+		git \
+		gnupg \
+		htop \
+		iproute2 \
+		iptables \
+		jq \
+		less \
+		locales \
+		lsb-release \
+		nano \
+		netcat-openbsd \
+		netplan.io \
+		net-tools \
+		rsync \
+		software-properties-common \
+		sudo \
+		systemd \
+		systemd-sysv \
+		systemd-timesyncd \
+		tzdata \
+		vim \
+		wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8 \
+	&& update-locale LANG=en_US.UTF-8
+
+# Ensure sshd privilege separation dir exists at boot on /run tmpfs.
+RUN printf 'd /run/sshd 0755 root root -\n' > /etc/tmpfiles.d/sshd.conf
+
+# Avoid ssh.service entering start-limit-hit during rapid restart loops in tests.
+RUN mkdir -p /etc/systemd/system/ssh.service.d \
+	&& cat > /etc/systemd/system/ssh.service.d/10-docker.conf << 'EOF'
+[Unit]
+StartLimitIntervalSec=0
+EOF
+
+# Ensure netplan exists in Ubuntu containers so v-add-sys-ip uses netplan path in tests.
+RUN cat > /etc/netplan/01-docker.yaml << 'EOF'
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: true
+EOF
+
+VOLUME ["/sys/fs/cgroup"]
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/.github/docker/hestia-ci.Dockerfile
+++ b/.github/docker/hestia-ci.Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -49,25 +47,11 @@ RUN locale-gen en_US.UTF-8 \
 RUN printf 'd /run/sshd 0755 root root -\n' > /etc/tmpfiles.d/sshd.conf
 
 # Avoid ssh.service entering start-limit-hit during rapid restart loops in tests.
-RUN << 'EOF'
-mkdir -p /etc/systemd/system/ssh.service.d
-cat > /etc/systemd/system/ssh.service.d/10-docker.conf <<'UNIT'
-[Unit]
-StartLimitIntervalSec=0
-UNIT
-EOF
+RUN mkdir -p /etc/systemd/system/ssh.service.d
+COPY .github/docker/files/ssh.service.10-docker.conf /etc/systemd/system/ssh.service.d/10-docker.conf
 
 # Ensure netplan exists in Ubuntu containers so v-add-sys-ip uses netplan path in tests.
-RUN << 'EOF'
-cat > /etc/netplan/01-docker.yaml <<'NETPLAN'
-network:
-  version: 2
-  renderer: networkd
-  ethernets:
-    eth0:
-      dhcp4: true
-NETPLAN
-EOF
+COPY .github/docker/files/netplan.01-docker.yaml /etc/netplan/01-docker.yaml
 
 VOLUME ["/sys/fs/cgroup"]
 

--- a/.github/docker/hestia-ci.Dockerfile
+++ b/.github/docker/hestia-ci.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -47,20 +49,24 @@ RUN locale-gen en_US.UTF-8 \
 RUN printf 'd /run/sshd 0755 root root -\n' > /etc/tmpfiles.d/sshd.conf
 
 # Avoid ssh.service entering start-limit-hit during rapid restart loops in tests.
-RUN mkdir -p /etc/systemd/system/ssh.service.d \
-	&& cat > /etc/systemd/system/ssh.service.d/10-docker.conf << 'EOF'
+RUN << 'EOF'
+mkdir -p /etc/systemd/system/ssh.service.d
+cat > /etc/systemd/system/ssh.service.d/10-docker.conf <<'UNIT'
 [Unit]
 StartLimitIntervalSec=0
+UNIT
 EOF
 
 # Ensure netplan exists in Ubuntu containers so v-add-sys-ip uses netplan path in tests.
-RUN cat > /etc/netplan/01-docker.yaml << 'EOF'
+RUN << 'EOF'
+cat > /etc/netplan/01-docker.yaml <<'NETPLAN'
 network:
   version: 2
   renderer: networkd
   ethernets:
     eth0:
       dhcp4: true
+NETPLAN
 EOF
 
 VOLUME ["/sys/fs/cgroup"]

--- a/.github/workflows/pr-docker-bats.yml
+++ b/.github/workflows/pr-docker-bats.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/pr-docker-bats.yml
+++ b/.github/workflows/pr-docker-bats.yml
@@ -50,6 +50,10 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/hestiacp-git" \
             -w /hestiacp-git \
             hestia-ci:${{ github.sha }}
+          for _ in {1..100}; do
+            docker exec hestia-ci bash -lc 'systemctl is-system-running 2>/dev/null | grep -Eq "running|degraded"' && break
+            sleep 0.1
+          done
 
       - name: Install Hestia from local git
         run: |

--- a/.github/workflows/pr-docker-bats.yml
+++ b/.github/workflows/pr-docker-bats.yml
@@ -1,0 +1,94 @@
+name: PR Docker BATS testsuite
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  docker-bats:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build CI container
+        run: |
+          docker build \
+            -f .github/docker/hestia-ci.Dockerfile \
+            -t hestia-ci:${{ github.sha }} \
+            .
+
+      - name: Start CI container
+        run: |
+          docker run -d \
+            --name hestia-ci \
+            --hostname hestia-dev.local \
+            --privileged \
+            --cgroupns=host \
+            --tmpfs /run \
+            --tmpfs /run/lock \
+            --tmpfs /tmp:exec,mode=1777 \
+            --dns 8.8.8.8 \
+            --dns 8.8.4.4 \
+            --dns 2001:4860:4860::8888 \
+            --dns 2001:4860:4860::8844 \
+            -e TZ=UTC \
+            -e LANG=en_US.UTF-8 \
+            -e LC_ALL=en_US.UTF-8 \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            -v "${GITHUB_WORKSPACE}:/hestiacp-git" \
+            -w /hestiacp-git \
+            hestia-ci:${{ github.sha }}
+
+      - name: Install Hestia from local git
+        run: |
+          docker exec hestia-ci bash -lc '
+            set -euxo pipefail
+            cd /hestiacp-git/src
+            bash ./hst_autocompile.sh --hestia --noinstall --keepbuild "~localsrc"
+            cd /hestiacp-git
+            bash install/hst-install-ubuntu.sh \
+              --hostname hestia.local.test \
+              --email admin@example.com \
+              --username admin \
+              --password Password123 \
+              --interactive no \
+              --force \
+              --with-debs /tmp/hestiacp-src/deb \
+              --clamav no \
+              --spamassassin no
+          '
+
+      - name: Run BATS test suite
+        run: |
+          docker exec hestia-ci bash -lc '
+            set -euxo pipefail
+            cd /hestiacp-git
+            if ! command -v bats >/dev/null 2>&1; then
+              test/test_helper/bats-core/install.sh /usr/local
+            fi
+            bats test/test.bats
+          '
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          docker exec hestia-ci bash -lc 'journalctl --no-pager -n 500' || true
+          docker exec hestia-ci bash -lc 'ls -la /root/hst_install_backups || true' || true
+          docker exec hestia-ci bash -lc 'tail -n 500 /root/hst_install_backups/hst_install-*.log || true' || true
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          docker rm -f hestia-ci || true

--- a/.github/workflows/pr-docker-bats.yml
+++ b/.github/workflows/pr-docker-bats.yml
@@ -1,4 +1,4 @@
-name: PR Docker BATS testsuite
+name: BATS testsuite
 
 on:
   pull_request:

--- a/.github/workflows/pr-docker-bats.yml
+++ b/.github/workflows/pr-docker-bats.yml
@@ -55,8 +55,21 @@ jobs:
         run: |
           docker exec hestia-ci bash -lc '
             set -euxo pipefail
+            export TERM=xterm
             cd /hestiacp-git/src
             bash ./hst_autocompile.sh --hestia --noinstall --keepbuild "~localsrc"
+            DEB_PATH=""
+            if compgen -G "/tmp/hestiacp-src/deb/hestia_*.deb" >/dev/null; then
+              DEB_PATH="/tmp/hestiacp-src/deb"
+            elif compgen -G "/tmp/hestiacp-src/debs/hestia_*.deb" >/dev/null; then
+              DEB_PATH="/tmp/hestiacp-src/debs"
+            else
+              echo "No local hestia debs found under /tmp/hestiacp-src/{deb,debs}"
+              ls -la /tmp/hestiacp-src || true
+              ls -la /tmp/hestiacp-src/deb || true
+              ls -la /tmp/hestiacp-src/debs || true
+              exit 1
+            fi
             cd /hestiacp-git
             bash install/hst-install-ubuntu.sh \
               --hostname hestia.local.test \
@@ -65,7 +78,7 @@ jobs:
               --password Password123 \
               --interactive no \
               --force \
-              --with-debs /tmp/hestiacp-src/deb \
+              --with-debs "${DEB_PATH}" \
               --clamav no \
               --spamassassin no
           '

--- a/.github/workflows/pr-docker-bats.yml
+++ b/.github/workflows/pr-docker-bats.yml
@@ -59,6 +59,14 @@ jobs:
             cd /hestiacp-git/src
             bash ./hst_autocompile.sh --hestia --noinstall --keepbuild "~localsrc"
             DEB_PATH=""
+            if [[ -f "/tmp/hestiacp-src/deb" ]]; then
+              pkg="$(dpkg-deb -f /tmp/hestiacp-src/deb Package)"
+              ver="$(dpkg-deb -f /tmp/hestiacp-src/deb Version)"
+              arch="$(dpkg-deb -f /tmp/hestiacp-src/deb Architecture)"
+              DEB_PATH="/tmp/hestiacp-src/debs"
+              mkdir -p "${DEB_PATH}"
+              cp /tmp/hestiacp-src/deb "${DEB_PATH}/${pkg}_${ver}_${arch}.deb"
+            fi
             if compgen -G "/tmp/hestiacp-src/deb/hestia_*.deb" >/dev/null; then
               DEB_PATH="/tmp/hestiacp-src/deb"
             elif compgen -G "/tmp/hestiacp-src/debs/hestia_*.deb" >/dev/null; then


### PR DESCRIPTION
~~This PR is not ready for merge, currently testing in this PR~~
Done testing, seems to work great 👍 

Create a pull-request GitHub Actions workflow that builds a Hestiacp-capable Ubuntu 24.04 docker-container,
 installs Hestia from local git-built debs, and runs test/test.bats in the container.

I encountered a bunch of issues getting hestiacp to run in docker, notes:

- hestiacp requires systemd and netplan, but it's not included by default in ubuntu24.04 docker, have to add it manually
- hestiacp installer requires /tmp to be executable, in docker /tmp is no-execute by default (we can probably fix that later)
- had trouble with apparmor..
- eatmydata is a performance hack (makes hestiacp install and bats run ~30% faster on my local computer)
