### PR TITLE
Use fixed FileGator version for installation

### DIFF
--- a/bin/v-add-sys-filemanager
+++ b/bin/v-add-sys-filemanager
@@ -23,8 +23,8 @@ MODE=$1
 user="$ROOT_USER"
 
 FM_INSTALL_DIR="$HESTIA/web/fm"
-FM_FILE="filegator_latest"
-FM_URL="https://github.com/filegator/static/raw/master/builds/filegator_latest.zip"
+FM_FILE="filegator_v${fm_v}"
+FM_URL="https://github.com/filegator/static/raw/master/builds/${FM_FILE}.zip"
 COMPOSER_BIN="$HOMEDIR/$user/.composer/composer"
 
 #----------------------------------------------------------#


### PR DESCRIPTION
Update the File Manager installation script to reference a specific FileGator version instead of using the latest build. This change introduces a versioned filename (`filegator_v${fm_v}`) and dynamically constructs the download URL based on that version, improving reproducibility and avoiding unexpected changes from upstream updates.