### PR TITLE
Fix File Manager null/empty session user handling in Hestia auth integration

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
+++ b/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
@@ -27,9 +27,7 @@ class HestiaAuth implements Service, AuthInterface {
 	protected $hestia_user = "";
 
 	public function init(array $config = []) {
-		if (isset($_SESSION["user"])) {
-			$v_user = $_SESSION["user"];
-		}
+		$v_user = $_SESSION["user"] ?? $_SESSION["USER"] ?? "";
 		if (!empty($_SESSION["look"])) {
 			if (isset($_SESSION["look"]) && $_SESSION["userContext"] === "admin") {
 				$v_user = $_SESSION["look"];
@@ -43,7 +41,7 @@ class HestiaAuth implements Service, AuthInterface {
 				exit();
 			}
 		}
-		$this->hestia_user = $v_user;
+		$this->hestia_user = is_string($v_user) ? $v_user : "";
 		$this->permissions = isset($config["permissions"]) ? (array) $config["permissions"] : [];
 		$this->private_repos = isset($config["private_repos"])
 			? (bool) $config["private_repos"]
@@ -51,13 +49,19 @@ class HestiaAuth implements Service, AuthInterface {
 	}
 
 	public function user(): ?User {
+		if ($this->hestia_user === "") {
+			return $this->getGuest();
+		}
+
 		$cmd = "/usr/bin/sudo /usr/local/hestia/bin/v-list-user";
 		exec($cmd . " " . quoteshellarg($this->hestia_user) . " json", $output, $return_var);
 
 		if ($return_var == 0) {
 			$data = json_decode(implode("", $output), true);
-			$hestia_user_info = $data[$this->hestia_user];
-			return $this->transformUser($hestia_user_info);
+			$hestia_user_info = $data[$this->hestia_user] ?? null;
+			if (is_array($hestia_user_info)) {
+				return $this->transformUser($hestia_user_info);
+			}
 		}
 
 		return $this->getGuest();

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -162,9 +162,7 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 	} else {
 		echo '<meta http-equiv="refresh" content="0; url=/">';
 	}
-	if (isset($_SESSION["user"])) {
-		$v_user = $_SESSION["user"];
-	}
+	$v_user = $_SESSION["user"] ?? $_SESSION["USER"] ?? "";
 	if (!empty($_SESSION["look"])) {
 		if (isset($_SESSION["look"]) && $_SESSION["userContext"] === "admin") {
 			$v_user = $_SESSION["look"];
@@ -176,6 +174,10 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 		) {
 			header("Location: /");
 		}
+	}
+	if ($v_user === "") {
+		echo '<meta http-equiv="refresh" content="0; url=/">';
+		exit();
 	}
 	# Create filemanager sftp key if missing and trash it after 30 min
 	if (!file_exists("/home/" . basename($v_user) . "/.ssh/hst-filemanager-key")) {


### PR DESCRIPTION
Summary This PR hardens Hestia File Manager integration against null/empty session user states to prevent runtime failures (including quoteshellarg(null) TypeError) in /fm/.

Fixes #5318

What changed

install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
Added session user fallback: $_SESSION["user"] ?? $_SESSION["USER"] ?? ""
Normalized assignment: is_string($v_user) ? $v_user : ""
Added early guard in user(): return guest user when session user is empty.
Added safer handling when v-list-user output does not contain expected user key.
install/deb/filemanager/filegator/configuration.php
Replaced direct session user assumption with fallback: $_SESSION["user"] ?? $_SESSION["USER"] ?? ""
Added explicit guard before using $v_user: redirect + exit when empty.
Why Even after the SessionStorage::migrate fix (#5241), /fm/ can still fail in edge session contexts due to missing user identity in session payload. This PR prevents those failures and preserves expected behavior (guest/redirect flow) instead of fatal errors.

Validation

php -l passed for:
install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
install/deb/filemanager/filegator/configuration.php
Runtime behavior:
/fm/ no longer fatals on empty session user path
valid authenticated sessions continue normal behavior.
Related context

#5240
#5281
#5241 (already fixed different issue)