### PR TITLE
Bump hestia-nginx version to 1.30.1

### DIFF
--- a/src/deb/nginx/control
+++ b/src/deb/nginx/control
@@ -1,7 +1,7 @@
 Source: hestia-nginx
 Package: hestia-nginx
 Priority: optional
-Version: 1.28.3
+Version: 1.30.1
 Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com


### PR DESCRIPTION
Nginx 1.30.x is the new stable version and version **1.30.1** fixes a few critical security fixes.

**Changes with nginx 1.30.1  - 13 May 2026**

    *) Security: when using the "proxy_set_body" directive, an attacker
       might inject data in the proxied request to an HTTP/2 backend
       (CVE-2026-42926).
       Thanks to Mufeed VH of Winfunc Research.

    *) Security: a heap memory buffer overflow might occur in a worker
       process while handling a specially crafted request by
       ngx_http_rewrite_module, potentially resulting in arbitrary code
       execution (CVE-2026-42945).
       Thanks to Leo Lin.

    *) Security: a heap memory buffer overread might occur in a worker
       process while handling a specially crafted response by
       ngx_http_scgi_module or ngx_http_uwsgi_module, allowing an attacker
       to cause a disclosure of worker process memory or segmentation fault
       in a worker process (CVE-2026-42946).
       Thanks to Leo Lin.

    *) Security: a heap memory buffer overread might occur in a worker
       process while handling a specially sent response with decoding from
       UTF-8 via the "charset_map" directive, allowing an attacker to cause
       a limited disclosure of worker proccess memory or segmentation fault
       in a worker process (CVE-2026-42934).
       Thanks to David Carlier.

    *) Security: when using HTTP/3, processing of connection migration might
       cause new QUIC streams to receive a new client address before
       validation, allowing an attacker to cause address spoofing
       (CVE-2026-40460).
       Thanks to Rodrigo Laneth.

    *) Security: use-after-free might occur during DNS server response
       processing if the "ssl_ocsp" directive was used, allowing an attacker
       to cause worker process memory corruption or segmentation fault in a
       worker process (CVE-2026-40701).
       Thanks to Leo Lin.

    *) Bugfix: connections with HTTP/2 backends might not be cached when
       using the "proxy_set_body" or "proxy_pass_request_body" directives.

    *) Bugfix: proxied HTTP/0.9, SCGI, or uWSGI responses might be
       transferred incorrectly if the first line was not fully read.