### PR TITLE
Bump hestia-nginx version to 1.30.2

### DIFF
--- a/src/deb/nginx/control
+++ b/src/deb/nginx/control
@@ -1,7 +1,7 @@
 Source: hestia-nginx
 Package: hestia-nginx
 Priority: optional
-Version: 1.30.1
+Version: 1.30.2
 Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com


### PR DESCRIPTION
[nginx-1.30.2](https://nginx.org/en/download.html) stable version has been released, with a fix for [buffer overflow](https://nginx.org/en/security_advisories.html) vulnerability in the ngx_http_rewrite_module (CVE-2026-9256).