### PR TITLE
Fix PR #5162

### DIFF
--- a/install/upgrade/versions/1.9.5.sh
+++ b/install/upgrade/versions/1.9.5.sh
@@ -75,9 +75,9 @@ done
 if [[ -n "$ANTISPAM_SYSTEM" ]]; then
 	installed_services="$(systemctl list-units --type=service 2>&1)"
 	if [[ $installed_services == *spamassassin.service* ]]; then
-		write_config_value "ANTISPAM_SYSTEM" "spamassassin"
+		"$BIN/v-change-sys-config-value" "ANTISPAM_SYSTEM" "spamassassin"
 	elif [[ $installed_services == *spamd.service* ]]; then
-		write_config_value "ANTISPAM_SYSTEM" "spamd"
+		"$BIN/v-change-sys-config-value" "ANTISPAM_SYSTEM" "spamd"
 	fi
 fi
 


### PR DESCRIPTION
Testing the upgrade I realized that `write_config_value` is not the right function to replace existing conf value.

I've fixed **Fix SpamAssassin service name for Ubuntu 24.04** #5162 in this PR.

@ScIT-Raphael please, merge this PR.