### PR TITLE
Drop python-based yescrypt validation due to crypt removal in Python 3.13

### DIFF
--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -85,14 +85,7 @@ if [ -z "$salt" ]; then
 fi
 
 if [ "$method" = "yescrypt" ]; then
-	if which python3 > /dev/null; then
-		export PASS="$password" SALT="$shadow"
-		hash=$(python3 -c 'import crypt, os; print(crypt.crypt(os.getenv("PASS"), os.getenv("SALT")))')
-	else
-		# Fall back to mkpasswd as fallback
-		hash=$(mkpasswd "$password" "$shadow")
-	fi
-
+	hash=$(mkpasswd "$password" "$shadow")
 	if [ $? -ne 0 ]; then
 		echo "Error: password missmatch"
 		if [ -z "$return_hash" ]; then


### PR DESCRIPTION
Remove the python3-based yescrypt hash validation since the crypt module was removed in Python 3.13, and switch to using mkpasswd for password verification instead.