### PR TITLE
Fix 1.9.5: rebuilding mail domains removes webmail SSL config

### DIFF
--- a/bin/v-rebuild-mail-domain
+++ b/bin/v-rebuild-mail-domain
@@ -69,7 +69,7 @@ rebuild_mail_domain_conf
 # Rebuild webmail configuration
 if [ -n "$WEB_SYSTEM" ] || [ -n "$PROXY_SYSTEM" ]; then
 	if [ -n "$IMAP_SYSTEM" ]; then
-		WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
+		WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "WEBMAIL")
 		if [ -n "$WEBMAIL" ]; then
 			$BIN/v-delete-mail-domain-webmail "$user" "$domain" "$restart" 'yes'
 			$BIN/v-add-mail-domain-webmail "$user" "$domain" "$WEBMAIL" "$restart" 'yes'

--- a/install/upgrade/versions/1.9.6.sh
+++ b/install/upgrade/versions/1.9.6.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.9.6
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### upgrade_config_set_value only accepts true or false.                    #######
+#######                                                                         #######
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+# Set UPGRADE_REBUILD_USERS to true to fix the bug that removes ssl conf for webmail
+# when rebuilding mail domains
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'true'


### PR DESCRIPTION
Due to the modified `get_object_value` in Hestia 1.9.5, a bug in `v-rebuild-mail-domain-webdomain` arose:

```bash
WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
```

This worked in previous versions of get_object_value by coincidence.

The fix is:

```bash
WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "WEBMAIL")
```

Also created upgrade script `1.9.6.sh` to set `UPGRADE_REBUILD_USERS` to `true` so current installations can be fixed.

@jaapmarcus @ScIT-Raphael @divinity76 please, take a look because right now there are a lot of servers without access to the webmail.

Fixes #5353