### PR TITLE
Bump Roundcube to version 1.6.16

### DIFF
--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -50,7 +50,7 @@ pga_v='7.14.6'
 
 # Set version of RoundCube (Webmail) to update during upgrade if not already installed
 # Note: only applies to "non-apt installs >= 1.4.0 or manually phased out"
-rc_v='1.6.15'
+rc_v='1.6.16'
 
 # Set version of SnappyMail (Webmail) to update during upgrade if not already installed
 sm_v='2.38.2'


### PR DESCRIPTION
This is a security update to the LTS version 1.6 of Roundcube Webmail.
It provides fixes to recently reported security vulnerabilities:

    Fix stored XSS/HTML/CSS injection in subject field of the draft restore dialog, reported by zazy
    Fix CSS injection bypass in HTML sanitizer via SVG <animate attributeName="style">, reported by wooseokdotkim
    Fix pre-auth SQL injection in virtuser_query plugin via preg_replace backslash escape bypass, reported by skull
    Fix SSRF bypass via specific local address URLs
    Fix local/private URL fetch bypass when remote resources were not allowed, reported by Orange Cyberdefense Vulnerability Disclosure Team
    Fix bypass of remote image blocking via CSS var(), reported by Geame
    Fix pre-auth arbitrary file delete via redis/memcache session poisoning bypass, reported by valent1
    Fix code injection vulnerability - remove support for code evaluation in LDAP autovalues option, reported by Glendaenri
