### PR TITLE
Fix: Remove /public document root from Moodle Nginx templates

### DIFF
--- a/install/deb/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/deb/templates/web/nginx/php-fpm/moodle.stpl
@@ -7,7 +7,7 @@
 server {
 	listen      %ip%:%web_ssl_port% ssl;
 	server_name %domain_idn% %alias_idn%;
-	root        %sdocroot%/public;
+	root        %sdocroot%;
 	index       index.php index.html index.htm;
 	access_log  /var/log/nginx/domains/%domain%.log combined;
 	access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/deb/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/deb/templates/web/nginx/php-fpm/moodle.tpl
@@ -7,7 +7,7 @@
 server {
 	listen      %ip%:%web_port%;
 	server_name %domain_idn% %alias_idn%;
-	root        %docroot%/public;
+	root        %docroot%;
 	index       index.php index.html index.htm;
 	access_log  /var/log/nginx/domains/%domain%.log combined;
 	access_log  /var/log/nginx/domains/%domain%.bytes bytes;


### PR DESCRIPTION
**What does this PR do?**
This PR fixes a bug in the Nginx templates for Moodle (`moodle.tpl` and `moodle.stpl`) that causes a 404 error on fresh deployments.

It removes the `/public` directory from the `root` directive. Unlike modern frameworks (like Laravel or Symfony), Moodle's core architecture requires the document root to point directly to `public_html` (the `%docroot%` variable), as it does not use a `/public` subfolder for its entry point.

**Why is this change necessary?**
Without this change, any user selecting the `moodle` template in HestiaCP will experience a 404 Not Found error by default.

**Testing**
1. Assigned the updated `moodle` template to a web domain in HestiaCP.
2. Verified that Nginx correctly routes traffic to `/public_html` instead of `/public_html/public`.
3. Moodle interface loads successfully.