### PR TITLE
[Fixed] The Database Creation tab doesn’t show which prefix will be added

### DIFF
--- a/web/templates/pages/add_db.php
+++ b/web/templates/pages/add_db.php
@@ -48,7 +48,7 @@
 			<?php if (($_SESSION["role"] == "admin" && $accept === "true") || $_SESSION["role"] !== "admin") { ?>
 					<p class="hint u-mb20">
 						<?php
-							$prefix_hint = tohtml(_("Prefix %s will be automatically added to database name and database user"));
+							$prefix_hint = _("Prefix %s will be automatically added to database name and database user");
 							$prefix_hint_html = '<span class="u-text-bold">' . tohtml($user_plain) . '_</span>';
 							printf($prefix_hint, $prefix_hint_html);
 						?>


### PR DESCRIPTION
Demo has the same issue.

Forum posts: [1](https://forum.hestiacp.com/t/anyone-tested-the-1-9-5-release-yet-on-debian/21808/44), [2](https://forum.hestiacp.com/t/anyone-tested-the-1-9-5-release-yet-on-debian/21808/45), [3](https://forum.hestiacp.com/t/anyone-tested-the-1-9-5-release-yet-on-debian/21808/46)

<img width="1112" height="749" alt="image" src="https://github.com/user-attachments/assets/574fcc33-5f30-46f5-b65c-2e06b284eb61" />
