### PR TITLE
Fix(i18n): add locale fallback when en_US.UTF-8 is unavailable

### DIFF
--- a/web/inc/i18n.php
+++ b/web/inc/i18n.php
@@ -3,7 +3,7 @@
 // I18N support information here
 
 putenv("LANGUAGE=" . detect_user_language());
-setlocale(LC_ALL, "en_US.UTF-8");
+setlocale(LC_ALL, "en_US.UTF-8", "C.UTF-8", "C");
 
 $domain = "hestiacp";
 $localedir = "/usr/local/hestia/web/locale";


### PR DESCRIPTION
@50P15 found the bug and provided the solution.

Fixes an issue where translations doesn't work on systems that do not have the `en_US.UTF-8` locale generated.

The current code assumes that `en_US.UTF-8` is always available. On systems where this locale is missing, `setlocale()` fails and gettext initialization can behave unexpectedly, resulting in untranslated strings.

This change adds fallback locales:

```php
setlocale(LC_ALL, "en_US.UTF-8", "C.UTF-8", "C");
```

The application will now use en_US.UTF-8 when available, fall back to C.UTF-8 on systems that provide it, and finally use the standard C locale as a last resort.

Fixes #5385