### PR TITLE
Fix phpMyAdmin SSO failing  when hostname returns short hostname

### DIFF
--- a/bin/v-add-sys-pma-sso
+++ b/bin/v-add-sys-pma-sso
@@ -71,7 +71,7 @@ chown root:hestiamail $PMA_INSTALL/hestia-sso.php
 
 sed -i "s/%PHPMYADMIN_KEY%/$phpmyadminkey/g" $PMA_INSTALL/hestia-sso.php
 sed -i "s/%API_KEY%/$apikey/g" $PMA_INSTALL/hestia-sso.php
-sed -i "s/%API_HOST_NAME%/$(hostname)/g" $PMA_INSTALL/hestia-sso.php
+sed -i "s/%API_HOST_NAME%/$(hostname -f)/g" $PMA_INSTALL/hestia-sso.php
 sed -i "s/%API_HESTIA_PORT%/$BACKEND_PORT/g" $PMA_INSTALL/hestia-sso.php
 
 # Check if config already contains the keys


### PR DESCRIPTION
## Description

This change replaces `hostname` with `hostname -f` when generating the phpMyAdmin SSO configuration.

### Problem

On some systems `hostname` returns only the short hostname:

```text
panel
```

while the actual server hostname is:

```text
panel.domain.com
```

The generated `hestia-sso.php` file therefore contains the short hostname, causing phpMyAdmin SSO authentication to fail because the API host validation expects the fully qualified hostname.

### Solution

Use:

```bash
hostname -f
```

instead of:

```bash
hostname
```

when replacing `%API_HOST_NAME%`.

### Testing

Server hostname:

```text
panel.domain.com
```

Before change:

* Generated host value: `panel`
* phpMyAdmin SSO failed
* Clicking the database arrow opened the phpMyAdmin login page

After change:

* Generated host value: `panel.domain.com`
* phpMyAdmin SSO succeeded
* Clicking the database arrow logs directly into phpMyAdmin
