### PR TITLE
Bump hestia-php version to 8.4.22

### DIFF
--- a/src/deb/php/control
+++ b/src/deb/php/control
@@ -1,7 +1,7 @@
 Source: hestia-php
 Package: hestia-php
 Priority: optional
-Version: 8.4.21
+Version: 8.4.22
 Section: admin
 Maintainer: HestaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com


### PR DESCRIPTION
**Version 8.4.22**

04 Jun 2026

    Date:
        Fixed bug [GH-18422](https://github.com/php/php-src/issues/18422) (int overflow in php_date_llabs).
    Intl:
        Fix incorrect argument positions in out-of-bounds errors for IntlCalendar::set(), IntlCalendar::setDate(), IntlCalendar::setDateTime(), and IntlGregorianCalendar date/time construction.
        Expose Spoofchecker restriction-level APIs on all supported ICU versions.
        Fix SpoofChecker::setAllowedChars() and IntlDateFormatter::__construct() to report PHP constant names instead of ICU constant names in user-visible error messages.
    MySQLnd:
        Fix persistent free of non-persistent connect_attr key (David Carlier).
    Opcache:
        Fixed tracing JIT crash when a VM interrupt is handled during an observed user function call.
        Fixed bug [GH-22004](https://github.com/php/php-src/issues/22004) (Assertion failure at ext/opcache/jit/zend_jit_trace.c).
    OpenSSL:
        Fix compatibility issues with OpenSSL 4.0.
    SPL:
        Fix SplFixedArray::setSize leak when destructor grows during clear.
        Fixed bug [GH-21933](https://github.com/php/php-src/issues/21933) (use after free of self-freeing MultipleIterator children).
    Standard:
        Fixed bug [GH-21689](https://github.com/php/php-src/issues/21689) (version_compare() incorrectly handles versions ending with a dot).
        Fixed ip2long() leading zeros handling inconsistency on AIX.