### PR TITLE
Fix get_percentage() returning 0 when total limit is unlimited

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -404,7 +404,7 @@ function humanize_usage_measure($usage) {
 }
 
 function get_percentage($used, $total) {
-	if ($total = "unlimited") {
+	if ($total == "unlimited") {
 		//return 0 if unlimited
 		return 0;
 	}

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -404,7 +404,7 @@ function humanize_usage_measure($usage) {
 }
 
 function get_percentage($used, $total) {
-	if ($total == "unlimited") {
+	if ($total === "unlimited") {
 		//return 0 if unlimited
 		return 0;
 	}


### PR DESCRIPTION
### Description
This pull request fixes a bug in the `get_percentage()` helper function where the check for `"unlimited"` total uses the assignment operator (`=`) instead of the comparison operator (`==`). 

As a result, `$total` was always assigned the value `"unlimited"`, which evaluated to truthy, causing the function to always return `0`. This made all disk, database, and other resource usage percentage indicators in the control panel show `0%`.

### Changes
- Fixed comparison operator in `get_percentage()` function inside `web/inc/main.php`.
