### PR TITLE
Fix Let's Encrypt YR1 chain validation

### DIFF
--- a/bin/v-add-letsencrypt-host
+++ b/bin/v-add-letsencrypt-host
@@ -67,11 +67,11 @@ add_ssl="yes"
 if [ "$SSL" = "yes" ]; then
 	# Valildate SSL Certificate
 	if [ -e "$USER_DATA/ssl/$domain.ca" ]; then
-		if openssl verify -CAfile <(openssl x509 -in $USER_DATA/ssl/$domain.ca) $USER_DATA/ssl/$domain.pem | grep -q "$domain.pem: OK"; then
+		if openssl verify -CAfile "$USER_DATA/ssl/$domain.ca" "$USER_DATA/ssl/$domain.pem" | grep -q "$domain.pem: OK"; then
 			add_ssl="no"
 		fi
 	else
-		if openssl verify $USER_DATA/ssl/$domain.pem | grep -q "$domain.pem: OK"; then
+		if openssl verify "$USER_DATA/ssl/$domain.pem" | grep -q "$domain.pem: OK"; then
 			add_ssl="no"
 		fi
 	fi


### PR DESCRIPTION
The previous implementation only validated the first certificate from the CA bundle. This caused verification failures when the bundle contained both the Let's Encrypt YR1 intermediate and the Root YR certificate.

Use the complete CA bundle during verification so the full chain can be validated.

Fixes #5396