### PR TITLE
fix: set writable phpMyAdmin tmp dir to avoid template cache error

### DIFF
--- a/install/deb/phpmyadmin/pma.sh
+++ b/install/deb/phpmyadmin/pma.sh
@@ -43,6 +43,15 @@ echo "\$cfg['Servers'][\$i]['pdf_pages'] = 'pma__pdf_pages';" >> $pmapath
 echo "\$cfg['Servers'][\$i]['designer_coords'] = 'pma__designer_coords';" >> $pmapath
 echo "\$cfg['Servers'][\$i]['hide_db'] = 'information_schema';" >> $pmapath
 
+# Create temporal dir in /var/lib/
+phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"
+phpmyadmin_tmp="/var/lib/phpmyadmin/tmp"
+
+mkdir -p "$phpmyadmin_tmp"
+chown -R hestiamail:www-data "$phpmyadmin_tmp"
+echo "<?php" > "$phpmyadmin_tempdir_conf"
+echo "\$cfg['TempDir'] = '$phpmyadmin_tmp';" >> "$phpmyadmin_tempdir_conf"
+
 #SOME WORK with DATABASE (table / user)
 PMADB=phpmyadmin
 PMAUSER=pma

--- a/install/upgrade/manual/migrate_phpmyadmin.sh
+++ b/install/upgrade/manual/migrate_phpmyadmin.sh
@@ -131,6 +131,15 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	echo "\$cfg['Servers'][\$i]['pdf_pages'] = 'pma__pdf_pages';" >> $pmapath
 	echo "\$cfg['Servers'][\$i]['designer_coords'] = 'pma__designer_coords';" >> $pmapath
 
+	# Create temporal dir in /var/lib/
+	phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"
+	phpmyadmin_tmp="/var/lib/phpmyadmin/tmp"
+
+	mkdir -p "$phpmyadmin_tmp"
+	chown -R hestiamail:www-data "$phpmyadmin_tmp"
+	echo "<?php" > "$phpmyadmin_tempdir_conf"
+	echo "\$cfg['TempDir'] = '$phpmyadmin_tmp';" >> "$phpmyadmin_tempdir_conf"
+
 	#SOME WORK with DATABASE (table / user)
 	PMADB=phpmyadmin
 	PMAUSER=pma

--- a/install/upgrade/versions/1.10.0.sh
+++ b/install/upgrade/versions/1.10.0.sh
@@ -165,3 +165,18 @@ if grep -q "^Subsystem.*/usr/lib/sftp-server-" /etc/ssh/sshd_config; then
 	sed -i 's/^Subsystem sftp \/usr\/lib\/sftp-server-.*/Subsystem sftp \/usr\/lib\/sftp-server/' /etc/ssh/sshd_config
 	systemctl reload ssh
 fi
+
+# Move phpMyAdmin tmp dir to /var/lib/phpmyadmin/tmp
+phpmyadmin_conf="/etc/phpmyadmin/conf.d/01-localhost.php"
+phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"
+
+if [[ -f "$phpmyadmin_conf" ]]; then
+	mkdir -p /var/lib/phpmyadmin/tmp/
+	chown -R hestiamail:www-data /var/lib/phpmyadmin/tmp/
+	if [[ ! -f "$phpmyadmin_tempdir_conf" ]]; then
+		cat > "$phpmyadmin_tempdir_conf" << 'EOF'
+<?php
+$cfg['TempDir'] = '/var/lib/phpmyadmin/tmp';
+EOF
+	fi
+fi


### PR DESCRIPTION
phpMyAdmin was failing to cache templates because Sury's PHP packages introduced systemd hardening that makes `/usr/share/phpmyadmin/tmp/` non-writable. This PR creates `/var/lib/phpmyadmin/tmp/` as a writable alternative and configures it via a dedicated `02-tempdir.php` conf file. Applied to fresh installs, manual migrations and the 1.10.0 upgrade script.