### PR TITLE
Bump OpenSSL to LTS 3.5.7

### DIFF
--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -217,7 +217,7 @@ fi
 echo "Build version $BUILD_VER, with Nginx version $NGINX_V, PHP version $PHP_V and Web Terminal version $WEB_TERMINAL_V"
 
 HESTIA_V="${BUILD_VER}_${BUILD_ARCH}"
-OPENSSL_V='3.4.5'
+OPENSSL_V='3.5.7'
 PCRE_V='10.47'
 ZLIB_V='1.3.2'
 


### PR DESCRIPTION
OpenSSL support for 3.4.x ends in October, so I think it's a good idea to move to 3.5.x LTS, which is supported until 8 April 2030.

I've tested it, and it compiles and works well.