### PR TITLE
Revert "Update ubuntu Docker tag to v26"

### DIFF
--- a/.github/docker/hestia-ci.Dockerfile
+++ b/.github/docker/hestia-ci.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV container=docker


### PR DESCRIPTION
Reverts hestiacp/hestiacp#5379

Hestiacp, even the bleeding edge git version, is not ready for Ubuntu 26.04, 

The change has made all testsuite runs fail on every pull request.

Revert to Ubuntu24.04 for now - When hestiacp is ready, we can make a separate ubuntu26.04 testsuite run. It's not ready yet.