### PR TITLE
hst_autocompile.sh: allow overriding BUILD_DIR via environment

### DIFF
--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -109,7 +109,7 @@ usage() {
 
 # Set compiling directory
 REPO='hestiacp/hestiacp'
-BUILD_DIR='/tmp/hestiacp-src'
+BUILD_DIR="${BUILD_DIR:-/tmp/hestiacp-src}"
 INSTALL_DIR='/usr/local/hestia'
 SRC_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 ARCHIVE_DIR="$SRC_DIR/src/archive/"


### PR DESCRIPTION
## What does this PR do
One-line change: `BUILD_DIR='/tmp/hestiacp-src'` → `BUILD_DIR="${BUILD_DIR:-/tmp/hestiacp-src}"`. The default behaviour is unchanged; it just becomes possible to override the build location via environment variable.

## Why
On systems where `/tmp` is a tmpfs (default on many minimal/cloud Debian images), compiling all packages with `hst_autocompile.sh --all` can exhaust the tmpfs (e.g. 1.9G on a 4GB VPS) and the build fails midway. Being able to run `BUILD_DIR=/root/hestiacp-build bash src/hst_autocompile.sh ...` solves it without patching the script.

Found while building the packages for Debian 13 (trixie) testing. Verified: full `--all --noinstall` build completes on Debian 13 with the override, and behaves identically without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)