### PR TITLE
Fix hestia-php deb dependencies for Debian 13 (libzip5)

### DIFF
--- a/src/deb/php/control
+++ b/src/deb/php/control
@@ -6,8 +6,7 @@ Section: admin
 Maintainer: HestaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com
 Architecture: amd64
-Depends: hestia, libzip4, unzip, libonig5 | libonig4 | libonig2
-Conflct: libzip5
+Depends: hestia, libzip5 | libzip4t64 | libzip4, unzip, libonig5 | libonig4 | libonig2
 Description: hestia php-fpm
  hestia is an open source hosting control panel.
  hestia has a clean and focused interface without the clutter.

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -525,17 +525,6 @@ if [ "$PHP_B" = true ]; then
 		sed -i "s/amd64/${BUILD_ARCH}/g" "$BUILD_DIR_HESTIAPHP/DEBIAN/control"
 	fi
 
-	os=$(lsb_release -is)
-	release=$(lsb_release -rs)
-	if [[ "$os" = "Ubuntu" ]] && [[ "$release" = "20.04" ]]; then
-		sed -i "/Conflicts: libzip5/d" "$BUILD_DIR_HESTIAPHP/DEBIAN/control"
-		sed -i "s/libzip4/libzip5/g" "$BUILD_DIR_HESTIAPHP/DEBIAN/control"
-	fi
-	if [[ "$os" = "Ubuntu" ]] && [[ "$release" = "24.04" ]]; then
-		sed -i "/Conflicts: libzip5/d" "$BUILD_DIR_HESTIAPHP/DEBIAN/control"
-		sed -i "s/libzip4/libzip4t64/g" "$BUILD_DIR_HESTIAPHP/DEBIAN/control"
-	fi
-
 	get_branch_file 'src/deb/php/copyright' "$BUILD_DIR_HESTIAPHP/DEBIAN/copyright"
 	get_branch_file 'src/deb/php/postinst' "$BUILD_DIR_HESTIAPHP/DEBIAN/postinst"
 	chmod +x $BUILD_DIR_HESTIAPHP/DEBIAN/postinst


### PR DESCRIPTION
## What does this PR do
Updates `src/deb/php/control`:
- `Depends: libzip4` → `libzip5 | libzip4t64 | libzip4` (covers Debian 13, Ubuntu 24.04 and Debian 12 respectively)
- Removes the `Conflct: libzip5` line — the field name is misspelled so dpkg never treated it as a real `Conflicts`, and it would contradict the new dependency anyway.

## Why
Debian 13 (trixie) only ships `libzip5` (1.11.x); `libzip4` does not exist there, which makes the `hestia-php` package uninstallable and breaks apt dependency resolution for any subsequent package. Now that Debian 13 support is merged into main (#5388), this is one of the remaining blockers for building/installing the packages on trixie.

Tested on a Debian 13 lab VPS: rebuilt `hestia-php` with this control file and completed a full installation (web + mail stack) with `--with-debs`; also verified the alternation still resolves to `libzip4` on Debian 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)