### PR TITLE
fix(installer): use single quotes to prevent password expansion

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -275,7 +275,7 @@ for arg; do
 		--with-debs) args="${args}-D " ;;
 		--help) args="${args}-h " ;;
 		*)
-			[[ "${arg:0:1}" == "-" ]] || delim="\""
+			[[ "${arg:0:1}" == "-" ]] || delim="'"
 			args="${args}${delim}${arg}${delim} "
 			;;
 	esac

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -276,7 +276,7 @@ for arg; do
 		--with-debs) args="${args}-D " ;;
 		--help) args="${args}-h " ;;
 		*)
-			[[ "${arg:0:1}" == "-" ]] || delim="\""
+			[[ "${arg:0:1}" == "-" ]] || delim="'"
 			args="${args}${delim}${arg}${delim} "
 			;;
 	esac


### PR DESCRIPTION
The installer's argument pre-processor was wrapping parameter values in double quotes before calling eval. This caused the shell to expand  special characters like '$' when passing passwords as arguments, resulting in incorrect credentials being set during installation.

Switched the argument delimiter from double to single quotes in the long-to-short option converter to ensure values are treated as literal strings.

Example using current delim: `delim="\""`

```bash
❯ bash hst-install-ubuntu.sh --hostname hestia.example.net --username 'admin' --email 'postmaster@example.net' --password 'HereThe$Password' --sieve yes --clamav no --quota yes --webterminal yes --interactive no --with-debs /home/sahsanu/hestiacp-src/deb
-s "hestia.example.net" -u "admin" -e "postmaster@example.net" -p "HereThe$Password" -Z "yes" -c "no" -q "yes" -W "yes" -y "no" -D "/home/sahsanu/hestiacp-src/deb"
==================== DEBUG ====================
apache        = <not set>
phpfpm        = <not set>
multiphp      = <not set>
vsftpd        = <not set>
proftpd       = <not set>
named         = <not set>
mysql         = <not set>
mysql8        = <not set>
postgresql    = <not set>
exim          = <not set>
dovecot       = <not set>
sieve         = yes
clamd         = no
spamd         = <not set>
iptables      = <not set>
fail2ban      = <not set>
quota         = yes
resourcelimit = <not set>
webterminal   = yes
port          = <not set>
lang          = <not set>
api           = <not set>
interactive   = no
servername    = hestia.example.net
email         = postmaster@example.net
username      = admin
vpass         = HereThe     <------ incorrect password
withdebs      = /home/sahsanu/hestiacp-src/deb
force         = <not set>
args (raw)    = -s "hestia.example.net" -u "admin" -e "postmaster@example.net" -p "HereThe$Password" -Z "yes" -c "no" -q "yes" -W "yes" -y "no" -D "/home/sahsanu/hestiacp-src/deb"
===============================================

```

Example using fixed delim: `delim="'"`

```bash
❯ bash hst-install-ubuntu.sh --hostname hestia.example.net --username 'admin' --email 'postmaster@example.net' --password 'HereThe$Password' --sieve yes --clamav no --quota yes --webterminal yes --interactive no --with-debs /home/sahsanu/hestiacp-src/deb
-s 'hestia.example.net' -u 'admin' -e 'postmaster@example.net' -p 'HereThe$Password' -Z 'yes' -c 'no' -q 'yes' -W 'yes' -y 'no' -D '/home/sahsanu/hestiacp-src/deb'
==================== DEBUG ====================
apache        = <not set>
phpfpm        = <not set>
multiphp      = <not set>
vsftpd        = <not set>
proftpd       = <not set>
named         = <not set>
mysql         = <not set>
mysql8        = <not set>
postgresql    = <not set>
exim          = <not set>
dovecot       = <not set>
sieve         = yes
clamd         = no
spamd         = <not set>
iptables      = <not set>
fail2ban      = <not set>
quota         = yes
resourcelimit = <not set>
webterminal   = yes
port          = <not set>
lang          = <not set>
api           = <not set>
interactive   = no
servername    = hestia.example.net
email         = postmaster@example.net
username      = admin
vpass         = HereThe$Password   <------ correct password
withdebs      = /home/sahsanu/hestiacp-src/deb
force         = <not set>
args (raw)    = -s 'hestia.example.net' -u 'admin' -e 'postmaster@example.net' -p 'HereThe$Password' -Z 'yes' -c 'no' -q 'yes' -W 'yes' -y 'no' -D '/home/sahsanu/hestiacp-src/deb'
===============================================
```