### PR TITLE
Allow continuing installation when netplan config is missing

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -530,14 +530,14 @@ if [ -d /etc/netplan ] && [ -z "$force" ]; then
 		echo
 		#check_result 1 "Unable to detect netplan configuration."
 
-        echo "Unable to detect netplan configuration."
-        echo
+		echo "Unable to detect netplan configuration."
+		echo
 
-        read -p 'Would you like to continue without netplan? [y/N]: ' answer
+		read -p 'Would you like to continue without netplan? [Y/n]: ' answer
 
-        if [ "$answer" != 'y' ] && [ "$answer" != 'Y' ] && [ "$answer" != '' ]; then
-            exit 1
-        fi
+		if [ "$answer" != 'y' ] && [ "$answer" != 'Y' ] && [ "$answer" != '' ]; then
+			exit 1
+		fi
 	fi
 fi
 

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -528,7 +528,15 @@ if [ -d /etc/netplan ] && [ -z "$force" ]; then
 		echo
 		echo '!!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!'
 		echo
-		check_result 1 "Unable to detect netplan configuration."
+		#check_result 1 "Unable to detect netplan configuration."
+		echo "Unable to detect netplan configuration."
+
+			read -rp "Do you still want to continue without netplan? [Y/n]: " confirm
+
+			case "${confirm,,}" in
+			    ""|y|yes) ;;
+			    *) exit 1 ;;
+			esac
 	fi
 fi
 

--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -529,14 +529,15 @@ if [ -d /etc/netplan ] && [ -z "$force" ]; then
 		echo '!!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!'
 		echo
 		#check_result 1 "Unable to detect netplan configuration."
-		echo "Unable to detect netplan configuration."
 
-			read -rp "Do you still want to continue without netplan? [Y/n]: " confirm
+        echo "Unable to detect netplan configuration."
+        echo
 
-			case "${confirm,,}" in
-			    ""|y|yes) ;;
-			    *) exit 1 ;;
-			esac
+        read -p 'Would you like to continue without netplan? [y/N]: ' answer
+
+        if [ "$answer" != 'y' ] && [ "$answer" != 'Y' ] && [ "$answer" != '' ]; then
+            exit 1
+        fi
 	fi
 fi
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -517,7 +517,16 @@ if [ -d /etc/netplan ] && [ -z "$force" ]; then
 		echo
 		echo '!!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!! !!!'
 		echo
-		check_result 1 "Unable to detect netplan configuration."
+		#check_result 1 "Unable to detect netplan configuration."
+
+		echo "Unable to detect netplan configuration."
+
+			read -rp "Do you still want to continue without netplan? [Y/n]: " confirm
+
+			case "${confirm,,}" in
+			    ""|y|yes) ;;
+			    *) exit 1 ;;
+			esac
 	fi
 fi
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -519,14 +519,14 @@ if [ -d /etc/netplan ] && [ -z "$force" ]; then
 		echo
 		#check_result 1 "Unable to detect netplan configuration."
 
-		echo "Unable to detect netplan configuration."
+        echo "Unable to detect netplan configuration."
+        echo
 
-			read -rp "Do you still want to continue without netplan? [Y/n]: " confirm
+        read -p 'Would you like to continue without netplan? [y/N]: ' answer
 
-			case "${confirm,,}" in
-			    ""|y|yes) ;;
-			    *) exit 1 ;;
-			esac
+        if [ "$answer" != 'y' ] && [ "$answer" != 'Y' ] && [ "$answer" != '' ]; then
+            exit 1
+        fi
 	fi
 fi
 

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -519,14 +519,14 @@ if [ -d /etc/netplan ] && [ -z "$force" ]; then
 		echo
 		#check_result 1 "Unable to detect netplan configuration."
 
-        echo "Unable to detect netplan configuration."
-        echo
+		echo "Unable to detect netplan configuration."
+		echo
 
-        read -p 'Would you like to continue without netplan? [y/N]: ' answer
+		read -p 'Would you like to continue without netplan? [Y/n]: ' answer
 
-        if [ "$answer" != 'y' ] && [ "$answer" != 'Y' ] && [ "$answer" != '' ]; then
-            exit 1
-        fi
+		if [ "$answer" != 'y' ] && [ "$answer" != 'Y' ] && [ "$answer" != '' ]; then
+			exit 1
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Currently the installer aborts when /etc/netplan exists but contains no configuration files.

In some environments, networking is managed through systemd-networkd or custom configurations, and users may still want to proceed with the installation despite the warning.

This change replaces the hard failure with an interactive confirmation prompt:

Unable to detect netplan configuration.
Do you still want to continue without netplan? [Y/n]:

Pressing Enter, y, or yes continues the installation, while any other response aborts.

Files changed
install/hst-install-ubuntu.sh
install/hst-install-debian.sh

Benefits
Prevents unnecessary installer termination.
Preserves the existing warning message.
Gives users control over whether to continue.
Maintains a safe default by clearly notifying users of the potential networking issue.
Testing

Tested on a system where /etc/netplan exists but contains no configuration files.

Enter → installation continues
y / yes → installation continues
n / no → installation exits