### PR TITLE
fix(biome): add aria-hidden and focusable="false" to decorative SVGs

### DIFF
--- a/install/common/templates/web/skel/document_errors/403.html
+++ b/install/common/templates/web/skel/document_errors/403.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="error icon-large fa-times-circle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/install/common/templates/web/skel/document_errors/404.html
+++ b/install/common/templates/web/skel/document_errors/404.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="info icon-large fa-question-circle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/install/common/templates/web/skel/document_errors/410.html
+++ b/install/common/templates/web/skel/document_errors/410.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="info icon-large fa-sign-out-alt"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/install/common/templates/web/skel/document_errors/50x.html
+++ b/install/common/templates/web/skel/document_errors/50x.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="warning icon-large fa-exclamation-triangle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 576 512"

--- a/install/common/templates/web/skel/public_html/index.html
+++ b/install/common/templates/web/skel/public_html/index.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="warning icon-large fa-hard-hat"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/install/common/templates/web/suspend/index.html
+++ b/install/common/templates/web/suspend/index.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="error icon-large fa-exclamation-circle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/install/common/templates/web/unassigned/index.html
+++ b/install/common/templates/web/unassigned/index.html
@@ -95,6 +95,8 @@
 					<div class="animate__animated animate__fadeIn">
 						<i class="success">
 							<svg
+								aria-hidden="true"
+								focusable="false"
 								class="success icon-large fa-check-circle"
 								xmlns="http://www.w3.org/2000/svg"
 								viewBox="0 0 512 512"

--- a/web/error/403.html
+++ b/web/error/403.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="error icon-large fa-times-circle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/web/error/404.html
+++ b/web/error/404.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="info icon-large fa-question-circle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/web/error/410.html
+++ b/web/error/410.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="info icon-large fa-sign-out-alt"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 512 512"

--- a/web/error/50x.html
+++ b/web/error/50x.html
@@ -94,6 +94,8 @@
 				<div class="col">
 					<div class="animate__animated animate__fadeIn">
 						<svg
+							aria-hidden="true"
+							focusable="false"
 							class="warning icon-large fa-exclamation-triangle"
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 576 512"


### PR DESCRIPTION
Fixes Biome lint errors in template and error pages. Decorative SVG icons were missing accessibility attributes, so `aria-hidden="true"` and `focusable="false"` have been added since these SVGs are purely decorative and accompanied by descriptive text.