### PR TITLE
Typo in $KEEP_MONTHLY on v-backup-user-restic

### DIFF
--- a/bin/v-backup-user-restic
+++ b/bin/v-backup-user-restic
@@ -89,8 +89,8 @@ fi
 if [[ -n "$KEEP_WEEKLY" && "$KEEP_WEEKLY" -ge 0 ]]; then
 	restic_prune="$restic_prune --keep-weekly $KEEP_WEEKLY"
 fi
-if [[ -n "$KEEP_MONTLY" && "$KEEP_MONTLY" -ge 0 ]]; then
-	restic_prune="$restic_prune --keep-monthly $KEEP_MONTLY"
+if [[ -n "$KEEP_MONTHLY" && "$KEEP_MONTHLY" -ge 0 ]]; then
+	restic_prune="$restic_prune --keep-monthly $KEEP_MONTHLY"
 fi
 if [[ -n "$KEEP_YEARLY" && "$KEEP_YEARLY" -ge 0 ]]; then
 	restic_prune="$restic_prune --keep-yearly $KEEP_YEARLY"


### PR DESCRIPTION
Fixes a typo in the $KEEP_MONTHLY variable, which was incorrectly set as $KEEP_MONTLY.

Fixes #5408