### PR TITLE
Fix bug HestiaZipArchiver.php

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
+++ b/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
@@ -26,11 +26,10 @@ class HestiaZipArchiver extends ZipArchiver implements Service, ArchiverInterfac
 			return;
 		}
 
-		if (strpos($source, "/home") === false) {
+		if (!str_starts_with($source, "/home")) {
 			$source = "/home/$v_user/" . $source;
 		}
-
-		if (strpos($destination, "/home") === false) {
+		if (!str_starts_with($destination, "/home")) {
 			$destination = "/home/$v_user/" . $destination;
 		}
 

--- a/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
+++ b/install/deb/filemanager/filegator/backend/Services/Archiver/Adapters/HestiaZipArchiver.php
@@ -26,20 +26,32 @@ class HestiaZipArchiver extends ZipArchiver implements Service, ArchiverInterfac
 			return;
 		}
 
+		$base = "/home/$v_user";
+
 		if (!str_starts_with($source, "/home")) {
-			$source = "/home/$v_user/" . $source;
+			$source = "$base/" . $source;
 		}
 		if (!str_starts_with($destination, "/home")) {
-			$destination = "/home/$v_user/" . $destination;
+			$destination = "$base/" . $destination;
+		}
+
+		$real_source = realpath($source);
+		$real_dest = realpath($destination);
+
+		if ($real_source === false || !str_starts_with($real_source, $base)) {
+			return;
+		}
+		if ($real_dest === false || !str_starts_with($real_dest, $base)) {
+			return;
 		}
 
 		exec(
 			"sudo /usr/local/hestia/bin/v-extract-fs-archive " .
 				quoteshellarg($v_user) .
 				" " .
-				quoteshellarg($source) .
+				quoteshellarg($real_source) .
 				" " .
-				quoteshellarg($destination),
+				quoteshellarg($real_dest),
 			$output,
 			$return_var,
 		);


### PR DESCRIPTION
[Bug] FileManager: Unzip fails silently when username or domain contains the word "home" #5394

https://github.com/hestiacp/hestiacp/issues/5394

Describe the bug
When a user account name or domain name contains the substring "home"
(e.g. "homemassageapp" / "homemassageapp.ma"), the Unpack/Unzip action
in the FileManager silently does nothing — no error message, no console
error, no red request in the Network tab.

The issue is asymmetric: other users on the same server whose names do
not contain "home" (e.g. "zenmajorelle") can unzip without any problem.

ROOT CAUSE — HestiaZipArchiver.php uses strpos() to check whether the
path already starts with /home:

if (strpos($source, "/home") === false) {
$source = "/home/$v_user/" . $source;
}

For a user like "homemassageapp" with domain "homemassageapp.ma",
FileGator transmits the path relative to its SFTP root:

/web/homemassageapp.ma/public_html/test.zip

strpos('/web/homemassageapp.ma/...', '/home') returns 4 (not false)
because "/home" appears inside the domain name "homemassageapp.ma" at
position 4. The if condition is never triggered, the prefix is never
added, and v-extract-fs-archive receives a truncated invalid path.

PROOF:
php -r "var_dump(strpos('/web/homemassageapp.ma/public_html/test.zip', '/home'));"
// returns int(4), NOT false

PROPOSED FIX (one character change per condition):
// Before (buggy)
if (strpos($source, "/home") === false)
if (strpos($destination, "/home") === false)

// After (fixed)
if (strpos($source, "/home") !== 0)
if (strpos($destination, "/home") !== 0)

Changing === false to !== 0 ensures the check only skips the prefix
when the path already BEGINS with /home (position 0), not when /home
appears anywhere inside the path.

The fix has been tested and confirmed working on the affected server.

Tell us how to replicate the bug
Create a user whose name contains "home" (e.g. "homemassageapp")
Add a domain that also contains "home" (e.g. "homemassageapp.ma")
Enable SFTP jail for this user
Upload a .zip file via the FileManager into public_html
Right-click the .zip and select "Unpack"
Nothing happens — no error, no extraction
To confirm via SSH:
tail -f /var/log/auth.log
(then click Unpack in the browser)

You will see:
COMMAND=v-extract-fs-archive homemassageapp
/web/homemassageapp.ma/public_html/test.zip
/web/homemassageapp.ma/public_html

The /home/homemassageapp prefix is missing because strpos() found
"/home" inside the domain name at position 4 instead of returning false.

Which components are affected by this bug?
Control Panel Web Interface

Hestia Control Panel Version
1.9.6

Operating system
Ubuntu 24.04 LTS

Log capture
sudo: hestiaweb : PWD=/usr/local/hestia/web/fm/dist ; USER=root ; 
COMMAND=/usr/local/hestia/bin/v-extract-fs-archive homemassageapp 
/web/homemassageapp.ma/public_html/test.zip 
/web/homemassageapp.ma/public_html