### PR TITLE
Check SFTP jail status before add/delete user jail operations

### DIFF
--- a/bin/v-add-user-sftp-jail
+++ b/bin/v-add-user-sftp-jail
@@ -40,6 +40,11 @@ if [ -z "$user_str" ]; then
 	exit
 fi
 
+# Check whether SFTP jail is enabled before adding a user jail
+if ! grep -A1 '^# Hestia SFTP Chroot$' /etc/ssh/sshd_config | grep -q '^Match User' &> /dev/null; then
+	exit 0
+fi
+
 # Get current users and split into array
 ssh_users=$(grep -A1 "^# Hestia SFTP Chroot" /etc/ssh/sshd_config | sed -n 2p | sed 's/Match User //')
 IFS=',' read -r -a users <<< "$ssh_users"

--- a/bin/v-delete-user-sftp-jail
+++ b/bin/v-delete-user-sftp-jail
@@ -32,6 +32,11 @@ if [ -z "$user_str" ]; then
 	exit
 fi
 
+# Check whether SFTP jail is enabled before deleting a user jail
+if ! grep -A1 '^# Hestia SFTP Chroot$' /etc/ssh/sshd_config | grep -q '^Match User' &> /dev/null; then
+	exit 0
+fi
+
 # Get current users and split into array
 ssh_users=$(grep -A1 "^# Hestia SFTP Chroot" /etc/ssh/sshd_config | sed -n 2p | sed 's/Match User //')
 IFS=',' read -r -a users <<< "$ssh_users"


### PR DESCRIPTION
Forum post: https://forum.hestiacp.com/t/v-rebuild-all-error/21893

Add a validation step in `v-add-user-sftp-jail` and `v-delete-user-sftp-jail` to verify that SFTP jail is enabled before attempting any user jail operation.

This prevents executing add/delete actions when the SFTP jail feature is not active, improving safety and providing more predictable behavior.

Error example when rebuilding user or adding directly a user SFTP jail.
```bash
❯ v-delete-sys-sftp-jail
❯ v-rebuild-all test
sed: -e expression #1, char 0: no previous regular expression
❯ v-add-user-sftp-jail test
sed: -e expression #1, char 0: no previous regular expression
```