### PR TITLE
fix: Propagate private key detection to sftpc()

### DIFF
--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -126,7 +126,7 @@ if [ "$type" = 'sftp' ]; then
 	USERNAME=$user
 	PASSWORD=$password
 	HOST=$host
-    PRIVATEKEY=$privatekey
+	PRIVATEKEY=$privatekey
 
 	if [ -z $path ]; then
 		sftmpdir="vst.bK76A9SUkt"

--- a/bin/v-add-backup-host
+++ b/bin/v-add-backup-host
@@ -126,6 +126,8 @@ if [ "$type" = 'sftp' ]; then
 	USERNAME=$user
 	PASSWORD=$password
 	HOST=$host
+    PRIVATEKEY=$privatekey
+
 	if [ -z $path ]; then
 		sftmpdir="vst.bK76A9SUkt"
 		sftpc "mkdir $sftmpdir" "rmdir $sftmpdir" > /dev/null 2>&1


### PR DESCRIPTION
When configuring an SFTP backup host with an OpenSSH private key, v-add-backup-host correctly detects the key and sets privatekey=yes.

However, the value is never propagated to sftpc() before connection validation. As a result, sftpc() falls back to password authentication and attempts to use the private key path as the password.

Adding:

    PRIVATEKEY=$privatekey

before the sftpc() validation call allows key-based authentication to work as intended.

Tested with:
- HestiaCP 1.9.6
- OpenSSH Ed25519 key authentication
- Custom SFTP port
- Successful remote directory creation and validation