### PR TITLE
fix(HestiaApp.php): increase timeout to handle long processes

### DIFF
--- a/web/src/app/System/HestiaApp.php
+++ b/web/src/app/System/HestiaApp.php
@@ -401,6 +401,8 @@ class HestiaApp
         $command = array_map(fn(string $argument) => str_replace(' ', '\\ ', $argument), $command);
 
         $process = new Process($command);
+        // Increase the timeout from the default 60 seconds to 5 minutes to handle long install processes
+        $process->setTimeout(300);
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
By default, Symfony processes have a [timeout](https://symfony.com/doc/current/components/process.html#process-timeout) of 60 seconds. This fixes the timeout error that occurs during installations with long-running processes, e.g., PrestaShop:

``` The process "'/usr/bin/sudo' '/usr/local/hestia/bin/v-run-cli-cmd' 'user' '/usr/bin/php8.5' '/home/user/web/domain.com/public_html/install/index_cli.php' '--db_server=localhost' '--db_user=prestashop_user' '--db_password=pass123' '--db_name=prestashop_user' '--firstname=john' '--lastname=doe' '--password=pass123' '--email=mail@example.com' '--domain=domain.com' '--ssl=1'" exceeded the timeout of 60 seconds. ```