### PR TITLE
Fix missing HESTIA variable by sourcing hestia.conf

### DIFF
--- a/bin/v-list-sys-sshd-port
+++ b/bin/v-list-sys-sshd-port
@@ -14,8 +14,10 @@
 format=${1-shell}
 
 # Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
-source $HESTIA/func/main.sh
+source "$HESTIA"/func/main.sh
 
 json_list() {
 	sh_counter=$(echo "$ports" | wc -l)


### PR DESCRIPTION
Source `/etc/hestiacp/hestia.conf` so the `HESTIA` variable is defined before loading `main.sh`.