### PR TITLE
Fix File Manager HTTP 500 when session user is empty (#5318)

### DIFF
--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -144,6 +144,10 @@ switch ($lang) {
 $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 	"adapter"
 ] = function () {
+	if (empty($_SESSION["user"])) {
+		echo '<meta http-equiv="refresh" content="0; url=/">';
+		exit();
+	}
 	if (!empty($_SESSION["INACTIVE_SESSION_TIMEOUT"])) {
 		if ($_SESSION["INACTIVE_SESSION_TIMEOUT"] * 60 + $_SESSION["LAST_ACTIVITY"] < time()) {
 			$v_user = quoteshellarg($_SESSION["user"]);


### PR DESCRIPTION
The Filegator storage adapter closure in configuration.php reads $_SESSION["user"] without guarding against an empty/missing value. When the session has no user (admin impersonation switch, logout, or a session transition) the closure either:

- reaches quoteshellarg($_SESSION["user"]) in the inactivity-timeout branch with a null value, throwing a TypeError -> HTTP 500, or
- falls through to the SFTP block where $v_user is undefined, emitting repeated "Undefined variable $v_user" warnings and constructing a broken SftpAdapter.

Guard the closure at the very top: when no session user is present, emit the existing redirect-to-login and exit before any user-dependent logic runs.

Fixes #5318