### PR TITLE
Reorganize firewall rule processing for improved efficiency

### DIFF
--- a/bin/v-add-firewall-ban
+++ b/bin/v-add-firewall-ban
@@ -75,7 +75,7 @@ date=$(echo "$time_n_date" | cut -f 2 -d \ )
 # Adding ip to banlist
 echo "IP='$ipv4_cidr' CHAIN='$chain' TIME='$time' DATE='$date'" >> $conf
 $iptables -I fail2ban-$chain 1 -s $ipv4_cidr \
-	-j REJECT --reject-with icmp-port-unreachable 2> /dev/null
+	-j DROP 2> /dev/null
 
 # Changing permissions
 chmod 660 $conf

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -63,12 +63,12 @@ fi
 chains="$HESTIA/data/firewall/chains.conf"
 banlist="$HESTIA/data/firewall/banlist.conf"
 
-# Checking custom OpenSSH port (or ports)
-sshport="$($BIN/v-list-sys-sshd-port plain | sed ':a;N;$!ba;s/\n/,/g')"
-if echo "$sshport" | grep -E '^[0-9]+(,[0-9]+)*$' &> /dev/null; then
-	sed -i -E "s/(PORT=')[0-9]+(,[0-9]+)*('.*COMMENT='SSH')/\1$sshport\3/" "$rules"
-	if [ -f "$chains" ]; then
-		sed -i "/CHAIN='SSH'/c\CHAIN='SSH' PORT='$sshport' PROTOCOL='TCP'" "$chains"
+# Detect custom OpenSSH port(s) and update SSH chain
+sshport=$("$BIN/v-list-sys-sshd-port" plain | paste -sd ',' -)
+if [[ "$sshport" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+	sed -i -E "s/(PORT=')[0-9]+(,[0-9]+)*('.*COMMENT='SSH')/\1${sshport}\3/" "$rules"
+	if [[ -f "$chains" ]]; then
+		sed -i "/CHAIN='SSH'/c\\CHAIN='SSH' PORT='${sshport}' PROTOCOL='TCP'" "$chains"
 	else
 		"$BIN/v-add-firewall-chain" 'SSH' "$sshport" 'TCP'
 	fi
@@ -84,6 +84,13 @@ tmp="$(mktemp)"
 echo "$iptables -P INPUT ACCEPT" >> "$tmp"
 echo "$iptables -F INPUT" >> "$tmp"
 
+# Handling local traffic
+echo "$iptables -A INPUT -i lo -j ACCEPT" >> "$tmp"
+ips="$(ls $HESTIA/data/ips)"
+for ip in $ips; do
+	echo "$iptables -A INPUT -s $ip -j ACCEPT" >> "$tmp"
+done
+
 # Enabling stateful support
 if [ "$conntrack" != 'no' ] || grep --quiet container=lxc /proc/1/environ; then
 	str="$iptables -A INPUT -m state"
@@ -91,12 +98,31 @@ if [ "$conntrack" != 'no' ] || grep --quiet container=lxc /proc/1/environ; then
 	echo "$str" >> "$tmp"
 fi
 
-ips="$(ls $HESTIA/data/ips)"
-# Handling local traffic
-for ip in $ips; do
-	echo "$iptables -A INPUT -s $ip -j ACCEPT" >> "$tmp"
-done
-echo "$iptables -A INPUT -s 127.0.0.1 -j ACCEPT" >> "$tmp"
+# Checking fail2ban support
+if [ -n "$FIREWALL_EXTENSION" ]; then
+	if [ -f "$chains" ]; then
+		while IFS= read -r chain; do
+			parse_object_kv_list "$chain"
+			if [[ "$PORT" =~ ,|-|: ]]; then
+				port="-m multiport --dports $PORT"
+			else
+				port="--dport $PORT"
+			fi
+			echo "$iptables -N fail2ban-$CHAIN" >> "$tmp"
+			echo "$iptables -F fail2ban-$CHAIN" >> "$tmp"
+			echo "$iptables -A fail2ban-$CHAIN -s 0.0.0.0/0 -j RETURN" >> "$tmp"
+			echo "$iptables -A INPUT -p $PROTOCOL $port -j fail2ban-$CHAIN" >> "$tmp"
+		done < "$chains"
+	fi
+
+	if [ -f "$banlist" ]; then
+		while IFS= read -r ban; do
+			parse_object_kv_list "$ban"
+			echo -n "$iptables -I fail2ban-$CHAIN 1 -s $IP" >> "$tmp"
+			echo " -j DROP" >> "$tmp"
+		done < "$banlist"
+	fi
+fi
 
 # Pasring iptables rules
 IFS=$'\n'
@@ -135,6 +161,7 @@ for line in $(sort -r -n -k 2 -t \' $rules); do
 			else
 				port="-m multiport --dports 20,21,12000:12100"
 			fi
+			ftp="yes"
 		fi
 
 		# Adding firewall rule
@@ -147,46 +174,14 @@ echo "$iptables -P INPUT DROP" >> "$tmp"
 
 # Adding hestia chain
 echo "$iptables -N hestia" >> "$tmp"
-
 # Applying rules
 bash "$tmp" 2> /dev/null
-
 # Deleting temporary file
 rm -f "$tmp"
 
 # Checking custom trigger
 if [ -x "$HESTIA/data/firewall/custom.sh" ]; then
 	bash "$HESTIA/data/firewall/custom.sh"
-fi
-
-# Checking fail2ban support
-if [ -n "$FIREWALL_EXTENSION" ]; then
-	if [ -f "$chains" ]; then
-		for chain in $(cat "$chains"); do
-			parse_object_kv_list "$chain"
-			if [[ "$PORT" =~ ,|-|: ]]; then
-				port="-m multiport --dports $PORT"
-			else
-				port="--dport $PORT"
-			fi
-			echo "$iptables -N fail2ban-$CHAIN" >> "$tmp"
-			echo "$iptables -F fail2ban-$CHAIN" >> "$tmp"
-			echo "$iptables -I fail2ban-$CHAIN -s 0.0.0.0/0 -j RETURN" >> "$tmp"
-			echo "$iptables -I INPUT -p $PROTOCOL $port -j fail2ban-$CHAIN" >> "$tmp"
-		done
-		bash "$tmp" 2> /dev/null
-		rm -f "$tmp"
-	fi
-
-	if [ -f "$banlist" ]; then
-		for ban in $(cat "$banlist"); do
-			parse_object_kv_list "$ban"
-			echo -n "$iptables -I fail2ban-$CHAIN 1 -s $IP" >> "$tmp"
-			echo " -j REJECT --reject-with icmp-port-unreachable" >> "$tmp"
-		done
-		bash "$tmp" 2> /dev/null
-		rm -f "$tmp"
-	fi
 fi
 
 # Clean up and saving rules to the master iptables file


### PR DESCRIPTION
Rule for banned IPs has been changed from REJECT to DROP to silently drop traffic from banned IPs without sending ICMP responses, reducing information leakage and improving security.

Refactor firewall generation logic to improve execution order and overall efficiency.

Before the change, the structure was this:

```
[Block of Fail2ban jail routing]
[Block of established/related connections acceptance]
[Block of trusted source acceptance (server IPs)]
[Block of loopback acceptance]
[Block of user rules/service port acceptance]
[Block of Fail2ban jail fallback]
```

iptables output example:
```
-A INPUT -p tcp -m multiport --dports 80,443 -j fail2ban-WEB
-A INPUT -p tcp -m tcp --dport 8083 -j fail2ban-HESTIA
-A INPUT -p tcp -m multiport --dports 25,465,587,110,995,143,993 -j fail2ban-MAIL
-A INPUT -p tcp -m tcp --dport 21 -j fail2ban-FTP
-A INPUT -p tcp -m multiport --dports 22 -j fail2ban-SSH
-A INPUT -p tcp -m multiport --dports 1:65535 -j fail2ban-RECIDIVE
-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
-A INPUT -s 192.168.2.212/32 -j ACCEPT
-A INPUT -s 127.0.0.1/32 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 22 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 80,443 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 21,12000:12100 -j ACCEPT
-A INPUT -p udp -m udp --dport 53 -j ACCEPT
-A INPUT -p tcp -m tcp --dport 53 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 25,465,587 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 110,995 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 143,993 -j ACCEPT
-A INPUT -p tcp -m tcp --dport 8083 -j ACCEPT
-A INPUT -p icmp -j ACCEPT
-A fail2ban-FTP -j RETURN
-A fail2ban-HESTIA -j RETURN
-A fail2ban-MAIL -j RETURN
-A fail2ban-RECIDIVE -j RETURN
-A fail2ban-SSH -j RETURN
-A fail2ban-WEB -s 201.0.113.112/32 -j REJECT --reject-with icmp-port-unreachable
-A fail2ban-WEB -j RETURN
```

Using the new structure:
```
[Block of loopback acceptance]
[Block of trusted source acceptance (server IPs)]
[Block of established/related connections acceptance]
[Block of Fail2ban jail routing]
[Block of user rules/service port acceptance]
[Block of Fail2ban jail fallback]
```

iptables output exmaple:
```
-P INPUT DROP
-P FORWARD ACCEPT
-P OUTPUT ACCEPT
-N fail2ban-FTP
-N fail2ban-HESTIA
-N fail2ban-MAIL
-N fail2ban-RECIDIVE
-N fail2ban-SSH
-N fail2ban-WEB
-N hestia
-A INPUT -i lo -j ACCEPT
-A INPUT -s 192.168.2.212/32 -j ACCEPT
-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
-A INPUT -p tcp -m multiport --dports 1:65535 -j fail2ban-RECIDIVE
-A INPUT -p tcp -m multiport --dports 22 -j fail2ban-SSH
-A INPUT -p tcp -m tcp --dport 21 -j fail2ban-FTP
-A INPUT -p tcp -m multiport --dports 25,465,587,110,995,143,993 -j fail2ban-MAIL
-A INPUT -p tcp -m tcp --dport 8083 -j fail2ban-HESTIA
-A INPUT -p tcp -m multiport --dports 80,443 -j fail2ban-WEB
-A INPUT -p tcp -m multiport --dports 22 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 80,443 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 21,12000:12100 -j ACCEPT
-A INPUT -p udp -m udp --dport 53 -j ACCEPT
-A INPUT -p tcp -m tcp --dport 53 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 25,465,587 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 110,995 -j ACCEPT
-A INPUT -p tcp -m multiport --dports 143,993 -j ACCEPT
-A INPUT -p tcp -m tcp --dport 8083 -j ACCEPT
-A INPUT -p icmp -j ACCEPT
-A fail2ban-FTP -j RETURN
-A fail2ban-HESTIA -j RETURN
-A fail2ban-MAIL -j RETURN
-A fail2ban-RECIDIVE -j RETURN
-A fail2ban-SSH -j RETURN
-A fail2ban-WEB -s 201.0.113.112/32 -j DROP
-A fail2ban-WEB -j RETURN
```