### PR TITLE
security: Change DokuWiki template to `dokuwiki` to secure sensitive directories

### DIFF
--- a/web/src/app/WebApp/Installers/DokuWiki/DokuWikiSetup.php
+++ b/web/src/app/WebApp/Installers/DokuWiki/DokuWikiSetup.php
@@ -53,7 +53,7 @@ class DokuWikiSetup extends BaseSetup
         ],
         'server' => [
             'nginx' => [
-                'template' => 'default',
+                'template' => 'dokuwiki',
             ],
             'php' => [
                 'supported' => ['8.0', '8.1', '8.2', '8.3', '8.4'],


### PR DESCRIPTION
This PR updates the default template assigned to DokuWiki installations to the dedicated `dokuwiki` template.

Currently, DokuWiki deployments on HestiaCP fall back to the `default` web template. This configuration violates [DokuWiki's security guidelines](https://www.dokuwiki.org/security#web_access_security) because it does not block direct web access to sensitive internal directories. As a result, installations trigger a critical security warning in the DokuWiki admin dashboard.

## Motivation and Context
DokuWiki operates on flat files and stores all page content, configuration, and user data in plain text inside the `data/` and `conf/` directories.

Under the current default template, these files are exposed to the public internet. For example, anyone can directly access raw wiki files by navigating to:
[http://yourserver.com/data/pages/wiki/dokuwiki.txt](http://yourserver.com/data/pages/wiki/dokuwiki.txt)

Changing the template to `dokuwiki` ensures the proper web server rules (Nginx/Apache) are applied to return a 403 Forbidden for the `data/`, `conf/`, `bin/`, and `inc/` directories, securing user data and resolving the admin dashboard warning.