### PR TITLE
Block access to internal folders and sensitive files

### DIFF
--- a/src/deb/nginx/nginx.conf
+++ b/src/deb/nginx/nginx.conf
@@ -134,6 +134,16 @@ http {
 		if ($anti_replay = 307) { return 307 https://$host:$server_port$request_uri; }
 		if ($anti_replay = 425) { return 425; }
 
+		# Deny access to internal PHP includes and source dirs
+		location ~* ^/(inc|src|locale|templates)(/|$) {
+			return 404;
+		}
+
+		# Deny access to sensitive file types
+		location ~* \.(map|log|sh|sql|bak|env)$ {
+			return 404;
+		}
+
 		location / {
 			expires off;
 			index index.php;


### PR DESCRIPTION
Deny access to `/inc`, `/src`, `/locale` and `/templates` folders.
Block sensitive files like `.map`, `.sh`, .`env`, etc.
Send 404 responses to hide these resources from the public.