### PR TITLE
Fix: Use control panel host for phpMyAdmin URL when adding remote database

### DIFF
--- a/web/add/db/index.php
+++ b/web/add/db/index.php
@@ -104,9 +104,6 @@ if (!empty($_POST["ok"])) {
 	// Get database manager url
 	if (empty($_SESSION["error_msg"])) {
 		[$http_host, $port] = explode(":", $_SERVER["HTTP_HOST"] . ":");
-		if ($_POST["v_host"] != "localhost") {
-			$http_host = $_POST["v_host"];
-		}
 		if ($_POST["v_type"] == "mysql") {
 			$db_admin = "phpMyAdmin";
 		}


### PR DESCRIPTION
## Description
When creating a database on a remote MySQL database host, the success message and the generated credentials email incorrectly link to `https://<remote_host>/phpmyadmin/`. Since HestiaCP centrally manages database administration and admins do not typically install phpMyAdmin on remote database nodes, this results in a broken link. 

This PR fixes the issue by removing the logic that overrides the host in `web/add/db/index.php`. The phpMyAdmin link will now consistently point to the Hestia control panel's host, matching the correct behavior found on the `list/db/` page.

## Changes
* Removed the `v_host != 'localhost'` host override block in `web/add/db/index.php` when generating `$db_admin_link`.

## How to test
1. Add an external/remote database server to HestiaCP.
2. Go to `Add Database` and create a database using the remote host.
3. Observe the success message: "Database <name> has been created successfully. / Open <name>".
4. Verify that the "Open <name>" link correctly points to the HestiaCP node's phpMyAdmin rather than the remote host.