### PR TITLE
feat: Add SSO support for phpMyAdmin link on database creation

### DIFF
--- a/web/add/db/index.php
+++ b/web/add/db/index.php
@@ -125,6 +125,30 @@ if (!empty($_POST["ok"])) {
 		if ($_POST["v_type"] == "pgsql" && !empty($_SESSION["DB_PGA_ALIAS"])) {
 			$db_admin_link = "https://" . $http_host . "/" . $_SESSION["DB_PGA_ALIAS"];
 		}
+
+		$sso_admin_link = $db_admin_link;
+		if (
+			$_POST["v_type"] == "mysql" &&
+			isset($_SESSION["PHPMYADMIN_KEY"]) &&
+			$_SESSION["PHPMYADMIN_KEY"] != "" &&
+			!ipUsed()
+		) {
+			$time = time();
+			$db_fullname = $user_plain . "_" . $_POST["v_database"];
+			$hestia_sso_token = password_hash(
+				$db_fullname . $user_plain . $_SESSION["user_combined_ip"] . $time . $_SESSION["PHPMYADMIN_KEY"],
+				PASSWORD_DEFAULT,
+			);
+			$sso_admin_link = rtrim($sso_admin_link, "/") . "/";
+			$sso_admin_link .=
+				"hestia-sso.php?" .
+				http_build_query([
+					"database" => $db_fullname,
+					"user" => $user_plain,
+					"exp" => $time,
+					"hestia_token" => $hestia_sso_token,
+				]);
+		}
 	}
 
 	// Email login credentials
@@ -206,7 +230,7 @@ if (!empty($_POST["ok"])) {
 				"_" .
 				htmlentities($_POST["v_database"]) .
 				'">',
-			'<a href="' . $db_admin_link . '" target="_blank">',
+			'<a href="' . $sso_admin_link . '" target="_blank">',
 		);
 		unset($v_database);
 		unset($v_dbuser);


### PR DESCRIPTION
### Description
This PR updates the success message shown after creating a new database in the HestiaCP Web UI (`/add/db/`). Specifically, it modifies the `Open [database_name]` link to seamlessly use the Single Sign-On (SSO) login functionality for phpMyAdmin when it is enabled. 

Previously, the success message always displayed a static link directly to the phpMyAdmin login page, requiring users to authenticate manually despite SSO being active. 

### Changes Made
- Updated `web/add/db/index.php` to conditionally generate a short-lived `hestia-sso.php` token and URL for the success message if the database is `mysql`, the `PHPMYADMIN_KEY` is present, and it's not being accessed via a bare IP.
- Assigned the SSO logic to a new `$sso_admin_link` variable to preserve the original `$db_admin_link` path. This ensures the automated credentials email still receives the permanent database login link, avoiding the unintended delivery of a 60-second expiring SSO token over email.

### Testing
- This PR has been tested with PMA SSO both enabled and disabled, and the PMA URL in the success message has been generated accordingly in both scenarios.