### PR TITLE
Add support for Ubuntu 26.04 LTS

### DIFF
--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -35,9 +35,9 @@ HESTIA_INSTALL_VER='1.10.0~alpha'
 # Supported PHP versions
 multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8.5")
 # One of the following PHP versions is required for Roundcube / phpmyadmin
-multiphp_required=("7.3" "7.4" "8.0" "8.1" "8.2" "8.3")
+multiphp_required=("8.1" "8.2" "8.3" "8.4" "8.5")
 # Default PHP version if none supplied
-fpm_v="8.3"
+fpm_v="8.5"
 # MariaDB version
 mariadb_v="11.8"
 # Node.js version

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -2290,6 +2290,11 @@ fi
 
 echo "[ * ] Configuring File Manager..."
 $HESTIA/bin/v-add-sys-filemanager quiet
+# Configuring sudoers to remove unsupported requiretty option on Ubuntu 26.04
+ubuntu_major="${release%%.*}"
+if [[ "$ubuntu_major" -ge 26 ]]; then
+	echo 'KexAlgorithms +diffie-hellman-group-exchange-sha256' > /etc/ssh/sshd_config.d/hestia-kex.conf
+fi
 
 #----------------------------------------------------------#
 #              Configure Web terminal                      #

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -6,7 +6,7 @@
 # https://www.hestiacp.com/
 #
 # Currently Supported Versions:
-# Ubuntu 22.04, 24.04 LTS
+# Ubuntu 22.04, 24.04, 26.04 LTS
 #
 # ======================================================== #
 
@@ -828,14 +828,20 @@ curl -s https://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/shar
 # Installing sury PHP repo
 # add-apt-repository does not yet support signed-by see: https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/1862764
 echo "[ * ] PHP"
-if [ "$release" = '24.04' ]; then
-	# Workaround for Ubuntu 24.04 due to weak key warning it sheduled to be fixed in 24.04.1
-	echo 'APT::Key::Assert-Pubkey-Algo "";' > /etc/apt/apt.conf.d/99weakkey-warning
+if [[ "$release" = "22.04" ]] || [[ "$release" = "24.04" ]]; then
+	if [ "$release" = '24.04' ]; then
+		# Workaround for Ubuntu 24.04 due to weak key warning it sheduled to be fixed in 24.04.1
+		echo 'APT::Key::Assert-Pubkey-Algo "";' > /etc/apt/apt.conf.d/99weakkey-warning
+	fi
+	LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php > /dev/null 2>&1
+else
+	# Ubuntu 26.04 and later use the Sury repository instead of a PPA
+	echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/sury-keyring.gpg] https://packages.sury.org/php/ $codename main" > $apt/php.list
+	curl -s https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /usr/share/keyrings/sury-keyring.gpg > /dev/null 2>&1
 fi
-LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php > /dev/null 2>&1
 
 # Installing sury Apache2 repo
-if [ "$apache" = 'yes' ] && [ "$release" != '24.04' ]; then
+if [ "$apache" = 'yes' ] && [ "$release" = '22.04' ]; then
 	echo "[ * ] Apache2"
 	echo "deb http://ppa.launchpad.net/ondrej/apache2/ubuntu $codename main" > $apt/apache2.list
 fi
@@ -1072,6 +1078,9 @@ fi
 if [ "$release" = '24.04' ]; then
 	software=$(echo "$software" | sed -e "s/libzip4/libzip4t64/")
 fi
+if [ "$release" = '26.04' ]; then
+	software=$(echo "$software" | sed -e "s/libzip4/libzip5/")
+fi
 
 #----------------------------------------------------------#
 #                 Disable Apparmor on LXC                  #
@@ -1223,9 +1232,12 @@ if [ -z "$(grep nologin /etc/shells)" ]; then
 fi
 
 # Configuring NTP
-sed -i 's/#NTP=/NTP=pool.ntp.org/' /etc/systemd/timesyncd.conf
-systemctl enable systemd-timesyncd
-systemctl start systemd-timesyncd
+# Ubuntu 26.04 doesn't install systemd-timesyncd, by default it uses Chrony
+if [[ "$release" = "22.04" ]] || [[ "$release" = "24.04" ]]; then
+	sed -i 's/#NTP=/NTP=pool.ntp.org/' /etc/systemd/timesyncd.conf
+	systemctl enable systemd-timesyncd
+	systemctl start systemd-timesyncd
+fi
 
 # Check iptables paths and add symlinks when necessary
 if [ ! -e "/sbin/iptables" ]; then
@@ -1284,6 +1296,10 @@ echo "[ * ] Configuring Hestia Control Panel..."
 # Installing sudo configuration
 mkdir -p /etc/sudoers.d
 cp -f $HESTIA_COMMON_DIR/sudo/hestiaweb /etc/sudoers.d/
+# Ubuntu 26.04 and the new rust implementation of sudo doesn't support !requiretty
+if [[ "$release" != "22.04" ]] && [[ "$release" != "24.04" ]]; then
+	sed -i '/^Defaults:root !requiretty$/d' /etc/sudoers.d/hestiaweb
+fi
 chmod 440 /etc/sudoers.d/hestiaweb
 
 # Add Hestia global config
@@ -1514,7 +1530,7 @@ echo "[ * ] Configuring OpenSSL to improve TLS performance..."
 tls13_ciphers="TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384"
 if [ "$release" = "22.04" ]; then
 	sed -i '/^system_default = system_default_sect$/a system_default = hestia_openssl_sect\n\n[hestia_openssl_sect]\nCiphersuites = '"$tls13_ciphers"'\nOptions = PrioritizeChaCha' /etc/ssl/openssl.cnf
-elif [ "$release" = "24.04" ]; then
+else
 	if ! grep -qw "^ssl_conf = ssl_sect$" /etc/ssl/openssl.cnf 2> /dev/null; then
 		sed -i '/providers = provider_sect$/a ssl_conf = ssl_sect' /etc/ssl/openssl.cnf
 	fi
@@ -1969,6 +1985,18 @@ if [ "$named" = 'yes' ]; then
 			systemctl restart apparmor >> $LOG
 		fi
 	fi
+
+	# Ubuntu 26.04 removed the named.conf.default-zones file if doesn't exsists remove it from the config file
+	if [ ! -f /etc/bind/named.conf.default-zones ]; then
+		sed -i "/^include.*named.conf.default-zones/d" /etc/bind/named.conf
+	fi
+
+	# Add root-hints include after named.conf.local if missing
+	if [[ -f /etc/bind/named.conf.root-hints ]] \
+		&& ! grep -q 'include.*named.conf.root-hints' /etc/bind/named.conf 2> /dev/null; then
+		sed -i '/include.*named\.conf\.local/a include "\/etc\/bind\/named.conf.root-hints";' /etc/bind/named.conf
+	fi
+
 	update-rc.d bind9 defaults > /dev/null 2>&1
 	systemctl start bind9
 	check_result $? "bind9 start failed"
@@ -2087,13 +2115,12 @@ fi
 #----------------------------------------------------------#
 #                  Configure SpamAssassin                  #
 #----------------------------------------------------------#
-
 if [ "$spamd" = 'yes' ]; then
 	# Set SpamAssassin Service Name
-	if [ "$release" = '24.04' ]; then
-		spamd_srvname="spamd"
-	else
+	if [ "$release" = '22.04' ]; then
 		spamd_srvname="spamassassin"
+	else
+		spamd_srvname="spamd"
 	fi
 	echo "[ * ] Configuring SpamAssassin..."
 	update-rc.d $spamd_srvname defaults > /dev/null 2>&1

--- a/install/hst-install.sh
+++ b/install/hst-install.sh
@@ -9,7 +9,7 @@
 # Currently Supported Operating Systems:
 #
 # Debian 11, 12, 13
-# Ubuntu 22.04, 24.04 LTS
+# Ubuntu 22.04, 24.04 26.04 LTS
 #
 # ======================================================== #
 
@@ -68,7 +68,7 @@ no_support_message() {
 	echo "Hestia Control Panel. Officially supported releases:"
 	echo "****************************************************"
 	echo "  Debian 11, 12, 13"
-	echo "  Ubuntu 22.04, 24.04 LTS"
+	echo "  Ubuntu 22.04, 24.04, 26.04 LTS"
 	echo ""
 	exit 1
 }
@@ -130,7 +130,7 @@ check_wget_curl() {
 
 # Check for supported operating system before proceeding with download
 # of OS-specific installer, and throw error message if unsupported OS detected.
-if [[ "$release" =~ ^(11|12|13|22.04|24.04)$ ]]; then
+if [[ "$release" =~ ^(11|12|13|22.04|24.04|26.04)$ ]]; then
 	check_wget_curl "$@"
 else
 	no_support_message

--- a/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
+++ b/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# info: Configure sudoers, SSH, Bind and Dovecot to work with Hestia on Ubuntu 26.04
+
+#----------------------------------------------------------#
+#                    Variables & Functions                 #
+#----------------------------------------------------------#
+
+[[ $EUID -eq 0 ]] || {
+	echo "You must be root to run the script" >&2
+	exit 1
+}
+
+source /etc/hestiacp/hestia.conf
+source $HESTIA/conf/hestia.conf
+source $HESTIA/func/main.sh
+
+[[ -f /etc/os-release ]] && source /etc/os-release
+
+if [[ "$ID" != "ubuntu" || "$VERSION_ID" != "26.04" ]]; then
+	echo "Error: this script requires Ubuntu 26.04" >&2
+	exit 1
+fi
+
+#----------------------------------------------------------#
+#                  sudoers configuration                   #
+#----------------------------------------------------------#
+
+echo "[ * ] Checking sudoers config:"
+if [[ -f /etc/sudoers.d/hestiaweb ]] && grep -q '^Defaults:root !requiretty$' /etc/sudoers.d/hestiaweb &> /dev/null; then
+	echo "[ + ] Configuring sudoers to remove unsupported requiretty option"
+	chmod 640 /etc/sudoers.d/hestiaweb
+	sed -i '/^Defaults:root !requiretty$/d' /etc/sudoers.d/hestiaweb
+	chmod 440 /etc/sudoers.d/hestiaweb
+else
+	echo "[ - ] sudoers already configured, nothing to do"
+fi
+echo
+
+#----------------------------------------------------------#
+#                    SSH configuration                     #
+#----------------------------------------------------------#
+
+_KEX_CONF="/etc/ssh/sshd_config.d/hestia-kex.conf"
+_KEX_LINE="KexAlgorithms +diffie-hellman-group-exchange-sha256"
+
+echo "[ * ] Checking SSH KexAlgorithms config:"
+if [[ ! -f "$_KEX_CONF" ]] || ! grep -qxF "$_KEX_LINE" "$_KEX_CONF"; then
+	echo "[ + ] Configuring SSH KexAlgorithms"
+	echo "$_KEX_LINE" > "$_KEX_CONF"
+	"$BIN"/v-restart-service ssh
+else
+	echo "[ - ] SSH KexAlgorithms already configured, nothing to do"
+fi
+echo
+
+#----------------------------------------------------------#
+#                   Dovecot configuration                  #
+#----------------------------------------------------------#
+
+if command -v dovecot &> /dev/null; then
+	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
+else
+	dovecot_version=false
+fi
+
+echo "[ * ] Checking Dovecot configuration:"
+if [[ "$dovecot_version" = "2.4" ]]; then
+	if ! grep -q 'modified by Hestia' /etc/dovecot/dovecot.conf \
+		|| ! grep -q 'ssl_server_cert_file = /usr/local/hestia' /etc/dovecot/conf.d/10-ssl.conf; then
+		echo "[ + ] Updating Dovecot $dovecot_version configuration"
+		cp -f "$HESTIA_COMMON_DIR"/dovecot/2.4/dovecot.conf /etc/dovecot/
+		cp -f "$HESTIA_COMMON_DIR"/dovecot/2.4/conf.d/* /etc/dovecot/conf.d/
+
+		if [[ -n "$MAIL_SYSTEM" ]]; then
+			echo "[ + ] Rebuilding mail domains"
+			export restart="no"
+			"$BIN/v-list-users" list | while read -r user; do
+				echo "      - $user..."
+				$BIN/v-rebuild-mail-domains "$user" &> /dev/null
+			done
+		fi
+
+		HAS_DOVECOT_SIEVE_INSTALLED=$(dpkg --get-selections dovecot-managesieved 2> /dev/null | grep -c dovecot-managesieved)
+		if [[ "$HAS_DOVECOT_SIEVE_INSTALLED" = "1" ]]; then
+			echo "[ * ] Updating Sieve $dovecot_version configuration"
+			grep -q 'protocols = sieve' /etc/dovecot/dovecot.conf \
+				|| sed -i -E 's/protocols = imap/protocols = sieve imap/' /etc/dovecot/dovecot.conf
+			grep -q 'unix_listener auth-master' /etc/dovecot/conf.d/10-master.conf \
+				|| sed -i -E -z 's/    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\n  unix_listener auth-master {\n    group = mail\n    mode = 0660\n    user = dovecot\n  }\n\}/' /etc/dovecot/conf.d/10-master.conf
+			grep -q 'mail_plugins.*sieve' /etc/dovecot/conf.d/15-lda.conf \
+				|| sed -i '/^protocol lda {$/a\  mail_plugins = mail_compress quota sieve' /etc/dovecot/conf.d/15-lda.conf
+			grep -q 'imap_sieve' /etc/dovecot/conf.d/20-imap.conf \
+				|| sed -i "s/quota imap_quota/quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
+			cp -f "$HESTIA_COMMON_DIR"/dovecot/2.4/sieve/* /etc/dovecot/conf.d
+		fi
+
+		chown -R root:root /etc/dovecot/
+		if systemctl restart dovecot &> /dev/null; then
+			echo "[ + ] Dovecot successfully restarted"
+		else
+			echo "[ ! ] Error restarting dovecot" >&2
+			systemctl status dovecot --no-pager -l >&2
+		fi
+	else
+		echo "[ - ] Dovecot already configured by Hestia, nothing to do"
+	fi
+elif [[ "$dovecot_version" = "false" ]]; then
+	echo "[ - ] Dovecot not installed, skipping"
+else
+	echo "[ - ] Dovecot $dovecot_version not supported, skipping"
+fi
+echo
+
+#----------------------------------------------------------#
+#                    Bind configuration                    #
+#----------------------------------------------------------#
+
+echo "[ * ] Checking Bind DNS configuration:"
+if [[ "$DNS_SYSTEM" =~ named|bind ]]; then
+	_bind_changed=false
+
+	# named.conf.default-zones was removed in Debian 13
+	if [[ ! -f /etc/bind/named.conf.default-zones ]] \
+		&& grep -q "include.*named.conf.default-zones" /etc/bind/named.conf 2> /dev/null; then
+		echo "[ + ] Removing the default-zones include from named.conf"
+		sed -i "/^include.*named.conf.default-zones/d" /etc/bind/named.conf
+		_bind_changed=true
+	else
+		echo "[ - ] default-zones include already clean, nothing to do"
+	fi
+
+	# Add root-hints include after named.conf.local if missing
+	if [[ -f /etc/bind/named.conf.root-hints ]] \
+		&& ! grep -q 'include.*named.conf.root-hints' /etc/bind/named.conf 2> /dev/null; then
+		echo "[ + ] Adding the root-hints include to named.conf"
+		sed -i '/include.*named\.conf\.local/a include "\/etc\/bind\/named.conf.root-hints";' /etc/bind/named.conf
+		_bind_changed=true
+	else
+		echo "[ - ] root-hints include already present, nothing to do"
+	fi
+
+	if [[ "$_bind_changed" = true ]]; then
+		if systemctl restart named &> /dev/null; then
+			echo "[ + ] Bind 9 successfully restarted"
+		else
+			echo "[ ! ] Error restarting Bind 9" >&2
+			systemctl status named --no-pager -l >&2
+		fi
+	fi
+else
+	echo "[ - ] Bind/named not in use (DNS_SYSTEM=$DNS_SYSTEM), skipping"
+fi
+echo
+
+echo "[ * ] Configuration finished!"

--- a/install/upgrade/versions/1.10.0.sh
+++ b/install/upgrade/versions/1.10.0.sh
@@ -31,8 +31,25 @@ if [ -f /etc/os-release ]; then
 	source /etc/os-release
 fi
 
-# Apply SSH config if running on Debian 13
+# Set running OS
+IS_DEBIAN13=false
+IS_UBUNTU2604=false
+IS_DEBIAN13_OR_UBUNTU2604=false
+
 if [[ "$ID" == "debian" && "$VERSION_ID" == "13" ]]; then
+	IS_DEBIAN13=true
+fi
+
+if [[ "$ID" == "ubuntu" && "$VERSION_ID" == "26.04" ]]; then
+	IS_UBUNTU2604=true
+fi
+
+if $IS_DEBIAN13 || $IS_UBUNTU2604; then
+	IS_DEBIAN13_OR_UBUNTU2604=true
+fi
+
+# Apply SSH config if running on Debian 13 or Ubuntu 26.04
+if $IS_DEBIAN13_OR_UBUNTU2604; then
 	_KEX_CONF="/etc/ssh/sshd_config.d/hestia-kex.conf"
 	_KEX_LINE="KexAlgorithms +diffie-hellman-group-exchange-sha256"
 
@@ -69,14 +86,14 @@ if [[ -d "$SNAPPYMAIL_ETC_DATA" ]] && ! [[ -L "$SNAPPYMAIL_ETC_DATA" ]]; then
 	fi
 fi
 
-# If Dovecot is version 2.4 and Debian is Trixie (13), replace Dovecot's configuration and rebuild users
+# If Dovecot is version 2.4 and OS is Trixie (13) or Ubuntu 26.04, replace Dovecot's configuration and rebuild users
 if command -v dovecot &> /dev/null; then
 	dovecot_version="$(dovecot --version | cut -f -2 -d .)"
 else
 	dovecot_version=false
 fi
 
-if [[ "$ID" == "debian" && "$VERSION_ID" == "13" && "$dovecot_version" = "2.4" ]]; then
+if $IS_DEBIAN13_OR_UBUNTU2604 && [[ "$dovecot_version" = "2.4" ]]; then
 	if ! grep -q 'modified by Hestia' /etc/dovecot/dovecot.conf \
 		|| ! grep -q 'ssl_server_cert_file = /usr/local/hestia' /etc/dovecot/conf.d/10-ssl.conf; then
 		echo "[ * ] Updating Dovecot $dovecot_version configuration"
@@ -105,8 +122,8 @@ if [[ "$ID" == "debian" && "$VERSION_ID" == "13" && "$dovecot_version" = "2.4" ]
 	fi
 fi
 
-# Configure Bind for Debian 13
-if [[ "$ID" == "debian" && "$VERSION_ID" == "13" ]]; then
+# Configure Bind for Debian 13 or Ubuntu 26.04
+if $IS_DEBIAN13_OR_UBUNTU2604; then
 	source "$HESTIA"/conf/hestia.conf
 	if [[ "$DNS_SYSTEM" =~ named|bind ]]; then
 		# named.conf.default-zones was removed in Debian 13
@@ -165,5 +182,15 @@ if [[ -f "$phpmyadmin_conf" ]]; then
 <?php
 $cfg['TempDir'] = '/var/lib/phpmyadmin/tmp';
 EOF
+	fi
+fi
+
+# Configuring sudoers to remove unsupported requiretty option on Ubuntu 26.04
+if $IS_UBUNTU2604; then
+	if [[ -f /etc/sudoers.d/hestiaweb ]] && grep -q '^Defaults:root !requiretty$' /etc/sudoers.d/hestiaweb &> /dev/null; then
+		echo "[ + ] Configuring sudoers to remove unsupported requiretty option"
+		chmod 640 /etc/sudoers.d/hestiaweb
+		sed -i '/^Defaults:root !requiretty$/d' /etc/sudoers.d/hestiaweb
+		chmod 440 /etc/sudoers.d/hestiaweb
 	fi
 fi


### PR DESCRIPTION
Changes include:
- Add Ubuntu 26.04 to the list of supported operating systems.
- Use the Sury PHP repository instead of Ondřej PPAs on Ubuntu 26.04.
- Restrict Apache2 PPA usage to Ubuntu 22.04 only.
- Update libzip dependency handling for Ubuntu 26.04 (libzip5).
- Skip systemd-timesyncd configuration since Ubuntu 26.04 uses Chrony by default.
- Remove unsupported `!requiretty` sudo option for the new Rust-based sudo implementation.
- Adjust BIND configuration to handle removed default-zones files and automatically include root hints when available.
- Update SpamAssassin service detection for newer Ubuntu releases.