### PR TITLE
Update default and required PHP versions for Debian installation

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -35,9 +35,9 @@ HESTIA_INSTALL_VER='1.10.0~alpha'
 # Supported PHP versions
 multiphp_v=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8.5")
 # One of the following PHP versions is required for Roundcube / phpmyadmin
-multiphp_required=("7.3" "7.4" "8.0" "8.1" "8.2" "8.3")
+multiphp_required=("8.1" "8.2" "8.3" "8.4" "8.5")
 # Default PHP version if none supplied
-fpm_v="8.3"
+fpm_v="8.5"
 # MariaDB version
 mariadb_v="11.8"
 # Node.js version


### PR DESCRIPTION
- Set PHP 8.5 as the default PHP-FPM version.
- Update the required PHP versions list for Roundcube and phpMyAdmin.
- Add PHP 8.4 and PHP 8.5 to the required versions list.
- Remove PHP 7.3, PHP 7.4, and PHP 8.0 from the required versions list.