### PR TITLE
Hide quotaon warnings when enabling quotas

### DIFF
--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -337,7 +337,7 @@ fi
 
 # Enabling group and user quota
 if quotaon -pa | grep " $mnt " | grep -E 'user|group' | grep -q 'is off'; then
-	quotaon -v "$mnt"
+	quotaon -v "$mnt" 2> >(grep -vE 'Cannot stat.*device tmpfs|kernel probably supports ext4 quota' >&2) > /dev/null
 	check_result $? "quota can't be enabled in $mnt" "$E_DISK"
 fi
 


### PR DESCRIPTION
In `v-add-sys-quota`, redirect `quotaon -v` stderr through a filter to suppress known non-critical warnings, such as:

- "Cannot stat ... device tmpfs"
- "kernel probably supports ext4 quota"

This reduces unnecessary noise while preserving other error messages. Standard output is discarded since it is not used.