### PR TITLE
Fix: database host dropdown not filtering by database type

### DIFF
--- a/web/add/db/index.php
+++ b/web/add/db/index.php
@@ -230,14 +230,16 @@ $db_types = explode(",", $_SESSION["DB_SYSTEM"]);
 
 // List available database servers
 exec(HESTIA_CMD . "v-list-database-hosts json", $output, $return_var);
-$db_hosts_tmp1 = json_decode(implode("", $output), true);
-$db_hosts_tmp2 = array_map(function ($host) {
-	return $host["HOST"];
-}, $db_hosts_tmp1);
-$db_hosts = array_values(array_unique($db_hosts_tmp2));
+$db_hosts_tmp = json_decode(implode("", $output), true);
+$db_hosts = [];
+foreach ($db_hosts_tmp as $host) {
+	if (!isset($db_hosts[$host["HOST"]])) {
+		$db_hosts[$host["HOST"]] = [];
+	}
+	$db_hosts[$host["HOST"]][] = $host["TYPE"];
+}
 unset($output);
-unset($db_hosts_tmp1);
-unset($db_hosts_tmp2);
+unset($db_hosts_tmp);
 
 $accept = $_GET["accept"] ?? "";
 

--- a/web/js/src/databaseHints.js
+++ b/web/js/src/databaseHints.js
@@ -12,6 +12,14 @@ export default function handleDatabaseHints() {
 	removeUserPrefix(databaseNameInput);
 	attachUpdateHintListener(usernameInput);
 	attachUpdateHintListener(databaseNameInput);
+
+	const typeSelect = document.getElementById('v_type');
+	const hostSelect = document.getElementById('v_host');
+
+	if (typeSelect && hostSelect) {
+		filterHostOptions(typeSelect, hostSelect);
+		typeSelect.addEventListener('change', () => filterHostOptions(typeSelect, hostSelect));
+	}
 }
 
 // Remove prefix from "Database" input if it exists during initial load (for editing)
@@ -41,4 +49,33 @@ function updateHint(input) {
 	}
 
 	hintElement.textContent = Alpine.store('globals').USER_PREFIX + input.value;
+}
+
+function filterHostOptions(typeSelect, hostSelect) {
+	const selectedType = typeSelect.value;
+	let hasVisibleSelectedOption = false;
+
+	for (const option of hostSelect.options) {
+		const types = option.getAttribute('data-types');
+		if (types && types.split(',').includes(selectedType)) {
+			option.style.display = '';
+			option.disabled = false;
+			if (option.selected) {
+				hasVisibleSelectedOption = true;
+			}
+		} else {
+			option.style.display = 'none';
+			option.disabled = true;
+			option.selected = false;
+		}
+	}
+
+	if (!hasVisibleSelectedOption) {
+		for (const option of hostSelect.options) {
+			if (!option.disabled) {
+				option.selected = true;
+				break;
+			}
+		}
+	}
 }

--- a/web/templates/pages/add_db.php
+++ b/web/templates/pages/add_db.php
@@ -109,10 +109,11 @@
 						<label for="v_host" class="form-label"><?= tohtml( _("Host")) ?></label>
 						<select class="form-select" name="v_host" id="v_host">
 							<?php
-								foreach ($db_hosts as $value) {
-									echo "\n\t\t\t\t\t\t\t\t\t\t<option value=\"".htmlentities($value)."\"";
-									if ((!empty($v_host)) && ( $value == $v_host )) echo ' selected';
-									echo ">".htmlentities($value)."</option>";
+								foreach ($db_hosts as $host => $types) {
+									$types_str = implode(',', $types);
+									echo "\n\t\t\t\t\t\t\t\t\t\t<option value=\"".htmlentities($host)."\" data-types=\"".htmlentities($types_str)."\"";
+									if ((!empty($v_host)) && ( $host == $v_host )) echo ' selected';
+									echo ">".htmlentities($host)."</option>";
 								}
 							?>
 						</select>


### PR DESCRIPTION
## Description
Currently, when selecting a database type (e.g., `mysql` or `pgsql`) on the **Add Database** page, the list of hosts in the **Advanced Options** section does not filter the valid hosts for that specific database type. This could allow a user to inadvertently select a mismatching host (e.g., selecting a `pgsql` host while creating a `mysql` database).

<img width="663" height="586" alt="SCR-20260627-kmmr" src="https://github.com/user-attachments/assets/0e9fc977-e6b0-4221-89f8-aa7f75d50c03" />

This PR fixes the issue by updating the host dropdown list to dynamically filter the valid hosts based on the currently selected database type on the client side.

https://github.com/user-attachments/assets/94899b1c-73d7-42a6-819b-b2af4d545caf

## Changes Made
* **`web/add/db/index.php`**: Updated the loop that processes `$db_hosts` from `v-list-database-hosts json` to capture and pass all valid `TYPE`s along with each `HOST`. (Also renamed `$db_hosts_tmp1` to `$db_hosts_tmp`).
* **`web/templates/pages/add_db.php`**: Injected the supported database types into each `<option>` as a `data-types` attribute (comma-separated).
* **`web/js/src/databaseHints.js`**: Added a JavaScript event listener on the database **Type** select box. The script dynamically hides or reveals the options inside the **Host** select box by checking if their `data-types` attribute includes the selected database type. If the currently selected host becomes invalid due to a type change, the script automatically resets the selection to the first valid host.
* Compiled the new JS assets into `web/js/dist/main.min.js`.

## How to Test
1. Go to **Add Database** in the web panel.
2. Expand the **Advanced Options** section.
3. Switch the database **Type** between `mysql` and `pgsql` (or other configured types).
4. Verify that the **Host** dropdown menu accurately updates to display only the valid database hosts configured for that specific type.