### PR TITLE
fix: round humanized time values in main.php

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -320,14 +320,12 @@ function convert_datetime($date, $format = "Y-m-d H:i:s") {
 }
 
 function humanize_time($usage) {
-	if ($usage > 60) {
-		$usage = $usage / 60;
-		if ($usage > 24) {
-			$usage = $usage / 24;
-			$usage = number_format($usage);
+	if ($usage >= 60) {
+		$usage = round($usage / 60);
+		if ($usage >= 24) {
+			$usage = round($usage / 24);
 			return sprintf(ngettext("%d day", "%d days", $usage), $usage);
 		} else {
-			$usage = round($usage);
 			return sprintf(ngettext("%d hour", "%d hours", $usage), $usage);
 		}
 	} else {


### PR DESCRIPTION
Update `humanize_time()` in 'web/inc/main.php` to use consistent rounding and inclusive thresholds when converting minutes to hours and hours to days, improving the accuracy of displayed time values.

Fixes #5321