### PR TITLE
v-restart-service: warn and continue when no init system reports status

### DIFF
--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -88,8 +88,20 @@ for service in $service_list; do
 
 	# Check the result of the service restart and report whether it failed.
 	if [ $? -ne 0 ]; then
-		check_result "$E_RESTART" "ERROR: Restart of $service failed."
-		$BIN/v-log-action "system" "Error" "System" "Service failed to restart (Name: $service)."
+		if [ -d /run/systemd/system ]; then
+			# systemd is the init system (the host was booted with systemd):
+			# a non-zero exit is an authoritative failure.
+			check_result "$E_RESTART" "ERROR: Restart of $service failed."
+			$BIN/v-log-action "system" "Error" "System" "Service failed to restart (Name: $service)."
+		else
+			# No systemd as PID 1 (e.g. running inside a container): systemctl
+			# cannot reliably manage or report on services, so a non-zero exit
+			# here is not authoritative and the service is frequently running
+			# regardless. Warn and continue instead of aborting the calling
+			# operation (e.g. v-add-web-domain). Behaviour on a normally-booted
+			# systemd host is unchanged.
+			$BIN/v-log-action "system" "Warning" "System" "Could not confirm restart of $service; init system does not report service status. Continuing."
+		fi
 	else
 		$BIN/v-log-action "system" "Info" "System" "Service restarted (Name: $service)."
 	fi


### PR DESCRIPTION
## Problem

When HestiaCP runs without systemd as PID 1 (for example inside a container), `systemctl` cannot reliably manage or report on services. A live panel operation such as `v-add-web-domain` calls `v-restart-service`, which runs `systemctl reload-or-restart` / `systemctl restart`. A non-zero exit there currently aborts the whole operation via `check_result "$E_RESTART"` and logs an error, even though nginx/php-fpm are typically running fine. The panel action fails and the only reliable workaround is a full config rebuild + clean restart at container start (`v-rebuild-user`), which rules out live operations.

This is the "small, init-agnostic robustness" discussed here, option 2 (warn-and-continue when the init system cannot report status, with no change on supported OSes):
https://forum.hestiacp.com/t/appetite-for-small-init-agnostic-robustness-in-service-handling-context-running-hestiacp-in-a-container/21912

## Change

Gate the restart-failure on whether the host was actually booted with systemd, using the canonical `sd_booted()` check (`/run/systemd/system` exists):

- **systemd present** -> a non-zero restart stays an authoritative failure (existing behaviour, unchanged).
- **systemd absent** -> log a `Warning` and continue instead of aborting the calling operation.

```
if [ $? -ne 0 ]; then
    if [ -d /run/systemd/system ]; then
        check_result "$E_RESTART" "ERROR: Restart of $service failed."
        ...Error...
    else
        ...Warning: Could not confirm restart; init system does not report status. Continuing.
    fi
else
    ...Info...
fi
```

## Impact

- **No behaviour change on any supported, systemd-booted OS** — `/run/systemd/system` always exists there, so the existing error path runs exactly as before.
- Only when systemd is not the init system (and its status reporting is therefore not authoritative) does the command warn and continue, letting live operations succeed in containers.

systemd remains the default and only officially supported path; this just stops a non-authoritative status check from aborting valid operations where systemd is absent.

Scope is intentionally minimal — one indirection in `v-restart-service`. Happy to adjust the log wording or approach.
