### PR TITLE
Add pluggable service-control backend (default: systemd)

### DIFF
--- a/bin/v-restart-service
+++ b/bin/v-restart-service
@@ -80,10 +80,9 @@ for service in $service_list; do
 		"$service" = "proftpd" -o \
 		"$service" = "ssh" -o \
 		"$service" = "fail2ban" ]; then
-		systemctl reload-or-restart "$service" >> $log 2>&1
+		service_action reload-or-restart "$service" "$log"
 	else
-		systemctl reset-failed "$service" >> $log 2>&1
-		systemctl restart "$service" >> $log 2>&1
+		service_action restart "$service" "$log"
 	fi
 
 	# Check the result of the service restart and report whether it failed.

--- a/bin/v-start-service
+++ b/bin/v-start-service
@@ -44,7 +44,7 @@ for service in $service_list; do
 	if [ "$service" = "iptables" ]; then
 		$BIN/v-update-firewall
 	else
-		systemctl start "$service"
+		service_action start "$service"
 		result=$?
 		if [ "$result" -ne 0 ]; then
 			$BIN/v-log-action "system" "Error" "System" "Service failed to start (Name: $service)."

--- a/bin/v-stop-service
+++ b/bin/v-stop-service
@@ -47,7 +47,7 @@ for service in $service_list; do
 	if [ "$service" = "iptables" ]; then
 		$BIN/v-stop-firewall
 	else
-		systemctl stop "$service"
+		service_action stop "$service"
 		result=$?
 		if [ "$result" -ne 0 ]; then
 			$BIN/v-log-action "system" "Error" "System" "Service failed to stop (Name: $service)."

--- a/func/main.sh
+++ b/func/main.sh
@@ -1797,6 +1797,41 @@ multiphp_versions() {
 	fi
 }
 
+# Service control abstraction - the single indirection point for starting,
+# stopping and restarting system services. Dispatches to the service manager
+# named by SERVICE_MANAGER in hestia.conf. systemd is the default and the only
+# officially supported backend; a generic SysV-style "service" backend is
+# provided for environments without systemd as PID 1 (e.g. containers), and the
+# case statement can be extended for other supervisors. Returns the backend
+# command's exit code.
+# Usage: service_action <start|stop|restart|reload-or-restart|reload> NAME [LOGFILE]
+service_action() {
+	local action="$1"
+	local name="$2"
+	local log="${3:-/dev/null}"
+
+	case "${SERVICE_MANAGER:-systemd}" in
+		sysv | service)
+			# Generic SysV-style backend: map systemd-only verbs onto the
+			# portable `service` equivalents.
+			[ "$action" = "reload-or-restart" ] && action="restart"
+			service "$name" "$action" >> "$log" 2>&1
+			;;
+		systemd | *)
+			# Default, officially supported backend (semantics unchanged).
+			case "$action" in
+				restart)
+					systemctl reset-failed "$name" >> "$log" 2>&1
+					systemctl restart "$name" >> "$log" 2>&1
+					;;
+				*)
+					systemctl "$action" "$name" >> "$log" 2>&1
+					;;
+			esac
+			;;
+	esac
+}
+
 multiphp_default_version() {
 	# Get system wide default php version (set by update-alternatives)
 	local sys_phpversion=$(php -r "echo substr(phpversion(),0,3);")


### PR DESCRIPTION
## Problem

When HestiaCP runs without systemd as PID 1 (for example inside a container), the service-control logic is hard-wired to `systemctl`, scattered across `v-restart-service`, `v-start-service` and `v-stop-service`. There is no supported way to target a different service manager, so the only options are forking these scripts or shimming `systemctl`.

This implements **option 1** from the discussion (a thin, pluggable abstraction), and is an alternative to the lighter-weight #5475 (option 2: warn-and-continue):
https://forum.hestiacp.com/t/appetite-for-small-init-agnostic-robustness-in-service-handling-context-running-hestiacp-in-a-container/21912

## Change

- Add a single indirection, `service_action()` in `func/main.sh`, that dispatches start/stop/restart/reload to the backend named by `SERVICE_MANAGER` in `hestia.conf`.
- Route `v-restart-service`, `v-start-service` and `v-stop-service` through it.
- Backends:
  - `systemd` (**default, and the only officially supported path**) - identical semantics to today: `reload-or-restart` for the web/php/mail/etc. services, `reset-failed` + `restart` otherwise, `start`/`stop` for the rest.
  - `sysv` / `service` - a generic SysV-style backend (`service NAME ACTION`) for environments without systemd; the `case` can be extended for other supervisors.

```sh
service_action() {
    local action="$1" name="$2" log="${3:-/dev/null}"
    case "${SERVICE_MANAGER:-systemd}" in
        sysv | service)
            [ "$action" = "reload-or-restart" ] && action="restart"
            service "$name" "$action" >> "$log" 2>&1 ;;
        systemd | *)
            case "$action" in
                restart) systemctl reset-failed "$name" >>"$log" 2>&1; systemctl restart "$name" >>"$log" 2>&1 ;;
                *)       systemctl "$action" "$name" >>"$log" 2>&1 ;;
            esac ;;
    esac
}
```

## Impact

- **No behaviour change on supported, systemd-booted OSes.** `SERVICE_MANAGER` is unset by default, so the dispatcher uses the systemd backend with the exact commands used today. No new config is written to existing installs.
- Operators running without systemd can set `SERVICE_MANAGER='sysv'` (or add a custom backend) in `hestia.conf` to make live operations like `v-add-web-domain` work without forking.

systemd remains the default and only officially supported backend; this just removes the hard-coupling so other init systems can be plugged in.

## Relationship to #5475

#5475 (option 2) is the minimal change: keep one `systemctl` path but don't abort when there is no init system to report status. This PR (option 1) is the more structural alternative. They are mutually exclusive - happy to land whichever approach you prefer, or close one.
