### PR TITLE
hestia-nginx: Allow access to installer images under src/app/WebApp/Installers/

### DIFF
--- a/src/deb/nginx/nginx.conf
+++ b/src/deb/nginx/nginx.conf
@@ -134,6 +134,11 @@ http {
 		if ($anti_replay = 307) { return 307 https://$host:$server_port$request_uri; }
 		if ($anti_replay = 425) { return 425; }
 
+		# Allow installer images (Installers/*/file.png|jpg|svg)
+		location ~* ^/src/app/WebApp/Installers/[^/]+/[^/]+\.(png|jpe?g|svg)$ {
+			try_files $uri =404;
+		}
+
 		# Deny access to internal PHP includes and source dirs
 		location ~* ^/(inc|src|locale|templates)(/|$) {
 			return 404;


### PR DESCRIPTION
The existing rule that blocks access to /src, /inc, /locale and /templates was also blocking legitimate installer images (png, jpg, svg) located under src/app/WebApp/Installers/*/.

Add a more specific location block matching only image files in that path, placed before the deny rule so it takes precedence.

All other files under /src (php, json, etc.) remain blocked as before.

Related PR #5446