### PR TITLE
fix: use first option as default for CLI webapp installations

### DIFF
--- a/bin/v-quick-install-app
+++ b/bin/v-quick-install-app
@@ -18,13 +18,11 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-
 use Hestiacp\quoteshellarg\quoteshellarg;
 
 session_start();
-require_once( __DIR__ . '/../web/inc/vendor/autoload.php');
-require_once( __DIR__ . '/../web/src/init.php');
-
+require_once __DIR__ . "/../web/inc/vendor/autoload.php";
+require_once __DIR__ . "/../web/src/init.php";
 
 define("HESTIA_DIR_BIN", "/usr/local/hestia/bin/");
 define("HESTIA_CMD", "/usr/bin/sudo /usr/local/hestia/bin/");
@@ -34,32 +32,32 @@ exec(HESTIA_CMD . "v-list-sys-config json", $output, $return_var);
 $data = json_decode(implode("", $output), true);
 $sys_arr = $data["config"];
 foreach ($sys_arr as $key => $value) {
-$_SESSION[$key] = $value;
+	$_SESSION[$key] = $value;
 }
 
-
-$_SESSION['userContext'] = 'user';
+$_SESSION["userContext"] = "user";
 $application = new Application();
-$application -> register('install')
-	->setDescription('Install app via the CLI')
-	-> addArgument('user', InputArgument::REQUIRED, 'Hestia User')
-	-> addArgument('domain', InputArgument::REQUIRED, 'Domain')
-	-> addArgument('app', InputArgument::REQUIRED, 'App Name')
-	-> addArgument('options', InputArgument::IS_ARRAY, 'Options')
-	-> setCode(function(InputInterface $input, OutputInterface $output): int {
-		$user = $input -> getArgument('user');
-		$_SESSION['user'] = $user;
-		$v_domain = $input -> getArgument('domain');
-		$app = $input -> getArgument('app');
-		$options = $input -> getArgument('options');
+$application
+	->register("install")
+	->setDescription("Install app via the CLI")
+	->addArgument("user", InputArgument::REQUIRED, "Hestia User")
+	->addArgument("domain", InputArgument::REQUIRED, "Domain")
+	->addArgument("app", InputArgument::REQUIRED, "App Name")
+	->addArgument("options", InputArgument::IS_ARRAY, "Options")
+	->setCode(function (InputInterface $input, OutputInterface $output): int {
+		$user = $input->getArgument("user");
+		$_SESSION["user"] = $user;
+		$v_domain = $input->getArgument("domain");
+		$app = $input->getArgument("app");
+		$options = $input->getArgument("options");
 		$data = [];
-		foreach($options as $option){
-			$o  = explode('=', $option);
-			$data['webapp_'.$o[0]] = $o[1];
+		foreach ($options as $option) {
+			$o = explode("=", $option);
+			$data["webapp_" . $o[0]] = $o[1];
 		}
 		$hestia = new \Hestia\System\HestiaApp();
-		if(class_exists("\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup") === false){
-			$output -> writeln('App not found');
+		if (class_exists("\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup") === false) {
+			$output->writeln("App not found");
 			return Command::FAILURE;
 		}
 		$app_installer_class = "\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup";
@@ -67,12 +65,16 @@ $application -> register('install')
 
 		// check for default fields
 		$WebappInstaller = new \Hestia\WebApp\AppWizard($app_installer, $v_domain, $hestia);
-		$fields = $WebappInstaller -> getOptions();
+		$fields = $WebappInstaller->getOptions();
 		$array = [];
-		foreach($fields as $key => $field){
-			if(is_array($field)){
-				if(!empty($field['value'])){
-					$array['webapp_'.$key] = $field['value'];
+		foreach ($fields as $key => $field) {
+			if (is_array($field)) {
+				if (!empty($field["value"])) {
+					$array["webapp_" . $key] = $field["value"];
+				} elseif (!empty($field["options"])) {
+					// If the field has options but no value (like database_host),
+					// take the first option as the default value.
+					$array["webapp_" . $key] = reset($field["options"]);
 				}
 			}
 		}
@@ -80,102 +82,132 @@ $application -> register('install')
 		//loop trough data and check all fields are set
 
 		$error = false;
-		foreach($fields as $key => $field){
-			if(empty($data['webapp_'.$key])){
-				if(strpos($key, 'database_') !== false){
-					if($data['webapp_database_create'] != true){
-					$output -> writeln('Missing required field: ' . $key);
+		foreach ($fields as $key => $field) {
+			if (empty($data["webapp_" . $key])) {
+				if (strpos($key, "database_") !== false) {
+					if ($data["webapp_database_create"] != true) {
+						$output->writeln("Missing required field: " . $key);
 						$error = true;
 					}
-				}else{
+				} else {
 					//all ways the case
-					$output -> writeln('Missing required field: ' . $key);
+					$output->writeln("Missing required field: " . $key);
 					$error = true;
 				}
 			}
 		}
 
-		if($error !== false){
+		if ($error !== false) {
 			return Command::FAILURE;
 		}
 
 		$installer = new \Hestia\WebApp\AppWizard($app_installer, $v_domain, $hestia);
-		$installer -> execute($data);
+		$installer->execute($data);
 		return Command::SUCCESS;
 	});
 
-$application -> register('apps')
-	->setDescription('List availble apps')
-	-> setCode(function(InputInterface $input, OutputInterface $output): int {
-	$appInstallers = glob(__DIR__ . "/../web/src/app/WebApp/Installers/*/*.php");
-	$output -> writeln('Available Apps');
-	$output -> writeln('---------------------------------');
-	foreach($appInstallers as $appInstaller){
-		$app = basename(dirname($appInstaller));
-		$hestia = new \Hestia\System\HestiaApp();
-		$domain = 'demo.hestiacp.com';
-		if( !file_exists(__DIR__ . "/../web/src/app/WebApp/Installers/" . $app . "/". $app . "Setup.php") ){
-			continue;
+$application
+	->register("apps")
+	->setDescription("List availble apps")
+	->setCode(function (InputInterface $input, OutputInterface $output): int {
+		$appInstallers = glob(__DIR__ . "/../web/src/app/WebApp/Installers/*/*.php");
+		$output->writeln("Available Apps");
+		$output->writeln("---------------------------------");
+		foreach ($appInstallers as $appInstaller) {
+			$app = basename(dirname($appInstaller));
+			$hestia = new \Hestia\System\HestiaApp();
+			$domain = "demo.hestiacp.com";
+			if (
+				!file_exists(
+					__DIR__ .
+						"/../web/src/app/WebApp/Installers/" .
+						$app .
+						"/" .
+						$app .
+						"Setup.php",
+				)
+			) {
+				continue;
+			}
+			$app_installer_class = "\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup";
+			$app_installer = new $app_installer_class($domain, $hestia);
+			$info = $app_installer->info();
+			$output->writeln($info["name"] . " - " . $info["version"]);
 		}
-		$app_installer_class = "\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup";
-		$app_installer = new $app_installer_class($domain, $hestia);
-		$info = $app_installer -> info();
-		$output -> writeln($info['name'] . ' - ' . $info['version']);
-	}
-	$output -> writeln('---------------------------------');
-	$output -> writeln('Please note app names are case sensitive');
+		$output->writeln("---------------------------------");
+		$output->writeln("Please note app names are case sensitive");
 
-	return Command::SUCCESS;
-});
+		return Command::SUCCESS;
+	});
 
-$application -> register('options')
-->setDescription('List options requied / optional for the app')
-	-> addArgument('user', InputArgument::REQUIRED, 'Hestia User')
-	-> addArgument('domain', InputArgument::REQUIRED, 'Domain')
-	-> addArgument('app', InputArgument::REQUIRED, 'App Name')
-	-> setCode(function(InputInterface $input, OutputInterface $output): int {
-		$user = $input -> getArgument('user');
-		$_SESSION['user'] = $user;
-		$v_domain = $input -> getArgument('domain');
-		$app = $input -> getArgument('app');
+$application
+	->register("options")
+	->setDescription("List options requied / optional for the app")
+	->addArgument("user", InputArgument::REQUIRED, "Hestia User")
+	->addArgument("domain", InputArgument::REQUIRED, "Domain")
+	->addArgument("app", InputArgument::REQUIRED, "App Name")
+	->setCode(function (InputInterface $input, OutputInterface $output): int {
+		$user = $input->getArgument("user");
+		$_SESSION["user"] = $user;
+		$v_domain = $input->getArgument("domain");
+		$app = $input->getArgument("app");
 		$hestia = new \Hestia\System\HestiaApp();
 
-		if(class_exists("\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup") === false){
-			$output -> writeln('App not found');
+		if (class_exists("\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup") === false) {
+			$output->writeln("App not found");
 			return Command::FAILURE;
 		}
 		$app_installer_class = "\Hestia\WebApp\Installers\\" . $app . "\\" . $app . "Setup";
 		$app_installer = new $app_installer_class($v_domain, $hestia);
 		$WebappInstaller = new \Hestia\WebApp\AppWizard($app_installer, $v_domain, $hestia);
-		$output -> writeln('To install '.$app.' use the following command:');
-		$output -> writeln('v-quick-install-app install ' . $user . ' ' . $v_domain . ' ' . $app . ' email="info@hestiacp" password="12346"');
-		$output -> writeln('---------------------------------');
-		$output -> writeln('Options for ' . $app);
-		$output -> writeln('---------------------------------');
-		$options = $WebappInstaller -> getOptions();
-		foreach($options as $key => $option){
-			if(!is_array($option)){
-				$output -> writeln('Key: ' . $key . ' Type: ' . $option .' (Required)');
-			}else{
-				$required = '';
-				if(empty($option['value'])){
-					 $option['value'] = 'none';
-					 if(strpos($key, 'database_') === false){
-					 $required = '('	. 'Required' . ')';
-					 }
-				}
-				if(!empty($option['type'])){
-					if($option['type'] == 'boolean'){
-						$option['value'] = $option['value'] ? 'true' : 'false';
+		$output->writeln("To install " . $app . " use the following command:");
+		$output->writeln(
+			"v-quick-install-app install " .
+				$user .
+				" " .
+				$v_domain .
+				" " .
+				$app .
+				' email="info@hestiacp" password="12346"',
+		);
+		$output->writeln("---------------------------------");
+		$output->writeln("Options for " . $app);
+		$output->writeln("---------------------------------");
+		$options = $WebappInstaller->getOptions();
+		foreach ($options as $key => $option) {
+			if (!is_array($option)) {
+				$output->writeln("Key: " . $key . " Type: " . $option . " (Required)");
+			} else {
+				$required = "";
+				if (empty($option["value"])) {
+					$option["value"] = "none";
+					if (strpos($key, "database_") === false) {
+						$required = "(" . "Required" . ")";
 					}
-					$output -> writeln('Key: ' .$key . ' Default Value: ' . $option['value'] .' Type: ' . $option['type'] . ' ' . $required);
-				}else{
-					$output -> writeln('Key :' .$key . ' Default Value: ' . $option['value'] . ' ' . $required);
+				}
+				if (!empty($option["type"])) {
+					if ($option["type"] == "boolean") {
+						$option["value"] = $option["value"] ? "true" : "false";
+					}
+					$output->writeln(
+						"Key: " .
+							$key .
+							" Default Value: " .
+							$option["value"] .
+							" Type: " .
+							$option["type"] .
+							" " .
+							$required,
+					);
+				} else {
+					$output->writeln(
+						"Key :" . $key . " Default Value: " . $option["value"] . " " . $required,
+					);
 				}
 			}
 		}
 		return Command::SUCCESS;
 	});
 
+$application->run();
 
-$application -> run();


### PR DESCRIPTION
Updated `v-quick-install-app` to handle fields that provide a list of options instead of a static default value. Previously, these fields (like `database_host`) remained empty, causing TypeErrors in the AppWizard execution. This fix ensures the installer picks the first available option as a fallback when no explicit value is provided.

This change fixes the bats test:
```bash
not ok 78 WEB: Use quick install app on web domain
# (from function `assert_success' in file test/test_helper/bats-assert/src/assert_success.bash, line 42,
#  in test file test/test.bats, line 922)
#   `assert_success' failed
#
# -- command failed --
# status : 255
# output (14 lines):
#   PHP Warning:  Undefined array key "database_host" in /usr/local/hestia/web/src/app/WebApp/AppWizard.php on line 144
#   PHP Fatal error:  Uncaught TypeError: Hestia\WebApp\InstallationTarget\TargetDatabase::__construct(): Argument #1 ($host) must be of type string, null given, called in /usr/local/hestia/web/src/app/WebApp/AppWizard.php on line 143 and defined in /usr/local/hestia/web/src/app/WebApp/InstallationTarget/TargetDatabase.php:9
#   Stack trace:
#   #0 /usr/local/hestia/web/src/app/WebApp/AppWizard.php(143): Hestia\WebApp\InstallationTarget\TargetDatabase->__construct()
#   #1 /usr/local/hestia/bin/v-quick-install-app(103): Hestia\WebApp\AppWizard->execute()
#   #2 [internal function]: Closure->{closure:/usr/local/hestia/bin/v-quick-install-app:49}()
#   #3 /usr/local/hestia/web/src/vendor/symfony/console/Command/InvokableCommand.php(62): ReflectionFunction->invoke()
#   #4 /usr/local/hestia/web/src/vendor/symfony/console/Command/Command.php(281): Symfony\Component\Console\Command\InvokableCommand->__invoke()
#   #5 /usr/local/hestia/web/src/vendor/symfony/console/Application.php(1121): Symfony\Component\Console\Command\Command->run()
#   #6 /usr/local/hestia/web/src/vendor/symfony/console/Application.php(379): Symfony\Component\Console\Application->doRunCommand()
#   #7 /usr/local/hestia/web/src/vendor/symfony/console/Application.php(218): Symfony\Component\Console\Application->doRun()
#   #8 /usr/local/hestia/bin/v-quick-install-app(181): Symfony\Component\Console\Application->run()
#   #9 {main}
#     thrown in /usr/local/hestia/web/src/app/WebApp/InstallationTarget/TargetDatabase.php on line 9
# --
#
```

Because of the linter, there are many changes but this is the only part I've modified:

```diff
                         if (is_array($field)) {
                                 if (!empty($field["value"])) {
                                         $array["webapp_" . $key] = $field["value"];
+                                } elseif (!empty($field["options"])) {
+                                        // If the field has options but no value (like database_host),
+                                        // take the first option as the default value.
+                                        $array["webapp_" . $key] = reset($field["options"]);
                                 }
                         }
                 }
```