### PR TITLE
fix: error adding self-signed cert using default options

### DIFF
--- a/web/generate/ssl/index.php
+++ b/web/generate/ssl/index.php
@@ -18,7 +18,7 @@ $v_email = "";
 $v_country = "US";
 $v_state = "California";
 $v_locality = "San Francisco";
-$v_org = "MyCompany Inc.";
+$v_org = "MyCompany Inc";
 $v_org_unit = "IT";
 
 // Back uri


### PR DESCRIPTION
Default options when generating a self-signed certificate from the Web UI use `MyCompany Inc.` as the organizational unit, but due to Hestia’s hardened input validation (which restricts what users can enter in fields), the **dot** is not allowed, causing the following error:
```
Error: invalid org format :: MyCompany Inc.
```