### PR TITLE
feat(ipv6): add complete IPv6 support for system IPs, web domains, and DNS

### DIFF
--- a/bin/v-add-dns-domain
+++ b/bin/v-add-dns-domain
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add dns domain
-# options: USER DOMAIN IP [NS1] [NS2] [NS3] [NS4] [NS5] [NS6] [NS7] [NS8] [RESTART]
+# options: USER DOMAIN IP [NS1] [NS2] [NS3] [NS4] [NS5] [NS6] [NS7] [NS8] [RESTART] [DNSSEC] [IPV6]
 #
 # example: v-add-dns-domain admin example.com ns1.example.com ns2.example.com '' '' '' '' '' '' yes
 #
@@ -28,6 +28,7 @@ ns7=${10}
 ns8=${11}
 restart=${12}
 dnssec=${13}
+ipv6=${14}
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -51,7 +52,8 @@ domain_utf=$(idn2 --quiet -d "$domain_idn")
 #----------------------------------------------------------#
 
 check_args '3' "$#" 'USER DOMAIN IP [NS1] [NS2] [NS3] [..] [NS8] [RESTART]'
-is_format_valid 'user' 'domain' 'ip'
+is_format_valid 'user' 'domain'
+is_ip_format_valid "$ip" || check_result $E_INVALID "Invalid IP format: $ip"
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -85,35 +87,35 @@ is_dns_template_valid "$template"
 is_base_domain_owner "$domain"
 
 if [ -n "$ns1" ]; then
-	ns1=$(echo "$4" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns1=$(echo $4 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns1'
 fi
 if [ -n "$ns2" ]; then
-	ns2=$(echo "$5" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns2=$(echo $5 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns2'
 fi
 if [ -n "$ns3" ]; then
-	ns3=$(echo "$6" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns3=$(echo $6 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns3'
 fi
 if [ -n "$ns4" ]; then
-	ns4=$(echo "$7" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns4=$(echo $7 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns4'
 fi
 if [ -n "$ns5" ]; then
-	ns5=$(echo "$8" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns5=$(echo $8 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns5'
 fi
 if [ -n "$ns6" ]; then
-	ns6=$(echo "$9" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns6=$(echo $9 | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns6'
 fi
 if [ -n "$ns7" ]; then
-	ns7=$(echo "${10}" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns7=$(echo ${10} | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns7'
 fi
 if [ -n "$ns8" ]; then
-	ns8=$(echo "${11}" | sed -e 's/\.*$//g' -e 's/^\.*//g')
+	ns8=$(echo ${11} | sed -e 's/\.*$//g' -e 's/^\.*//g')
 	is_format_valid 'ns8'
 fi
 
@@ -170,6 +172,19 @@ time=$(echo "$time_n_date" | cut -f 1 -d \ )
 date=$(echo "$time_n_date" | cut -f 2 -d \ )
 
 # Adding dns zone to the user config
+# Add AAAA records if IPv6 is specified
+if [ -n "$ipv6" ]; then
+	max_id=$(grep -o "ID='[0-9]*'" <<< "$template_data" | sed "s/ID='//;s/'//" | sort -n | tail -1)
+	id=$((max_id + 1))
+	template_data="${template_data}"$'\n'"ID='${id}' RECORD='@' TYPE='AAAA' PRIORITY='' VALUE='${ipv6}' SUSPENDED='no' TIME='${time}' DATE='${date}'"
+	id=$((id + 1))
+	template_data="${template_data}"$'\n'"ID='${id}' RECORD='www' TYPE='AAAA' PRIORITY='' VALUE='${ipv6}' SUSPENDED='no' TIME='${time}' DATE='${date}'"
+	id=$((id + 1))
+	template_data="${template_data}"$'\n'"ID='${id}' RECORD='ftp' TYPE='AAAA' PRIORITY='' VALUE='${ipv6}' SUSPENDED='no' TIME='${time}' DATE='${date}'"
+	id=$((id + 1))
+	template_data="${template_data}"$'\n'"ID='${id}' RECORD='mail' TYPE='AAAA' PRIORITY='' VALUE='${ipv6}' SUSPENDED='no' TIME='${time}' DATE='${date}'"
+fi
+
 echo "$template_data" \
 	| sed -e "s/%ip%/$ip/g" \
 		-e "s/%domain_idn%/$domain_idn/g" \

--- a/bin/v-add-domain
+++ b/bin/v-add-domain
@@ -56,7 +56,7 @@ fi
 if [ -n "$WEB_SYSTEM" ]; then
 	check1=$(is_package_full 'WEB_DOMAINS')
 	if [ $? -eq 0 ]; then
-		$BIN/v-add-web-domain "$user" "$domain" "$ip" 'no'
+		$BIN/v-add-web-domain-ipv46 "$user" "$domain" "$ip" "" 'no'
 		check_result $? "can't add web domain"
 	fi
 fi

--- a/bin/v-add-letsencrypt-host
+++ b/bin/v-add-letsencrypt-host
@@ -50,7 +50,7 @@ is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
 # Check if hostname already exists as domain
 if [ "$($BIN/v-list-web-domain $user $domain plain | cut -f 1)" != "$domain" ]; then
 	# Create web domain for hostname
-	$BIN/v-add-web-domain "$user" "$domain"
+	$BIN/v-add-web-domain-ipv46 "$user" "$domain"
 fi
 
 # Validate web domain
@@ -67,11 +67,11 @@ add_ssl="yes"
 if [ "$SSL" = "yes" ]; then
 	# Valildate SSL Certificate
 	if [ -e "$USER_DATA/ssl/$domain.ca" ]; then
-		if openssl verify -CAfile "$USER_DATA/ssl/$domain.ca" "$USER_DATA/ssl/$domain.pem" | grep -q "$domain.pem: OK"; then
+		if openssl verify -CAfile <(openssl x509 -in $USER_DATA/ssl/$domain.ca) $USER_DATA/ssl/$domain.pem | grep -q "$domain.pem: OK"; then
 			add_ssl="no"
 		fi
 	else
-		if openssl verify "$USER_DATA/ssl/$domain.pem" | grep -q "$domain.pem: OK"; then
+		if openssl verify $USER_DATA/ssl/$domain.pem | grep -q "$domain.pem: OK"; then
 			add_ssl="no"
 		fi
 	fi

--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -84,11 +84,20 @@ check_hestia_demo_mode
 source_conf "$USER_DATA/user.conf"
 # Inherit web domain local ip address
 domain_ip=$(get_object_value 'web' 'DOMAIN' "$domain" '$IP')
-if [ ! -z "$domain_ip" ]; then
+domain_ipv6=$(get_object_value 'web' 'DOMAIN' "$domain" '$IP6')
+if [ -n "$domain_ipv6" ]; then
+	local_ipv6=$(get_real_ip "$domain_ipv6")
+	is_ipv6_valid "$local_ipv6" "$user"
+fi
+if [ -n "$domain_ip" ]; then
 	local_ip=$(get_real_ip "$domain_ip")
 	is_ip_valid "$local_ip" "$user"
-else
-	get_user_ip
+fi
+if [ -z "$local_ip" -a -z "$local_ipv6" ]; then
+	get_user_ipv6 #	get first available user ipv6 address as fallback, if none ip address was defined
+	if [ -z "$ipv6" ]; then
+		get_user_ip #	get first available user ipv4 address as fallback, if none ipv6 user address available
+	fi
 fi
 
 # Generating timestamp
@@ -138,6 +147,9 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 	if [ -n "$local_ip" ]; then
 		echo "$local_ip" > $HOMEDIR/$user/conf/mail/$domain/ip
 	fi
+	if [ -n "$local_ipv6" ]; then
+		echo "$local_ipv6" > $HOMEDIR/$user/conf/mail/$domain/ipv6
+	fi
 
 	if [ -n "$ANTISPAM_SYSTEM" ]; then
 		# Adding antispam protection
@@ -182,6 +194,10 @@ if [ -n "$DNS_SYSTEM" ] && [ "$dkim" = 'yes' ]; then
 	check_dns_domain=$(is_object_valid 'dns' 'DOMAIN' "$domain")
 	if [ "$?" -eq 0 ]; then
 		p=$(cat $USER_DATA/mail/$domain.pub | grep -v ' KEY---' | tr -d '\n')
+		record='_domainkey'
+		policy="\"t=y; o=~;\""
+		$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$policy" '' '' 'no' '' 'yes'
+
 		record='mail._domainkey'
 		selector="\"v=DKIM1\; k=rsa\; p=$p\""
 		$BIN/v-add-dns-record "$user" "$domain" "$record" TXT "$selector" '' '' 'yes' '' 'yes'

--- a/bin/v-add-mail-domain-webmail
+++ b/bin/v-add-mail-domain-webmail
@@ -79,6 +79,12 @@ check_hestia_demo_mode
 
 # Inherit web domain local ip address
 domain_ip=$(get_object_value 'web' 'DOMAIN' "$domain" '$IP')
+domain_ipv6=$(get_object_value 'web' 'DOMAIN' "$domain" '$IP6')
+if [ -n "$domain_ipv6" ]; then
+	local_ipv6=$(get_real_ip "$domain_ipv6")
+	is_ipv6_valid "$local_ipv6" "$user"
+	ipv6=$local_ipv6
+fi
 if [ -n "$domain_ip" ]; then
 	local_ip=$(get_real_ip "$domain_ip")
 	is_ip_valid "$local_ip" "$user"
@@ -88,8 +94,12 @@ if [ -n "$domain_ip" ]; then
 	if [ -n "$nat_ip" ]; then
 		ip=$nat_ip
 	fi
-else
-	get_user_ip
+fi
+if [ -z "$ip" -a -z "$ipv6" ]; then
+	get_user_ipv6 #	get first available user ipv6 address as fallback, if none ip address was defined
+	if [ -z "$ipv6" ]; then
+		get_user_ip #	get first available user ipv4 address as fallback, if none ipv6 user address available
+	fi
 fi
 
 # Verify that webmail alias variable exists and create it if it does not
@@ -99,10 +109,10 @@ else
 	# Ensure DNS record exists if Hestia is hosting DNS zones
 	if [ -n "$DNS_SYSTEM" ]; then
 		dns_domain=$($BIN/v-list-dns-domains $user | grep $domain | cut -d' ' -f1)
+		webmail_record=$($BIN/v-list-dns-records $user $domain | grep -i " $WEBMAIL_ALIAS " | cut -d' ' -f1)
 		if [ "$dns_domain" = "$domain" ]; then
 			if [ "$WEBMAIL_ALIAS" != "mail" ]; then
-				# Handle non-mail webmail alias (e.g., "webmail")
-				webmail_record=$($BIN/v-list-dns-records $user $domain | awk '{if ($2 == "'"$WEBMAIL_ALIAS"'") print $1}')
+				#Prevent mail.domain.com to be cycled
 				if [ -z "$webmail_record" ]; then
 					if [ "$quiet" = "yes" ]; then
 						$BIN/v-add-dns-record "$user" "$domain" "$WEBMAIL_ALIAS" A "$ip" '' '' "$restart" '' 'yes'
@@ -116,27 +126,6 @@ else
 					else
 						$BIN/v-delete-dns-record "$user" "$domain" "$webmail_record" "$restart" 'yes'
 						$BIN/v-add-dns-record "$user" "$domain" "$WEBMAIL_ALIAS" A "$ip" '' '' "$restart" '' 'yes'
-					fi
-				fi
-			else
-				# WEBMAIL_ALIAS is "mail" - ensure webmail CNAME points to mail.domain.com
-				webmail_cname_record=$($BIN/v-list-dns-records $user $domain | awk '$2 == "webmail" && $3 == "CNAME" {print $1}')
-				mail_target="mail.$domain."
-				if [ -z "$webmail_cname_record" ]; then
-					# Add webmail CNAME record
-					if [ "$quiet" = "yes" ]; then
-						$BIN/v-add-dns-record "$user" "$domain" "webmail" CNAME "$mail_target" '' '' "$restart" '' 'yes'
-					else
-						$BIN/v-add-dns-record "$user" "$domain" "webmail" CNAME "$mail_target" '' '' "$restart" '' 'yes'
-					fi
-				else
-					# Update existing webmail CNAME record
-					if [ "$quiet" = "yes" ]; then
-						$BIN/v-delete-dns-record "$user" "$domain" "$webmail_cname_record" "$restart" 'yes'
-						$BIN/v-add-dns-record "$user" "$domain" "webmail" CNAME "$mail_target" '' '' "$restart" '' 'yes'
-					else
-						$BIN/v-delete-dns-record "$user" "$domain" "$webmail_cname_record" "$restart" 'yes'
-						$BIN/v-add-dns-record "$user" "$domain" "webmail" CNAME "$mail_target" '' '' "$restart" '' 'yes'
 					fi
 				fi
 			fi
@@ -181,7 +170,7 @@ else
 	fi
 fi
 
-WEBMAIL=$(get_object_value 'mail' 'DOMAIN' "$domain" '$WEBMAIL')
+WEBMAIL=$(get_object_value 'web' 'DOMAIN' "$domain" "$WEBMAIL")
 if [ -z "$WEBMAIL" ]; then
 	add_object_key 'mail' 'DOMAIN' "$domain" 'WEBMAIL' 'SSL'
 fi

--- a/bin/v-add-sys-ip
+++ b/bin/v-add-sys-ip
@@ -1,8 +1,12 @@
 #!/bin/bash
 # info: add system IP address
-# options: IP NETMASK [INTERFACE] [USER] [IP_STATUS] [IP_NAME] [NAT_IP]
+# options: IP [NETMASK] [INTERFACE] [USER] [IP_STATUS] [IP_NAME] [NAT_IP]
 #
-# example: v-add-sys-ip 203.0.113.1 255.255.255.0
+# example: v-add-sys-ip 216.239.32.21 255.255.255.0
+# example: v-add-sys-ip 216.239.32.21 /24
+# example: v-add-sys-ip 216.239.32.21/24
+# example: v-add-sys-ip 1234:55:66::1 /64
+# example: v-add-sys-ip 1234:55:66::1/64
 #
 # This function adds IP address into a system. It also creates rc scripts. You
 # can specify IP name which will be used as root domain for temporary aliases.
@@ -16,22 +20,25 @@
 #----------------------------------------------------------#
 
 # Argument definition
-ip="${1// /}"
-netmask="$2"
-
+# Parse first argument: supports plain IP, IP/CIDR (e.g. 192.0.2.1/24 or 2001:db8::/32),
+# and IP with prefix length. IPv4 requires netmask or CIDR; IPv6 requires prefix length.
+first_parameter=${1// /}                                     # remove spaces from input
+ip46=${1%/*}                                                 # clean ip address without cidr/prefix_length
+[ -n "$ip46" ] && [ "$ip46" = "${1}" ] || ip_cidr=${1#$ip46} # extract cidr/prefix from first parameter
+second_parameter=${2}                                        # second parameter can be netmask, cidr or prefix_length
 # Get interface name
 # First try to detect which interface the IP address resides on
-iface="$(ip -d -j addr show | jq --arg IP "$ip" -r '.[] | if .addr_info[].local == $IP then .ifname else empty end')"
+iface="$(ip -d -j addr show | jq --arg IP "$ip46" -r '.[] | if .addr_info[].local == $IP then .ifname else empty end')"
 # If that fails, detect the default interface as a fallback
 if [ -z "$iface" ]; then
 	iface="$(ip -d -j route show | jq -r '.[] | if .dst == "default" then .dev else empty end')"
 fi
 
 iface="${3-$iface}"
-user="$4"
+user="${4-${ROOT_USER}}"
 ip_status="${5-shared}"
-ip_name="$6"
-nat_ip="$7"
+ip_name="${6}"
+nat_ip="${7}"
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -55,15 +62,90 @@ fi
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '2' "$#" 'IP NETMASK [INTERFACE] [USER] [STATUS] [NAME] [NATED_IP]'
-is_format_valid 'ip' 'netmask' 'iface' 'user' 'ip_status'
-is_ip_free
+check_args '1' "$#" 'IP [NETMASK] [INTERFACE] [USER] [STATUS] [NAME] [NATED_IP]'
+
+# Detect IP version: get_ip_format returns "4" for IPv4 or "6" for IPv6.
+# An empty result means the address is invalid.
+ip_format="$(get_ip_format ${ip46})"
+if [ -n "$second_parameter" -a -n "$ip_format" ]; then
+	[ -n "$ip_cidr" ] && check_result 1 "cidr / prefix length double defined as IP address suffix and as separate argument!"                        # wrong parameters
+	netmask="$(echo ${second_parameter} | sed -nr ''/$REGEX_IPV4/p'')"                                                                              # extract netmask from second parameter if available
+	cidr_prefixlen="$(echo ${second_parameter} | sed -ne '/^\/[0-9]\{1,3\}$/p')"                                                                    # extract cidr/prefix_length from second parameter if available
+	[ -z "$netmask" -a -z "$cidr_prefixlen" ] && check_result 2 "Wrong netmask / cidr / prefix length definition!"                                  # wrong parameters
+	[ -n "$netmask" -a $ip_format -ne 4 ] && check_result 3 "Netmask definition for a not IPV4 address! Define a prefix lenght instead of netmask!" # wrong parameters
+fi
+add_string_ipv6=""
+add_cap_string_ipv6=""
+full_ip46=""
+netmask_prelen=""
+# formatted_ip: stores the plain IPv4 address or the bracketed IPv6 address (for use in configs where brackets are required)
+formatted_ip=""
+if [ -n "$ip_format" ]; then
+	if [ $ip_format -eq 4 ]; then
+		ip=${ip46}
+		ipv6=''
+		if [ -n "$netmask" ]; then
+			is_ip_format_valid "${netmask}" 'netmask' # check for correct netmask
+			cidr="$(convert_netmask $netmask)"        # convert netmask to cidr
+		fi
+		if [ -n "$cidr_prefixlen" ]; then
+			cidr=${cidr_prefixlen}
+		fi
+		if [ -n "$ip_cidr" ]; then
+			cidr=${ip_cidr}
+		else
+			[ -z "$cidr" ] && cidr="/32"
+		fi
+		if [ -z "$netmask" ]; then
+			is_ip_format_valid "${cidr}" 'cidr' # check for correct cidr
+			netmask=$(convert_cidr ${cidr})     # convert cidr to netmask
+		fi
+		is_ip_format_valid "${ip}" 'ipv4'       # check for correct ipv4 format
+		broadcast=$(get_broadcast $ip $netmask) # generate broadcast
+		full_ip46="$ip$cidr"
+		netmask_prelen="${netmask}"
+		formatted_ip="${ip}"
+	fi
+	if [ $ip_format -eq 6 ]; then
+		ip=''
+		ipv6=${ip46}
+		add_string_ipv6="6"
+		[ -n "$cidr_prefixlen" ] && prefix_length=${cidr_prefixlen}
+		if [ -n "$ip_cidr" ]; then
+			prefix_length="${ip_cidr}"
+		else
+			[ -z "$prefix_length" ] && prefix_length="/64"
+		fi
+		is_ip_format_valid "${ipv6}" 'ipv6' # check for correct ipv6 format
+		broadcast=""                        # reset broadcast
+		full_ip46="$ipv6$prefix_length"
+		netmask_prelen="${prefix_length}"
+		formatted_ip="[${ipv6}]"
+		add_cap_string_ipv6="V6"
+	fi
+fi
+
+[ -z "$iface" ] && iface="$($BIN/v-list-sys-interfaces plain | head -n 1)" # Get first available system interface, if none defined
+[ -z "$iface" ] && iface=$(ip route | awk '/default/ {print $5; exit}')
+if [ -z "$iface" ]; then
+	echo "Error: Unable to determine the network interface automatically."
+	exit 1
+fi
+
+# Extract IPv6 prefix number for validation (removes initial slash)
+if [[ "$prefix_length" =~ ^/([0-9]{1,3})$ ]]; then
+	prefix_length_num="${BASH_REMATCH[1]}"
+else
+	prefix_length_num=""
+fi
+is_format_valid 'netmask' 'cidr' "$prefix_length_num" "$iface" "$user" "$ip_status"
+is_ip_free ${ip46}
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
 if [ -n "$ip_name" ]; then
 	is_format_valid 'ip_name'
 fi
-if [ -n "$nat_ip" ]; then
+if [ -n "$nat_ip" -a $ip_format -eq 4 ]; then
 	is_format_valid 'nat_ip'
 fi
 if [ "$user" != "$ROOT_USER" ]; then
@@ -77,33 +159,35 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-cidr="$(convert_netmask "$netmask")"
-broadcast="$(get_broadcast "$ip" "$netmask")"
-
-sys_ip_check="$(ip addr | grep -w "$ip")"
+check_ip_par=""
+[ -n "$ip_format" ] && [ $ip_format -eq 4 -o $ip_format -eq 6 ] && check_ip_par=" -${ip_format}"
+sys_ip_check=$(ip$check_ip_par addr | sed -ne "/inet[6]*[ \t]${ip46}\//p")
 if [ -z "$sys_ip_check" ]; then
 	# Adding system IP
-	ip addr add "$ip/$cidr" dev "$iface" broadcast "$broadcast" label "$iface"
+	if [ -n "$ip_format" ] && [ $ip_format -eq 6 ]; then
+		/sbin/ip addr add ${full_ip46} dev ${iface%:*} label ${iface}
+	else
+		ip addr add ${full_ip46} dev ${iface} broadcast ${broadcast} label ${iface}
+	fi
+	sleep 2 # wait to avoid issues with apache and nginx port binding
 
 	# Check if netplan is in use and generate configuration file
-	if [ -n "$(netplan generate --mapping "$iface" 2> /dev/null | grep networkd)" ]; then
-		netplan="true"
+	if [ -n "$(which netplan)" ]; then
+		if [ -n "$(netplan generate --mapping "${iface}" 2> /dev/null | grep networkd)" ]; then
+			netplan="true"
+		else
+			netplan="false"
+		fi
 	else
 		netplan="false"
 	fi
 
 	if [ "$netplan" = "true" ]; then
-		netplan_file="/etc/netplan/60-hestia.yaml"
-		if [ -f "$netplan_file" ]; then
-			netplan_file_exists="true"
+		if [ -f "/etc/netplan/60-hestia.yaml" ]; then
+			sys_ip=" - ${full_ip46}"
 		else
-			netplan_file_exists="false"
-			install -m 600 /dev/null "$netplan_file"
-		fi
-
-		if [ "$netplan_file_exists" = "true" ]; then
-			sys_ip="        - $ip/$cidr"
-		else
+			# The following indentation and spacing is intentional for valid YAML formatting required by Netplan.
+			# Please do not change the spaces or structure, as Netplan is sensitive to incorrect indentation.
 			sys_ip="# Added by Hestia, please do not edit the file manually!"
 			sys_ip="$sys_ip\nnetwork:"
 			sys_ip="$sys_ip\n  version: 2"
@@ -111,17 +195,21 @@ if [ -z "$sys_ip_check" ]; then
 			sys_ip="$sys_ip\n  ethernets:"
 			sys_ip="$sys_ip\n    $iface:"
 			sys_ip="$sys_ip\n      addresses:"
-			sys_ip="$sys_ip\n        - $ip/$cidr"
+			sys_ip="$sys_ip\n 		 - ${full_ip46}"
 		fi
 		IFS='%'
-		echo -e "$sys_ip" >> "$netplan_file"
+		echo -e $sys_ip >> /etc/netplan/60-hestia.yaml
 		unset IFS
 	else
 		sys_ip="\n# Added by Hestia Control Panel"
-		sys_ip="$sys_ip\nauto $iface"
-		sys_ip="$sys_ip\niface $iface inet static"
-		sys_ip="$sys_ip\naddress $ip"
-		sys_ip="$sys_ip\nnetmask $netmask"
+		sys_ip="$sys_ip\nauto ${iface}"
+		sys_ip="$sys_ip\niface ${iface} inet${add_string_ipv6} static"
+		if [ -n "$ip_format" ] && [ $ip_format -eq 6 ]; then
+			sys_ip="$sys_ip\naddress ${full_ip46}"
+		else
+			sys_ip="$sys_ip\naddress $ip"
+			sys_ip="$sys_ip\nnetmask $netmask"
+		fi
 		echo -e $sys_ip >> /etc/network/interfaces
 	fi
 fi
@@ -136,73 +224,85 @@ NAME='$ip_name'
 U_SYS_USERS=''
 U_WEB_DOMAINS='0'
 INTERFACE='$iface'
-NETMASK='$netmask'
+NETMASK='${netmask_prelen}'
 NAT='$nat_ip'
 TIME='$time'
-DATE='$date'" > $HESTIA/data/ips/$ip
-chmod 660 $HESTIA/data/ips/$ip
+DATE='$date'
+VERSION='${ip_format}'" > $HESTIA/data/ips/${ip46}
+chmod 660 $HESTIA/data/ips/${ip46}
+
+server_hostname=$(hostname -f 2>/dev/null || hostname)
 
 # WEB support
 if [ -n "$WEB_SYSTEM" ]; then
-	web_conf="/etc/$WEB_SYSTEM/conf.d/$ip.conf"
-	rm -f "$web_conf"
+	web_conf="/etc/$WEB_SYSTEM/conf.d/${ip46}.conf"
+	rm -f ${web_conf}
 
 	if [ "$WEB_SYSTEM" = 'httpd' ] || [ "$WEB_SYSTEM" = 'apache2' ]; then
 		if [ -z "$(/usr/sbin/apachectl -v | grep Apache/2.4)" ]; then
-			echo "NameVirtualHost $ip:$WEB_PORT" > "$web_conf"
+			echo "NameVirtualHost ${formatted_ip}:$WEB_PORT" > ${web_conf}
 		fi
-		echo "Listen $ip:$WEB_PORT" >> "$web_conf"
-		cat $HESTIA_INSTALL_DIR/apache2/unassigned.conf >> "$web_conf"
-		sed -i 's/directIP/'$ip'/g' "$web_conf"
-		sed -i 's/directPORT/'$WEB_PORT'/g' "$web_conf"
+		echo "Listen ${formatted_ip}:$WEB_PORT" >> ${web_conf}
+		cat $HESTIA_INSTALL_DIR/apache2/unassigned.conf >> ${web_conf}
+		[ -n "$ip_format" ] && [ $ip_format -eq 6 ] && sed -i 's/\(VirtualHost \)directIP/\1'${formatted_ip}'/g' ${web_conf}
+		sed -i 's/directIP/'${ip46}'/g' ${web_conf}
+		sed -i 's/directPORT/'$WEB_PORT'/g' ${web_conf}
+		if [ "$ip_format" -eq 6 ]; then
+			server_hostname=$(hostname -f 2>/dev/null || hostname)
+			sed -i 's/^\(\s*ServerName\s*\).*/\1'"${server_hostname}"'/' ${web_conf}
+		fi
 
 	elif [ "$WEB_SYSTEM" = 'nginx' ]; then
-		cp -f $HESTIA_INSTALL_DIR/nginx/unassigned.inc "$web_conf"
-		sed -i 's/directIP/'$ip'/g' "$web_conf"
+		cp -f $HESTIA_INSTALL_DIR/nginx/unassigned.inc ${web_conf}
+		sed -i 's/directIP/'${formatted_ip}'/g' ${web_conf}
 		process_http2_directive "$web_conf"
 	fi
 
 	if [ "$WEB_SSL" = 'mod_ssl' ]; then
 		if [ -z "$(/usr/sbin/apachectl -v | grep Apache/2.4)" ]; then
-			sed -i "1s/^/NameVirtualHost $ip:$WEB_SSL_PORT\n/" "$web_conf"
+			sed -i "1s/^/NameVirtualHost ${formatted_ip}:$WEB_SSL_PORT\n/" ${web_conf}
 		fi
-		sed -i "1s/^/Listen $ip:$WEB_SSL_PORT\n/" "$web_conf"
-		sed -i 's/directSSLPORT/'$WEB_SSL_PORT'/g' "$web_conf"
+		sed -i "1s/^/Listen ${formatted_ip}:$WEB_SSL_PORT\n/" ${web_conf}
+		sed -i 's/directSSLPORT/'$WEB_SSL_PORT'/g' ${web_conf}
 	fi
 fi
 
 # Proxy support
 if [ -n "$PROXY_SYSTEM" ]; then
 	cat $WEBTPL/$PROXY_SYSTEM/proxy_ip.tpl \
-		| sed -e "s/%ip%/$ip/g" \
+		| sed -e "s/%ip%/${formatted_ip}/g" \
 			-e "s/%web_port%/$WEB_PORT/g" \
 			-e "s/%proxy_port%/$PROXY_PORT/g" \
 			-e "s/%proxy_ssl_port%/$PROXY_SSL_PORT/g" \
-			> /etc/$PROXY_SYSTEM/conf.d/$ip.conf
+			> /etc/$PROXY_SYSTEM/conf.d/${ip46}.conf
 
-	process_http2_directive "/etc/$PROXY_SYSTEM/conf.d/$ip.conf"
+	if [ "$ip_format" -eq 6 ]; then
+		process_http2_directive "/etc/$PROXY_SYSTEM/conf.d/${ip46}.conf"
+	else
+		process_http2_directive "/etc/$PROXY_SYSTEM/conf.d/${ip}.conf"
+	fi
 
 	# mod_extract_forwarded
 	fw_conf="/etc/$WEB_SYSTEM/conf.d/mod_extract_forwarded.conf"
 	if [ -e "$fw_conf" ]; then
-		ips=$(grep 'MEFaccept ' "$fw_conf" | grep -v '#' | head -n1)
-		sed -i "s/$ips/$ips $ip/g" "$fw_conf"
+		ips=$(grep 'MEFaccept ' ${fw_conf} | grep -v '#' | head -n1)
+		sed -i "s/$ips/$ips $ip46/g" ${fw_conf}
 	fi
 
 	# mod_rpaf
 	rpaf_conf="/etc/$WEB_SYSTEM/mods-enabled/rpaf.conf"
 	if [ -e "$rpaf_conf" ]; then
-		rpaf_str="$(grep RPAFproxy_ips "$rpaf_conf")"
-		[ -z "$rpaf_str" ] && sed -i 's|</IfModule>|RPAFproxy_ips\n</IfModule>|' "$rpaf_conf" && rpaf_str='RPAFproxy_ips'
-		rpaf_str="$rpaf_str $ip"
-		sed -i "s/.*RPAFproxy_ips.*/$rpaf_str/" "$rpaf_conf"
+		rpaf_str=$(grep RPAFproxy_ips ${rpaf_conf})
+		[ -z "$rpaf_str" ] && sed -i 's|</IfModule>|RPAFproxy_ips\n</IfModule>|' ${rpaf_conf} && rpaf_str='RPAFproxy_ips'
+		rpaf_str="$rpaf_str ${ip46}"
+		sed -i "s/.*RPAFproxy_ips.*/$rpaf_str/" ${rpaf_conf}
 	fi
 
-	# mod_remoteip
+	#mod_remoteip
 	remoteip_conf="/etc/$WEB_SYSTEM/mods-enabled/remoteip.conf"
 	if [ -e "$remoteip_conf" ]; then
-		if [ "$(grep -ic "$ip" "$remoteip_conf")" -eq "0" ]; then
-			sed -i "s/<\/IfModule>/RemoteIPInternalProxy $ip\n<\/IfModule>/g" "$remoteip_conf"
+		if [ $(grep -ic "${ip46}" ${remoteip_conf}) -eq 0 ]; then
+			sed -i "s/<\/IfModule>/RemoteIPInternalProxy $ip46\n<\/IfModule>/g" ${remoteip_conf}
 		fi
 	fi
 fi
@@ -216,18 +316,19 @@ syshealth_adapt_nginx_resolver
 #----------------------------------------------------------#
 
 # Updating user counters
-increase_user_value "$user" '$IP_OWNED'
-if [ "$user" = $ROOT_USER ]; then
+
+increase_user_value "$user" "IP_OWNED"
+if [ "$user" = "$ROOT_USER" ]; then
 	if [ "$ip_status" = 'shared' ]; then
 		for hestia_user in $("$BIN/v-list-users" list); do
-			increase_user_value "$hestia_user" '$IP_AVAIL'
+			increase_user_value "$hestia_user" "IP_AVAIL"
 		done
 	else
-		increase_user_value $ROOT_USER '$IP_AVAIL'
+		increase_user_value "$ROOT_USER" "IP_AVAIL"
 	fi
 else
-	increase_user_value "$user" '$IP_AVAIL'
-	increase_user_value $ROOT_USER '$IP_AVAIL'
+	increase_user_value "$user" "IP_AVAIL"
+	increase_user_value "$ROOT_USER" "IP_AVAIL"
 fi
 
 # Restarting web server
@@ -252,7 +353,7 @@ if [ "$NGINX_BCONF_CHANGED" = "yes" -a -f "/etc/init.d/hestia" ]; then
 fi
 
 # Logging
-$BIN/v-log-action "system" "Info" "Network" "Added new IP address to the system (IP: $ip)."
+$BIN/v-log-action "system" "Info" "Network" "Added new IP$add_cap_string_ipv6 address to the system (IP$add_cap_string_ipv6: $ip46)."
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -1,6 +1,12 @@
 #!/bin/bash
+#
+# !!! WRAPPER SCRIPT FOR COMPATIBILITY PURPOSES WITH OLD IPV4 SCRIPTS AND EXTERNAL CALLS !!!
+#
+# This script is a wrapper for backward compatibility with legacy scripts and external tools that call v-add-web-domain using the old IPv4-only arguments.
+# It transparently calls v-add-web-domain-ipv46, which supports both IPv4 and IPv6, ensuring existing integrations do not break.
+#
 # info: add web domain
-# options: USER DOMAIN [IP] [RESTART] [ALIASES] [PROXY_EXTENSIONS]
+# options: USER DOMAIN [IPV4] [RESTART] [ALIASES] [PROXY_EXTENSIONS]
 #
 # example: v-add-web-domain admin wonderland.com 192.18.22.43 yes www.wonderland.com
 #
@@ -16,246 +22,15 @@
 #----------------------------------------------------------#
 
 # Argument definition
-user=$1
-domain=$2
-domain_idn=$2
-ip=$3
-restart=$4 # will be moved to the end soon
-aliases=$5
-proxy_ext=$6
+user="$1"
+domain="$2"
+ip="$3"
+ipv6=""      # EMPTY! Not used here, because of old IPV4 only mode
+restart="$4" # will be moved to the end soon
+aliases="$5"
+proxy_ext="$6"
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf
-# shellcheck source=/usr/local/hestia/func/main.sh
-source $HESTIA/func/main.sh
-# shellcheck source=/usr/local/hestia/func/domain.sh
-source $HESTIA/func/domain.sh
-# shellcheck source=/usr/local/hestia/func/ip.sh
-source $HESTIA/func/ip.sh
-# shellcheck source=/usr/local/hestia/func/syshealth.sh
-source $HESTIA/func/syshealth.sh
-# load config file
-source_conf "$HESTIA/conf/hestia.conf"
-
-# Additional argument formatting
-format_domain
-format_domain_idn
-format_aliases
-domain_utf=$(idn2 --quiet -d "$domain_idn")
-
-#----------------------------------------------------------#
-#                    Verifications                         #
-#----------------------------------------------------------#
-
-is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
-check_args '2' "$#" 'USER DOMAIN [IP] [RESTART] [ALIASES] [PROXY_EXTENSIONS]'
-is_format_valid 'user' 'domain' 'aliases' 'ip' 'proxy_ext' 'restart'
-is_object_valid 'user' 'USER' "$user"
-is_object_unsuspended 'user' 'USER' "$user"
-is_package_full 'WEB_DOMAINS'
-
-if [ "$aliases" != "none" ]; then
-	ALIAS="$aliases"
-	is_package_full 'WEB_ALIASES'
-fi
-
-if [ "$($BIN/v-list-web-domain $user $domain_utf plain | cut -f 1) " != "$domain" ]; then
-	is_domain_new 'web' "$domain_utf,$aliases"
-fi
-if [ "$($BIN/v-list-web-domain $user $domain_idn plain | cut -f 1) " != "$domain" ]; then
-	is_domain_new 'web' "$domain_idn,$aliases"
-else
-	is_domain_new 'web' "$domain,$aliases"
-fi
-if [ -z "$(is_ip_format_valid $domain)" ]; then
-	echo "Error: Invalid domain format. IP address detected as input."
-	exit 1
-fi
-
-is_dir_symlink "$HOMEDIR/$user/web"
-is_dir_symlink "$HOMEDIR/$user/web/$domain"
-
-is_base_domain_owner "$domain,$aliases"
-
-if [ -n "$ip" ]; then
-	is_ip_valid "$ip" "$user"
-else
-	get_user_ip
-fi
-
-# Perform verification if read-only mode is enabled
-check_hestia_demo_mode
-
-#----------------------------------------------------------#
-#                       Action                             #
-#----------------------------------------------------------#
-
-# Reading user values
-source_conf "$USER_DATA/user.conf"
-
-[[ -e "$HOMEDIR/$user/web/$domain" ]] && check_result "$E_EXISTS" "Web domain folder for $domain should not exist"
-
-# Creating domain directories
-mkdir $HOMEDIR/$user/web/$domain
-chown $user:$user $HOMEDIR/$user/web/$domain
-$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/public_html"
-$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/document_errors"
-$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/cgi-bin"
-$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/private"
-$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/stats"
-$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/logs"
-
-# Creating domain logs
-touch /var/log/$WEB_SYSTEM/domains/$domain.bytes \
-	/var/log/$WEB_SYSTEM/domains/$domain.log \
-	/var/log/$WEB_SYSTEM/domains/$domain.error.log
-ln -f -s /var/log/$WEB_SYSTEM/domains/$domain.*log \
-	$HOMEDIR/$user/web/$domain/logs/
-
-# Adding domain skeleton
-user_exec cp -r $WEBTPL/skel/* "$HOMEDIR/$user/web/$domain/" > /dev/null 2>&1
-for file in $(find "$HOMEDIR/$user/web/$domain/" -type f); do
-	sed -i "s/%domain%/$domain/g" $file
-done
-
-# Changing file owner & permission
-chown -R $user:$user $HOMEDIR/$user/web/$domain
-chown root:$user /var/log/$WEB_SYSTEM/domains/$domain.* $conf
-chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
-user_exec chmod 751 $HOMEDIR/$user/web/$domain/*
-user_exec chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
-# Apply 755 to directories and 644 to files
-find $HOMEDIR/$user/web/$domain/public_html -type d | xargs chmod 755
-find $HOMEDIR/$user/web/$domain/public_html -type f | xargs chmod 644
-
-# domain folder permissions: DOMAINDIR_WRITABLE: default-val:no source:hestia.conf
-DOMAINDIR_MODE=551
-if [ "$DOMAINDIR_WRITABLE" = 'yes' ]; then DOMAINDIR_MODE=751; fi
-
-user_exec chmod $DOMAINDIR_MODE $HOMEDIR/$user/web/$domain
-chown --no-dereference $user:www-data $HOMEDIR/$user/web/$domain/public_*html
-
-# Adding PHP-FPM backend
-if [ -n "$WEB_BACKEND" ]; then
-	if [ -z "$BACKEND_TEMPLATE" ]; then
-		BACKEND_TEMPLATE='default'
-		if [ -z "$(grep BACKEND_TEMPLATE $USER_DATA/user.conf)" ]; then
-			sed -i "s/^DNS_TEMPL/BACKEND_TEMPLATE='default'\nDNS_TEMPL/g" \
-				$USER_DATA/user.conf
-		else
-			update_user_value "$user" '$BACKEND_TEMPLATE' "default"
-		fi
-	fi
-	export BACKEND="$BACKEND_TEMPLATE"
-	$BIN/v-add-web-domain-backend "$user" "$domain" "$BACKEND_TEMPLATE" "$restart"
-	check_result $? "Backend error" > /dev/null
-fi
-
-# Preparing domain aliases
-if [ "$aliases" = 'none' ]; then
-	ALIAS=''
-else
-	ALIAS="www.$domain"
-	if [ -z "$aliases" ]; then
-		# Check and skip www alias for subdomains.
-		IFS='.' read -r -a domain_elements <<< "$domain"
-		if [ "${#domain_elements[@]}" -gt 2 ]; then
-			is_valid_2_part_extension $domain
-			if [ $? -ne 0 ]; then
-				ALIAS=""
-			else
-				ALIAS="www.$domain"
-			fi
-		else
-			ALIAS="www.$domain"
-		fi
-	else
-		ALIAS="$aliases"
-	fi
-
-	ip_alias=$(get_ip_alias "$domain")
-	if [ -n "$ip_alias" ]; then
-		ALIAS="$ALIAS,$ip_alias"
-	fi
-fi
-
-# Preparing domain variables
-prepare_web_domain_values
-
-if [ -z "$WEB_TEMPLATE" ]; then
-	WEB_TEMPLATE='default'
-	update_user_value "$user" '$WEB_TEMPLATE' "default"
-fi
-
-# Adding web server config
-add_web_config "$WEB_SYSTEM" "$WEB_TEMPLATE.tpl"
-
-# Adding proxy config
-if [ -n "$PROXY_SYSTEM" ]; then
-	PROXY_EXT="$proxy_ext"
-	if [ -z "$proxy_ext" ]; then
-		# Code
-		PROXY_EXT="css,htm,html,js,mjs,json,xml"
-		# Image (from https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types)
-		PROXY_EXT="$PROXY_EXT,apng,avif,bmp,cur,gif,ico,jfif,jpg,jpeg,pjp,pjpeg,png,svg,tif,tiff,webp"
-		# Audio from (https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Audio_codecs)
-		PROXY_EXT="$PROXY_EXT,aac,caf,flac,m4a,midi,mp3,ogg,opus,wav"
-		# Video (from https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs)
-		PROXY_EXT="$PROXY_EXT,3gp,av1,avi,m4v,mkv,mov,mpg,mpeg,mp4,mp4v,webm"
-		# Fonts
-		PROXY_EXT="$PROXY_EXT,otf,ttf,woff,woff2"
-		# Productivity
-		PROXY_EXT="$PROXY_EXT,doc,docx,odf,odp,ods,odt,pdf,ppt,pptx,rtf,txt,xls,xlsx"
-		# Archive
-		PROXY_EXT="$PROXY_EXT,7z,bz2,gz,rar,tar,tgz,zip"
-		# Binaries
-		PROXY_EXT="$PROXY_EXT,apk,appx,bin,dmg,exe,img,iso,jar,msi"
-		# Other
-		PROXY_EXT="$PROXY_EXT,webmanifest"
-
-	fi
-	if [ -z "$PROXY_TEMPLATE" ]; then
-		PROXY_TEMPLATE='default'
-		update_user_value "$user" '$PROXY_TEMPLATE' "default"
-	fi
-
-	add_web_config "$PROXY_SYSTEM" "$PROXY_TEMPLATE.tpl"
-fi
-
-#----------------------------------------------------------#
-#                       Hestia                             #
-#----------------------------------------------------------#
-
-# Increasing counters
-increase_ip_value "$local_ip"
-increase_user_value "$user" '$U_WEB_DOMAINS'
-increase_user_value "$user" '$U_WEB_ALIASES' "$alias_number"
-
-# Generating timestamp
-time_n_date=$(date +'%T %F')
-time=$(echo "$time_n_date" | cut -f 1 -d \ )
-date=$(echo "$time_n_date" | cut -f 2 -d \ )
-
-# Adding domain in web.conf
-echo "DOMAIN='$domain' IP='$ip' IP6='' CUSTOM_DOCROOT='' ALIAS='$ALIAS' TPL='$WEB_TEMPLATE'\
- SSL='no' SSL_FORCE='no' SSL_HOME='same' LETSENCRYPT='no' FTP_USER='' FTP_MD5=''\
- BACKEND='$BACKEND_TEMPLATE' PROXY='$PROXY_TEMPLATE' PROXY_EXT='$PROXY_EXT'\
- STATS='' STATS_USER='' STATS_CRYPT='' U_DISK='0' U_BANDWIDTH='0'\
- SUSPENDED='no' TIME='$time' DATE='$date'" >> $USER_DATA/web.conf
-
-syshealth_repair_web_config
-
-# Restarting web server
-$BIN/v-restart-web "$restart"
-check_result $? "Web restart failed" > /dev/null
-
-# Restarting proxy server
-$BIN/v-restart-proxy "$restart"
-check_result $? "Proxy restart failed" > /dev/null
-
-# Logging
-$BIN/v-log-action "$user" "Info" "Web" "Added new web domain (Name: $domain)."
-log_event "$OK" "$ARGUMENTS"
-
-exit
+${HESTIA}/bin/v-add-web-domain-ipv46 "$user" "$domain" "$ip" "$ipv6" "$restart" "$aliases" "$proxy_ext"

--- a/bin/v-add-web-domain-ipv46
+++ b/bin/v-add-web-domain-ipv46
@@ -1,0 +1,269 @@
+#!/bin/bash
+# info: add web domain
+# options: USER DOMAIN [IPV4] [IPV6] [RESTART] [ALIASES] [PROXY_EXTENSIONS]
+#
+# example: v-add-web-domain admin wonderland.com 192.18.22.43 1111:2222:3333::1 yes www.wonderland.com
+#
+# This function adds virtual host to a server. In cases when ip is
+# undefined in the script, "default" template will be used. The alias of
+# www.domain.tld type will be automatically assigned to the domain unless
+# "none" is transmited as argument. If ip have associated dns name, this
+# domain will also get the alias domain-tpl.$ipname. An alias with the ip
+# name is useful during the site testing while dns isn't moved to server yet.
+
+#----------------------------------------------------------#
+#                Variables & Functions                     #
+#----------------------------------------------------------#
+
+# Argument definition
+user=$1
+domain=$2
+domain_idn=$2
+ip=$3
+ipv6=$4
+restart=$5 # will be moved to the end soon
+aliases=$6
+proxy_ext=$7
+
+# Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+# shellcheck source=/usr/local/hestia/func/domain.sh
+source $HESTIA/func/domain.sh
+# shellcheck source=/usr/local/hestia/func/ip.sh
+source $HESTIA/func/ip.sh
+# shellcheck source=/usr/local/hestia/func/syshealth.sh
+source $HESTIA/func/syshealth.sh
+# load config file
+source_conf "$HESTIA/conf/hestia.conf"
+
+# Additional argument formatting
+format_domain
+format_domain_idn
+format_aliases
+domain_utf=$(idn2 --quiet -d "$domain_idn")
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
+check_args '2' "$#" 'USER DOMAIN [IPV4] [IPV6] [RESTART] [ALIASES] [PROXY_EXTENSIONS]'
+is_format_valid 'user' 'domain' 'aliases' 'ip' 'ipv6' 'proxy_ext'
+is_object_valid 'user' 'USER' "$user"
+is_object_unsuspended 'user' 'USER' "$user"
+is_package_full 'WEB_DOMAINS'
+
+if [ "$aliases" != "none" ]; then
+	ALIAS="$aliases"
+	is_package_full 'WEB_ALIASES'
+fi
+
+if [ "$($BIN/v-list-web-domain $user $domain_utf shell | sed -n '/DOMAIN/s/DOMAIN:[\t ]*//p')" != "$domain" ]; then
+	is_domain_new 'web' "$domain_utf,$aliases"
+fi
+if [ "$($BIN/v-list-web-domain $user $domain_idn shell | sed -n '/DOMAIN/s/DOMAIN:[\t ]*//p')" != "$domain" ]; then
+	is_domain_new 'web' "$domain_idn,$aliases"
+else
+	is_domain_new 'web' "$domain,$aliases"
+fi
+if [ -z "$(is_ip_format_valid $domain)" ]; then
+	echo "Error: Invalid domain format. IP address detected as input."
+	exit 1
+fi
+
+is_dir_symlink "$HOMEDIR/$user/web"
+is_dir_symlink "$HOMEDIR/$user/web/$domain"
+
+is_base_domain_owner "$domain,$aliases"
+
+if [ -n "$ip" ]; then
+	is_ip_valid "$ip" "$user"
+fi
+
+if [ -n "$ipv6" ]; then
+	# Auto-register IPv6 if not found BEFORE validation
+	ip_file="${HESTIA}/data/ips/${ipv6}"
+	if [ ! -f "$ip_file" ]; then
+		interface=$(ip -d -j route show | jq -r '.[] | select(.dst=="default") | .dev' | head -n 1)
+		[ -z "$interface" ] && interface="eth0"
+		/usr/local/hestia/bin/v-add-sys-ip "$ipv6" /128 "$interface" "$user" dedicated
+		if [ $? -ne 0 ]; then
+			echo "Error: failed to auto-register IPv6 $ipv6"
+			exit 1
+		fi
+	fi
+
+	is_ipv6_valid "$ipv6" "$user"
+fi
+
+if [ -z "$ip" -a -z "$ipv6" ]; then
+	get_user_ipv6 #	get first available user ipv6 address as fallback, if none ip address was defined
+	if [ -z "$ipv6" ]; then
+		get_user_ip #	get first available user ipv4 address as fallback, if none ipv6 user address available
+	fi
+fi
+
+# Perform verification if read-only mode is enabled
+check_hestia_demo_mode
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+# Reading user values
+source_conf "$USER_DATA/user.conf"
+
+[[ -e "$HOMEDIR/$user/web/$domain" ]] && check_result "$E_EXISTS" "Web domain folder for $domain should not exist"
+
+# Creating domain directories
+mkdir $HOMEDIR/$user/web/$domain
+chown $user:$user $HOMEDIR/$user/web/$domain
+$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/public_html"
+$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/document_errors"
+$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/cgi-bin"
+$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/private"
+$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/stats"
+$BIN/v-add-fs-directory "$user" "$HOMEDIR/$user/web/$domain/logs"
+
+# Creating domain logs
+touch /var/log/$WEB_SYSTEM/domains/$domain.bytes \
+	/var/log/$WEB_SYSTEM/domains/$domain.log \
+	/var/log/$WEB_SYSTEM/domains/$domain.error.log
+ln -f -s /var/log/$WEB_SYSTEM/domains/$domain.*log \
+	$HOMEDIR/$user/web/$domain/logs/
+
+# Adding domain skeleton
+user_exec cp -r $WEBTPL/skel/* "$HOMEDIR/$user/web/$domain/" > /dev/null 2>&1
+for file in $(find "$HOMEDIR/$user/web/$domain/" -type f); do
+	sed -i "s/%domain%/$domain/g" $file
+done
+
+# Changing file owner & permission
+chown -R $user:$user $HOMEDIR/$user/web/$domain
+chown root:$user /var/log/$WEB_SYSTEM/domains/$domain.* $conf
+chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
+user_exec chmod 751 $HOMEDIR/$user/web/$domain/*
+user_exec chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
+user_exec chmod 644 $HOMEDIR/$user/web/$domain/public_*html/*
+user_exec chmod 551 $HOMEDIR/$user/web/$domain
+chown --no-dereference $user:www-data $HOMEDIR/$user/web/$domain/public_*html
+
+# Adding PHP-FPM backend
+if [ -n "$WEB_BACKEND" ]; then
+	if [ -z "$BACKEND_TEMPLATE" ]; then
+		BACKEND_TEMPLATE='default'
+		if [ -z "$(grep BACKEND_TEMPLATE $USER_DATA/user.conf)" ]; then
+			sed -i "s/^DNS_TEMPL/BACKEND_TEMPLATE='default'\nDNS_TEMPL/g" \
+				$USER_DATA/user.conf
+		else
+			update_user_value "$user" '$BACKEND_TEMPLATE' "default"
+		fi
+	fi
+	export BACKEND="$BACKEND_TEMPLATE"
+	$BIN/v-add-web-domain-backend "$user" "$domain" "$BACKEND_TEMPLATE" "$restart"
+	check_result $? "Backend error" > /dev/null
+fi
+
+# Preparing domain aliases
+if [ "$aliases" = 'none' ]; then
+	ALIAS=''
+else
+	ALIAS="www.$domain"
+	if [ -z "$aliases" ]; then
+		# Check and skip www alias for subdomains.
+		IFS='.' read -r -a domain_elements <<< "$domain"
+		if [ "${#domain_elements[@]}" -gt 2 ]; then
+			is_valid_2_part_extension $domain
+			if [ $? -ne 0 ]; then
+				ALIAS=""
+			else
+				ALIAS="www.$domain"
+			fi
+		else
+			ALIAS="www.$domain"
+		fi
+	else
+		ALIAS="$aliases"
+	fi
+
+	if [ -n "$local_ip" ]; then
+		ip_alias=$(get_ip_alias "$domain" "$local_ip")
+		if [ -n "$ip_alias" ]; then
+			ALIAS="$ALIAS,$ip_alias"
+		fi
+	fi
+	if [ -n "$local_ipv6" ]; then
+		ipv6_alias=$(get_ip_alias "$domain" "$local_ipv6")
+		if [ -n "$ipv6_alias" ]; then
+			ALIAS="$ALIAS,$ipv6_alias"
+		fi
+	fi
+fi
+
+# Preparing domain variables
+prepare_web_domain_values
+
+if [ -z "$WEB_TEMPLATE" ]; then
+	WEB_TEMPLATE='default'
+	update_user_value "$user" '$WEB_TEMPLATE' "default"
+fi
+
+# Adding web server config
+add_web_config "$WEB_SYSTEM" "$WEB_TEMPLATE.tpl"
+
+# Adding proxy config
+if [ -n "$PROXY_SYSTEM" ]; then
+	PROXY_EXT="$proxy_ext"
+	if [ -z "$proxy_ext" ]; then
+		PROXY_EXT="jpg,jpeg,webp,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls"
+		PROXY_EXT="$PROXY_EXT,exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp"
+		PROXY_EXT="$PROXY_EXT,rtf,js,mp3,avi,mpeg,flv,html,htm,woff,woff2,ttf"
+	fi
+	if [ -z "$PROXY_TEMPLATE" ]; then
+		PROXY_TEMPLATE='default'
+		update_user_value "$user" '$PROXY_TEMPLATE' "default"
+	fi
+
+	add_web_config "$PROXY_SYSTEM" "$PROXY_TEMPLATE.tpl"
+fi
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Increasing counters
+[ -n "$local_ip" ] && increase_ip_value "$local_ip"
+[ -n "$local_ipv6" ] && increase_ip_value "$local_ipv6"
+increase_user_value "$user" '$U_WEB_DOMAINS'
+increase_user_value "$user" '$U_WEB_ALIASES' "$alias_number"
+
+# Generating timestamp
+time_n_date=$(date +'%T %F')
+time=$(echo "$time_n_date" | cut -f 1 -d \ )
+date=$(echo "$time_n_date" | cut -f 2 -d \ )
+
+# Adding domain in web.conf
+echo "DOMAIN='$domain' IP='$ip' IP6='$ipv6' CUSTOM_DOCROOT='' ALIAS='$ALIAS' TPL='$WEB_TEMPLATE'\
+ SSL='no' SSL_FORCE='no' SSL_HOME='same' LETSENCRYPT='no' FTP_USER='' FTP_MD5=''\
+ BACKEND='$BACKEND_TEMPLATE' PROXY='$PROXY_TEMPLATE' PROXY_EXT='$PROXY_EXT'\
+ STATS='' STATS_USER='' STATS_CRYPT='' U_DISK='0' U_BANDWIDTH='0'\
+ SUSPENDED='no' TIME='$time' DATE='$date'" >> $USER_DATA/web.conf
+
+syshealth_repair_web_config
+
+# Restarting web server
+$BIN/v-restart-web "$restart"
+check_result $? "Web restart failed" > /dev/null
+
+# Restarting proxy server
+$BIN/v-restart-proxy "$restart"
+check_result $? "Proxy restart failed" > /dev/null
+
+# Logging
+$BIN/v-log-action "$user" "Info" "Web" "Added new web domain (Name: $domain)."
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/bin/v-add-web-domain-ipv46
+++ b/bin/v-add-web-domain-ipv46
@@ -84,18 +84,9 @@ if [ -n "$ip" ]; then
 fi
 
 if [ -n "$ipv6" ]; then
-	# Auto-register IPv6 if not found BEFORE validation
-	ip_file="${HESTIA}/data/ips/${ipv6}"
-	if [ ! -f "$ip_file" ]; then
-		interface=$(ip -d -j route show | jq -r '.[] | select(.dst=="default") | .dev' | head -n 1)
-		[ -z "$interface" ] && interface="eth0"
-		/usr/local/hestia/bin/v-add-sys-ip "$ipv6" /128 "$interface" "$user" dedicated
-		if [ $? -ne 0 ]; then
-			echo "Error: failed to auto-register IPv6 $ipv6"
-			exit 1
-		fi
-	fi
-
+	# Security: only validate — do NOT auto-register system IPs.
+	# The IPv6 address must already exist in the Hestia IP pool (added by admin via v-add-sys-ip).
+	# Auto-registration would allow unprivileged users to inject arbitrary IPs into the system.
 	is_ipv6_valid "$ipv6" "$user"
 fi
 

--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -98,6 +98,7 @@ fi
 # Parsing domain values
 get_domain_values 'web'
 local_ip=$(get_real_ip "$IP")
+local_ipv6="$IP6"
 
 # Preparing domain values for the template substitution
 SSL_HOME="$ssl_home"

--- a/bin/v-change-dns-domain-ipv6
+++ b/bin/v-change-dns-domain-ipv6
@@ -1,10 +1,10 @@
 #!/bin/bash
 # info: change dns domain ip address
-# options: USER DOMAIN IP [RESTART]
+# options: USER DOMAIN IPV6 [RESTART]
 #
-# example: v-change-dns-domain-ip admin domain.com 123.212.111.222
+# example: v-change-dns-domain-ipv6 admin domain.com 1111:2222::1
 #
-# This function for changing the main ip of DNS zone.
+# This function for changing the main ipv6 of DNS zone.
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #
@@ -14,7 +14,7 @@
 user=$1
 domain=$2
 domain_idn=$2
-ip=$3
+ipv6=$3
 restart=$4
 
 # Includes
@@ -40,8 +40,8 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '3' "$#" 'USER DOMAIN IP [RESTART]'
-is_format_valid 'user' 'domain' 'ip' 'restart'
+check_args '3' "$#" 'USER DOMAIN IPV6 [RESTART]'
+is_format_valid 'user' 'domain' 'ipv6'
 is_system_enabled "$DNS_SYSTEM" 'DNS_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -55,18 +55,51 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
+if [ "$ipv6" != "no" ]; then
+	is_format_valid 'ipv6'
+fi
+if [ "$ipv6" != "no" ]; then
+	is_ipv6_valid "$ipv6" "$user"
+else
+	ipv6=''
+fi
+
 # Get old ip
 get_domain_values 'dns'
-old=$IP
+if [ -z "$ipv6" ] && [ -z "$IP" ]; then
+	check_result $E_INVALID "IP or IPv6 is required"
+fi
+old=$IP6
+
+if [ -z "$old" ]; then
+	#Create new
+	# Generating timestamp
+	time_n_date=$(date +'%T %F')
+	time=$(echo "$time_n_date" | cut -f 1 -d \ )
+	date=$(echo "$time_n_date" | cut -f 2 -d \ )
+	ip=""
+	add_dns_config_records
+else
+	if [ ! -z "$ipv6" ]; then
+		# Changing records
+		sed -i "s/$old/$ipv6/g" $USER_DATA/dns/$domain.conf
+	else
+		#Delete configs
+		ipv6=""
+		ip=$IP
+		remove_dns_config_records
+	fi
+fi
 
 # Changing ip
-update_object_value 'dns' 'DOMAIN' "$domain" '$IP' "$ip"
+update_object_value 'dns' 'DOMAIN' "$domain" '$IP6' "$ipv6"
 
-# Changing records
-sed -i "s/$old/$ip/g" $USER_DATA/dns/$domain.conf
+#update counters
+records="$(wc -l $USER_DATA/dns/$domain.conf | cut -f1 -d ' ')"
+update_object_value 'dns' 'DOMAIN' "$domain" '$RECORDS' "$records"
+records=$(wc -l $USER_DATA/dns/*.conf | cut -f 1 -d ' ')
+update_user_value "$user" '$U_DNS_RECORDS' "$records"
 
-# Update serial
-update_domain_serial
 # Updating zone
 if [[ "$DNS_SYSTEM" =~ named|bind ]]; then
 	rebuild_dns_domain_conf
@@ -77,7 +110,7 @@ if [ "$DNS_CLUSTER" = "yes" ]; then
 	# Check for first sync
 	dlock=$(grep "domain $user $domain" $HESTIA/data/queue/dns-cluster.pipe)
 	if [ -z "$dlock" ]; then
-		cmd="$BIN/v-add-remote-dns-domain $user $domain yes"
+		cmd="$BIN/v-add-remote-dns-domain $user $domain domain yes"
 		echo "$cmd" >> $HESTIA/data/queue/dns-cluster.pipe
 	fi
 fi
@@ -91,7 +124,7 @@ $BIN/v-restart-dns "$restart"
 check_result $? "DNS restart failed" > /dev/null
 
 # Logging
-$BIN/v-log-action "$user" "Info" "DNS" "IP address for DNS domain changed (IP: $ip, Domain: $domain)."
+$BIN/v-log-action "$user" "Info" "DNS" "IPV6 address for DNS domain changed (IPV6: $ipv6, Domain: $domain)."
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-change-sys-ip-name
+++ b/bin/v-change-sys-ip-name
@@ -2,7 +2,8 @@
 # info: change IP name
 # options: IP NAME
 #
-# example: v-change-sys-ip-name 203.0.113.1 acme.com
+# example: v-change-sys-ip-name 80.122.52.70 acme.com
+# example: v-change-sys-ip-name 1111:2222:3333::1 acme.com
 #
 # This function for changing dns domain associated with IP.
 
@@ -11,8 +12,8 @@
 #----------------------------------------------------------#
 
 # Argument definition
-ip="$1"
-ip_name="$2"
+ip46=${1}
+ip_name=${2}
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -29,9 +30,21 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 check_args '2' "$#" 'IP IP_NAME'
-is_format_valid 'ip'
+ip_format="$(get_ip_format ${ip46})" #	ip verification and format identification
+if [ -n "$ip_format" ]; then
+	if [ $ip_format -eq 6 ]; then
+		ip=""
+		ipv6="${ip46}"
+		is_format_valid 'ipv6'
+		is_ip_valid "$ipv6"
+	else
+		ip="${ip46}"
+		ipv6=""
+		is_format_valid 'ip'
+		is_ip_valid "$ip"
+	fi
+fi
 is_format_valid 'ip_name'
-is_ip_valid "$ip"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -41,7 +54,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Changing IP name
-update_ip_value '$NAME' "$ip_name"
+update_ip_value '$NAME' "$ip_name" "${ip46}"
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-change-sys-ip-nat
+++ b/bin/v-change-sys-ip-nat
@@ -3,6 +3,7 @@
 # options: IP NAT_IP [RESTART]
 #
 # example: v-change-sys-ip-nat 10.0.0.1 203.0.113.1
+# example: v-change-sys-ip-nat 1111:2222:3333::1 ''
 #
 # This function for changing NAT IP associated with IP.
 
@@ -11,9 +12,9 @@
 #----------------------------------------------------------#
 
 # Argument definition
-ip="$1"
-nat_ip="$2"
-restart="$3"
+ip46=${1}
+nat_ip=${2}
+restart=${3}
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -30,9 +31,22 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 check_args '2' "$#" 'IP NAT_IP [RESTART]'
-is_format_valid 'ip'
-is_format_valid 'nat_ip'
-is_ip_valid "$ip"
+ip_format="$(get_ip_format ${ip46})" #	ip verification and format identification
+if [ -n "$ip_format" ]; then
+	if [ $ip_format -eq 6 ]; then
+		ip=""
+		ipv6="${ip46}"
+		is_format_valid 'ipv6'
+		is_ip_valid "$ipv6"
+		nat_ip=""
+	else
+		ip="${ip46}"
+		ipv6=""
+		is_format_valid 'ip'
+		is_ip_valid "$ip"
+		is_format_valid 'nat_ip'
+	fi
+fi
 is_restart_format_valid "$restart"
 
 # Perform verification if read-only mode is enabled
@@ -43,70 +57,70 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Updating IP
-if [ -z "$(grep NAT= $HESTIA/data/ips/$ip)" ]; then
-	sed -i "s/^TIME/NAT='$nat_ip'\nTIME/g" $HESTIA/data/ips/$ip
+if [ -z "$(grep NAT= $HESTIA/data/ips/${ip46})" ]; then
+	sed -i "s/^TIME/NAT='$nat_ip'\nTIME/g" $HESTIA/data/ips/${ip46}
 	old=''
-	new="$nat_ip"
+	new=${nat_ip}
 else
 	old="$(get_ip_value '$NAT')"
-	new="$nat_ip"
-	sed -i "s/NAT=.*/NAT='$new'/" $HESTIA/data/ips/$ip
+	new=${nat_ip}
+	sed -i "s/NAT=.*/NAT='$new'/" ${HESTIA}/data/ips/${ip46}
 	if [ -z "$nat_ip" ]; then
-		new="$ip"
+		new=${ip46}
 	fi
 fi
 
 # Updating WEB configs
 if [ -n "$old" ] && [ -n "$WEB_SYSTEM" ]; then
 	for user in $("$BIN/v-list-users" list); do
-		sed -i "s/$old/$new/" $HESTIA/data/users/$user/web.conf
-		$BIN/v-rebuild-web-domains "$user" no
+		sed -i "s/$old/$new/" ${HESTIA}/data/users/${user}/web.conf
+		${BIN}/v-rebuild-web-domains ${user} no
 	done
-	$BIN/v-restart-dns "$restart"
+	${BIN}/v-restart-dns "$restart"
 fi
 
 # Updating DNS configs
 if [ -n "$old" ] && [ -n "$DNS_SYSTEM" ]; then
-	for user in $("$BIN/v-list-users" list); do
-		sed -i "s/$old/$new/" "$HESTIA/data/users/$user/dns.conf"
-		if ls $HESTIA/data/users/$user/dns/*.conf > /dev/null 2>&1; then
-			sed -i "s/$old/$new/" $HESTIA/data/users/$user/dns/*.conf
+	for user in $(${BIN}/v-list-sys-users plain); do
+		sed -i "s/$old/$new/" ${HESTIA}/data/users/${user}/dns.conf
+		if ls ${HESTIA}/data/users/${user}/dns/*.conf 1> /dev/null 2>&1; then
+			sed -i "s/$old/$new/" ${HESTIA}/data/users/${user}/dns/*.conf
 		fi
-		$BIN/v-rebuild-dns-domains "$user" no
+		${BIN}/v-rebuild-dns-domains ${user} no
 	done
-	$BIN/v-restart-dns "$restart"
+	${BIN}/v-restart-dns "$restart"
 fi
 
 # Updating FTP
 if [ -n "$old" ] && [ -n "$FTP_SYSTEM" ]; then
-	ftp_conf="$(find /etc -maxdepth 2 -name "$FTP_SYSTEM.conf")"
+	ftp_conf="$(find /etc -maxdepth 2 -name ${FTP_SYSTEM}.conf)"
 	if [ -e "$ftp_conf" ]; then
-		sed -i "s/$old/$new/g" "$ftp_conf"
+		sed -i "s/$old/$new/g" ${ftp_conf}
 		if [ "$FTP_SYSTEM" = 'vsftpd' ]; then
-			check_pasv="$(grep pasv_address "$ftp_conf")"
+			check_pasv="$(grep pasv_address ${ftp_conf})"
 			if [ -z "$check_pasv" ] && [ -n "$nat_ip" ]; then
-				echo "pasv_address=$nat_ip" >> "$ftp_conf"
+				echo "pasv_address=$nat_ip" >> ${ftp_conf}
 			fi
 			if [ -n "$check_pasv" ] && [ -z "$nat_ip" ]; then
-				sed -i "/pasv_address/d" "$ftp_conf"
+				sed -i "/pasv_address/d" ${ftp_conf}
 			fi
 			if [ -n "$check_pasv" ] && [ -n "$nat_ip" ]; then
-				sed -i "s/pasv_address=.*/pasv_address=$nat_ip/g" "$ftp_conf"
+				sed -i "s/pasv_address=.*/pasv_address='$nat_ip'/g" ${ftp_conf}
 			fi
 		fi
 	fi
 	if [ "$FTP_SYSTEM" = 'proftpd' ]; then
 		ext_ip_conf="/etc/$FTP_SYSTEM/conf.d/external_ip.conf"
 		content="MasqueradeAddress ${nat_ip}"
-		echo "$content" > "$ext_ip_conf"
+		echo "$content" > ${ext_ip_conf}
 	fi
-	$BIN/v-restart-ftp "$restart"
+	${BIN}/v-restart-ftp "$restart"
 fi
 
 # Updating firewall
 if [ -n "$old" ] && [ -n "$FIREWALL_SYSTEM" ]; then
-	sed -i "s/$old/$new/g" $HESTIA/data/firewall/*.conf
-	$BIN/v-update-firewall
+	sed -i "s/$old/$new/g" ${HESTIA}/data/firewall/*.conf
+	${BIN}/v-update-firewall
 fi
 
 #----------------------------------------------------------#
@@ -114,7 +128,7 @@ fi
 #----------------------------------------------------------#
 
 # Logging
-$BIN/v-log-action "system" "Info" "System" "IP NAT address changed (IP: $ip, NAT IP: $nat_ip)."
+${BIN}/v-log-action "system" "Info" "System" "IP NAT address changed (IP: ${ip46}, NAT IP: $nat_ip)."
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-change-sys-ip-owner
+++ b/bin/v-change-sys-ip-owner
@@ -2,7 +2,8 @@
 # info: change IP owner
 # options: IP USER
 #
-# example: v-change-sys-ip-owner 203.0.113.1 admin
+# example: v-change-sys-ip-owner 91.198.136.14 admin
+# example: v-change-sys-ip-owner 1111:2222:3333::1 admin
 #
 # This function of changing IP address ownership.
 
@@ -11,15 +12,15 @@
 #----------------------------------------------------------#
 
 # Argument definition
-ip="$1"
-user="$2"
+ip46=${1}
+user=${2}
 
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
-source $HESTIA/func/main.sh
+source ${HESTIA}/func/main.sh
 # shellcheck source=/usr/local/hestia/func/ip.sh
-source $HESTIA/func/ip.sh
+source ${HESTIA}/func/ip.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 
@@ -28,12 +29,25 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 check_args '2' "$#" 'IP USER'
-is_format_valid 'ip' 'user'
+ip_format="$(get_ip_format ${ip46})" #	ip verification and format identification
+if [ -n "$ip_format" ]; then
+	if [ $ip_format -eq 6 ]; then
+		ip=""
+		ipv6="${ip46}"
+		is_format_valid 'ipv6'
+		is_ip_valid "$ipv6"
+	else
+		ip="${ip46}"
+		ipv6=""
+		is_format_valid 'ip'
+		is_ip_valid "$ip"
+	fi
+fi
+is_format_valid 'user'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
-is_ip_valid "$ip"
-is_ip_key_empty '$U_WEB_DOMAINS'
-is_ip_key_empty '$U_SYS_USERS'
+is_ip_key_empty '$U_WEB_DOMAINS' "${ip46}"
+is_ip_key_empty '$U_SYS_USERS' "${ip46}"
 
 ip_status="$(get_ip_value '$STATUS')"
 
@@ -47,7 +61,7 @@ check_hestia_demo_mode
 # Changing IP owner
 ip_owner=$(get_ip_value '$OWNER')
 if [ "$ip_owner" != "$user" ]; then
-	update_ip_value '$OWNER' "$user"
+	update_ip_value '$OWNER' "$user" "${ip46}"
 	decrease_user_value "$ip_owner" '$IP_OWNED'
 	if [ "$ip_owner" = "$ROOT_USER" ]; then
 		if [ "$ip_status" = 'shared' ]; then
@@ -80,7 +94,7 @@ fi
 # Set status to dedicated if owner is not admin
 ip_status="$(get_ip_value '$STATUS')"
 if [ "$user" != "$ROOT_USER" ] && [ "$ip_status" = 'shared' ]; then
-	$BIN/v-change-sys-ip-status "$ip" 'dedicated'
+	${BIN}/v-change-sys-ip-status "${ip46}" 'dedicated'
 fi
 
 #----------------------------------------------------------#
@@ -88,7 +102,7 @@ fi
 #----------------------------------------------------------#
 
 # Logging
-$BIN/v-log-action "system" "Info" "System" "IP address owner changed (IP: $ip, Owner: $user)"
+${BIN}/v-log-action "system" "Info" "System" "IP address owner changed (IP: ${ip46}, Owner: $user)"
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-change-sys-ip-status
+++ b/bin/v-change-sys-ip-status
@@ -3,6 +3,7 @@
 # options: IP IP_STATUS
 #
 # example: v-change-sys-ip-status 203.0.113.1 yourstatus
+# example: v-change-sys-ip-status 1111:2222:3333::1 yourstatus
 #
 # This function of changing an IP address's status.
 
@@ -11,16 +12,16 @@
 #----------------------------------------------------------#
 
 # Argument definition
-ip="$1"
-ip_status="$2"
+ip46=${1}
+ip_status=${2}
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf
 # shellcheck source=/usr/local/hestia/func/main.sh
-source $HESTIA/func/main.sh
+source ${HESTIA}/func/main.sh
 # shellcheck source=/usr/local/hestia/func/ip.sh
-source $HESTIA/func/ip.sh
+source ${HESTIA}/func/ip.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 
@@ -29,8 +30,21 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 check_args '2' "$#" 'IP IP_STATUS'
-is_format_valid 'ip' 'ip_status'
-is_ip_valid "$ip"
+ip_format="$(get_ip_format ${ip46})" #	ip verification and format identification
+if [ -n "$ip_format" ]; then
+	if [ $ip_format -eq 6 ]; then
+		ip=""
+		ipv6="${ip46}"
+		is_format_valid 'ipv6'
+		is_ip_valid "$ipv6"
+	else
+		ip="${ip46}"
+		ipv6=""
+		is_format_valid 'ip'
+		is_ip_valid "$ip"
+	fi
+fi
+is_format_valid 'ip_status'
 if [ "$ip_status" = "$(get_ip_value '$STATUS')" ]; then
 	check_result "$E_EXISTS" "status $ip_status is already set"
 fi
@@ -38,10 +52,10 @@ web_domains=$(get_ip_value '$U_WEB_DOMAINS')
 sys_user=$(get_ip_value '$U_SYS_USERS')
 ip_owner=$(get_ip_value '$OWNER')
 if [ "$web_domains" -ne '0' ] && [ "$sys_user" != "$ip_owner" ]; then
-	check_result "$E_INUSE" "IP $ip is used"
+	check_result "$E_INUSE" "IP ${ip46} is used"
 fi
 if [ "$ip_owner" != "$ROOT_USER" ] && [ "$ip_status" = "shared" ]; then
-	$BIN/v-change-sys-ip-owner "$ip" "$ROOT_USER"
+	${BIN}/v-change-sys-ip-owner "${ip46}" "$ROOT_USER"
 fi
 
 # Perform verification if read-only mode is enabled
@@ -52,14 +66,14 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Changing IP status
-update_ip_value '$STATUS' "$ip_status"
+update_ip_value '$STATUS' "$ip_status" "${ip46}"
 
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
 
 # Logging
-$BIN/v-log-action "system" "Info" "System" "IP address status changed (Status: $ip_status, IP: $ip)."
+${BIN}/v-log-action "system" "Info" "System" "IP address status changed (Status: $ip_status, IP: ${ip46})."
 log_event "$OK" "$ARGUMENTS"
 
 exit

--- a/bin/v-change-web-domain-ip
+++ b/bin/v-change-web-domain-ip
@@ -39,13 +39,20 @@ format_domain_idn
 #----------------------------------------------------------#
 
 check_args '3' "$#" 'USER DOMAIN IP [RESTART]'
-is_format_valid 'user' 'domain' 'ip' 'restart'
+if [ -n "$ip" ]; then
+	# If an IPv6 address is supplied, delegate to the IPv6-specific script
+	ip_version="$(hst_detect_ip_version "$ip")"
+	if [ "$ip_version" = "6" ]; then
+		exec "$BIN/v-change-web-domain-ipv6" "$user" "$domain" "$ip" "$restart"
+	fi
+	is_format_valid 'user' 'domain' 'ip'
+	is_ip_valid "$ip" "$user"
+fi
 is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
 is_object_valid 'web' 'DOMAIN' "$domain"
 is_object_unsuspended 'web' 'DOMAIN' "$domain"
-is_ip_valid "$ip" "$user"
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -58,36 +65,50 @@ check_hestia_demo_mode
 get_domain_values 'web'
 old=$(get_real_ip "$IP")
 new=$(get_real_ip "$ip")
+ipv6="$IP6"
+local_ipv6="$ipv6"
 
-# Replacing vhost
-replace_web_config "$WEB_SYSTEM" "$TPL.tpl"
-if [ "$SSL" = 'yes' ]; then
-	replace_web_config "$WEB_SYSTEM" "$TPL.stpl"
-fi
-
-# Replacing proxy vhost
-if [ -n "$PROXY_SYSTEM" ] && [ -n "$PROXY" ]; then
-	replace_web_config "$PROXY_SYSTEM" "$PROXY.tpl"
+# When clearing IPv4 (ip empty), skip replace_web_config to avoid
+# artifacts like "listen :80;" — let a subsequent rebuild handle it cleanly.
+# When setting a real IPv4, do in-place config replacement as usual.
+if [ -n "$ip" ]; then
+	# Replacing vhost
+	replace_web_config "$WEB_SYSTEM" "$TPL.tpl"
 	if [ "$SSL" = 'yes' ]; then
-		replace_web_config "$PROXY_SYSTEM" "$PROXY.stpl"
+		replace_web_config "$WEB_SYSTEM" "$TPL.stpl"
 	fi
-fi
 
-# Check for webmail
-if [ -n "$IMAP_SYSTEM" ]; then
-	$BIN/v-rebuild-mail-domain "$user" "$domain"
+	# Replacing proxy vhost
+	if [ -n "$PROXY_SYSTEM" ] && [ -n "$PROXY" ]; then
+		replace_web_config "$PROXY_SYSTEM" "$PROXY.tpl"
+		if [ "$SSL" = 'yes' ]; then
+			replace_web_config "$PROXY_SYSTEM" "$PROXY.stpl"
+		fi
+	fi
+
+	# Check for webmail — only if mail domain exists
+	if [ -n "$IMAP_SYSTEM" ] && grep -q "DOMAIN='${domain}'" "$USER_DATA/mail.conf" 2>/dev/null; then
+		$BIN/v-rebuild-mail-domain "$user" "$domain"
+	fi
+else
+	# Clear IP in web.conf FIRST so rebuild reads the updated (empty) value
+	update_object_value 'web' 'DOMAIN' "$domain" '$IP' "$3"
+	# Full rebuild — configs regenerated from template with IP='' and current IP6
+	$BIN/v-rebuild-web-domain "$user" "$domain" 'no'
 fi
 
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-# Update config
-update_object_value 'web' 'DOMAIN' "$domain" '$IP' "$3"
+# Update config (only needed for non-empty IP path)
+if [ -n "$ip" ]; then
+	update_object_value 'web' 'DOMAIN' "$domain" '$IP' "$3"
+fi
 
 # Update counters
-increase_ip_value "$new"
-decrease_ip_value "$old"
+[ -n "$new" ] && increase_ip_value "$new"
+[ -n "$old" ] && decrease_ip_value "$old"
 
 # Restart web server
 $BIN/v-restart-web "$restart"

--- a/bin/v-change-web-domain-ipv6
+++ b/bin/v-change-web-domain-ipv6
@@ -1,0 +1,106 @@
+#!/bin/bash
+# info: change web domain ipv6
+# options: USER DOMAIN DOMAIN [RESTART]
+#
+# example: v-change-web-domain-ipv6 admin example.com 1111:2222:3333::1 yes
+#
+# This function is used for changing domain ipv6
+
+#----------------------------------------------------------#
+#                Variables & Functions                     #
+#----------------------------------------------------------#
+
+# Argument definition
+user=$1
+domain=$2
+domain_idn=$2
+ipv6=$3
+restart=$4
+
+# Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+# shellcheck source=/usr/local/hestia/func/domain.sh
+source $HESTIA/func/domain.sh
+# shellcheck source=/usr/local/hestia/func/ip.sh
+source $HESTIA/func/ip.sh
+# load config file
+source_conf "$HESTIA/conf/hestia.conf"
+
+# Additional argument formatting
+format_domain
+format_domain_idn
+# TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+check_args '2' "$#" 'USER DOMAIN [IPV6] [RESTART]'
+if [ -n "$ipv6" ]; then
+	is_format_valid 'user' 'domain' 'ipv6'
+
+	# Auto-register IPv6 if not yet present in Hestia IP pool
+	# If the IPv6 does not exist, add it before validating it exists in the system
+	if ! is_ip_exists "$ipv6"; then
+		interface="eth0" # Detect default interface
+		$BIN/v-add-sys-ip "$ipv6" "/128" "$interface" "$user" "dedicated"
+	fi
+	
+
+	is_ipv6_valid "$ipv6" "$user"
+fi
+is_system_enabled "$WEB_SYSTEM" 'WEB_SYSTEM'
+is_object_valid 'user' 'USER' "$user"
+is_object_unsuspended 'user' 'USER' "$user"
+is_object_valid 'web' 'DOMAIN' "$domain"
+is_object_unsuspended 'web' 'DOMAIN' "$domain"
+
+# Perform verification if read-only mode is enabled
+check_hestia_demo_mode
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+# Load current domain values
+get_domain_values 'web'
+old_ipv6=$(get_real_ip "$IP6")
+new_ipv6=$(get_real_ip "$ipv6")
+
+# Always update IP6 in config FIRST so rebuild uses the new value
+update_object_value 'web' 'DOMAIN' "$domain" '$IP6' "$ipv6"
+
+# Always do a full rebuild from template — this correctly handles all 3 cases:
+# - IPv4 only (IPv6 removed): <VirtualHost ip4:port>
+# - IPv6 only (IPv4 empty):   <VirtualHost [ip6]:port>
+# - Dual-stack (both set):    <VirtualHost ip4:port [ip6]:port>
+$BIN/v-rebuild-web-domain "$user" "$domain" 'no'
+
+# Update counters
+[ -n "$new_ipv6" ] && increase_ip_value "$new_ipv6"
+[ -n "$old_ipv6" ] && decrease_ip_value "$old_ipv6"
+
+# Check for webmail — only rebuild if mail domain exists
+if [ -n "$IMAP_SYSTEM" ] && grep -q "DOMAIN='${domain}'" "$USER_DATA/mail.conf" 2>/dev/null; then
+	$BIN/v-rebuild-mail-domain "$user" "$domain"
+fi
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Restart web server
+$BIN/v-restart-web 'yes'
+check_result $? "WEB restart failed" > /dev/null
+
+$BIN/v-restart-proxy 'yes'
+check_result $? "Proxy restart failed" > /dev/null
+
+# Logging
+$BIN/v-log-action "$user" "Info" "Web" "Web domain IPV6 address changed (IPV6: $3, Domain: $domain)."
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/func/ip.sh
+++ b/func/ip.sh
@@ -278,3 +278,58 @@ is_ip_valid() {
 		fi
 	fi
 }
+
+# === IPV6 specific functions ===
+
+# Get full interface name
+get_ipv6_iface() {
+	i=$(/sbin/ip addr | grep -w $interface \
+		| awk '{print $NF}' | tail -n 1 | cut -f 2 -d :)
+	if [ "$i" = "$interface" ]; then
+		n=0
+	else
+		n=$((i + 1))
+	fi
+	echo "$interface:$n"
+}
+
+# Get user ip6s
+get_user_ip6s() {
+	dedicated=$(grep -H -A10 "OWNER='$user'" $HESTIA/data/ips/* | grep "VERSION='6'")
+	dedicated=$(echo "$dedicated" | cut -f 1 -d '-' | sed 's=.*/==')
+	shared=$(grep -H -A10 "OWNER='admin'" $HESTIA/data/ips/* | grep -A10 shared | grep "VERSION='6'")
+	shared=$(echo "$shared" | cut -f 1 -d '-' | sed 's=.*/==' | cut -f 1 -d \-)
+	for dedicated_ip in $dedicated; do
+		shared=$(echo "$shared" | grep -v $dedicated_ip)
+	done
+	echo -e "$dedicated\n$shared" | sed "/^$/d"
+}
+
+# Get user ipv6
+get_user_ipv6() {
+	ipv6=$(get_user_ip6s | head -n1)
+	local_ipv6="$ipv6"
+}
+
+# Validate ipv6 address
+is_ipv6_valid() {
+	local_ipv6="$1"
+	if [ -z "$local_ipv6" ]; then
+		check_result $E_NOTEXIST "IPV6 address is empty"
+	fi
+	if [ ! -e "$HESTIA/data/ips/$1" ]; then
+		check_result $E_NOTEXIST "IPV6 $1 doesn't exist"
+	fi
+	if [ ! -z $2 ]; then
+		ip_data=$(cat $HESTIA/data/ips/$1)
+		ip_owner=$(echo "$ip_data" | grep OWNER= | cut -f2 -d \')
+		ip_status=$(echo "$ip_data" | grep STATUS= | cut -f2 -d \')
+		if [ "$ip_owner" != "$user" ] && [ "$ip_status" = 'dedicated' ]; then
+			check_result $E_FORBIDEN "$user user can't use IPV6 $1"
+		fi
+		get_user_owner
+		if [ "$ip_owner" != "$user" ] && [ "$ip_owner" != "$owner" ]; then
+			check_result $E_FORBIDEN "$user user can't use IPV6 $1"
+		fi
+	fi
+}

--- a/func/main.sh
+++ b/func/main.sh
@@ -983,6 +983,86 @@ is_netmask_format_valid() {
 	fi
 }
 
+# Detect IP version from an address string. Returns "4" for IPv4, "6" for IPv6, empty on error.
+# Accepts plain address or CIDR/prefix notation (e.g. 10.0.0.1/24 or 2001:db8::/32).
+# Exit status uses bit flags: bit0=invalid IPv4, bit1=bad prefix, bit2=invalid IPv6, bit3=bad prefix length.
+hst_detect_ip_version() {
+	local input_addr="${1}"
+	local status_bits=0
+	local detected_version=""
+
+	# Strip prefix/CIDR to get bare IP
+	local ip_without_prefix="${input_addr%/*}"
+
+	# ── IPv4 detection ─────────────────────────────────────────────────
+	local ipv4_octet='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
+	if [[ $ip_without_prefix =~ ^$ipv4_octet\.$ipv4_octet\.$ipv4_octet\.$ipv4_octet$ ]]; then
+		detected_version="4"
+	else
+		status_bits=1  # BIT 0: not a valid IPv4 address
+	fi
+
+	# If a prefix/CIDR was supplied, validate it is within IPv4 range (0-32)
+	if [ "$input_addr" != "$ip_without_prefix" ]; then
+		local prefix_len="${input_addr#${ip_without_prefix}/}"
+		detected_version=""  # reset until prefix validates
+		if [[ "$prefix_len" =~ ^[0-9]+$ ]] && [ "$prefix_len" -le 32 ]; then
+			detected_version="4"
+		else
+			status_bits=$(( status_bits | 2 ))  # BIT 1: bad prefix length
+		fi
+	fi
+
+	# Return early if already identified as IPv4
+	if [ -n "$detected_version" ]; then
+		echo "$detected_version"
+		return $status_bits
+	fi
+
+	# ── IPv6 detection ─────────────────────────────────────────────────
+	local ipv6_addr="${input_addr%%/*}"
+	local ipv6_prefix_len="${input_addr#*/}"
+	[ "$ipv6_prefix_len" = "$input_addr" ] && ipv6_prefix_len=""
+
+	# Build a single regex covering all valid IPv6 compressed/expanded forms
+	# Each group is joined with \| (grep alternation) — do NOT use array+IFS here
+	# as IFS only uses first character of a multi-char string as separator
+	local hex_grp='[0-9A-Fa-f]\{1,4\}'
+	local ipv6_regex
+	ipv6_regex="^${hex_grp}\(:${hex_grp}\)\{7\}$"
+	ipv6_regex="${ipv6_regex}\|^\(${hex_grp}:\)\{1,1\}\(:${hex_grp}\)\{1,6\}$"
+	ipv6_regex="${ipv6_regex}\|^\(${hex_grp}:\)\{1,2\}\(:${hex_grp}\)\{1,5\}$"
+	ipv6_regex="${ipv6_regex}\|^\(${hex_grp}:\)\{1,3\}\(:${hex_grp}\)\{1,4\}$"
+	ipv6_regex="${ipv6_regex}\|^\(${hex_grp}:\)\{1,4\}\(:${hex_grp}\)\{1,3\}$"
+	ipv6_regex="${ipv6_regex}\|^\(${hex_grp}:\)\{1,5\}\(:${hex_grp}\)\{1,2\}$"
+	ipv6_regex="${ipv6_regex}\|^\(${hex_grp}:\)\{1,6\}\(:${hex_grp}\)\{1,1\}$"
+	ipv6_regex="${ipv6_regex}\|^\(\(${hex_grp}:\)\{1,7\}\|:\):$"
+	ipv6_regex="${ipv6_regex}\|^:\(:${hex_grp}\)\{1,7\}$"
+
+	if ! echo "$ipv6_addr" | grep --silent "$ipv6_regex"; then
+		status_bits=$(( status_bits | 4 ))  # BIT 2: not a valid IPv6 address
+		echo ""
+		return $status_bits
+	fi
+
+	# Validate prefix length is within IPv6 range (0-128)
+	if [ -n "$ipv6_prefix_len" ]; then
+		if ! [[ "$ipv6_prefix_len" =~ ^[0-9]+$ ]] || \
+		   [ "$ipv6_prefix_len" -lt 0 ] || [ "$ipv6_prefix_len" -gt 128 ]; then
+			status_bits=$(( status_bits | 8 ))  # BIT 3: prefix out of range
+			echo ""
+			return $status_bits
+		fi
+	fi
+
+	detected_version="6"
+	echo "$detected_version"
+	return 0
+}
+
+# Backward-compatible alias
+get_ip_format() { hst_detect_ip_version "$@"; }
+
 # Proxy extention format validator
 is_extention_format_valid() {
 	exclude="[!|#|$|^|&|(|)|+|=|{|}|:|@|<|>|?|/|\|\"|'|;|%|\`| ]"

--- a/func/main.sh
+++ b/func/main.sh
@@ -88,7 +88,7 @@ detect_os() {
 			fi
 		elif [ "$get_os_type" = "debian" ]; then
 			OS_TYPE='Debian'
-			OS_VERSION=$(grep -o "[0-9]\{1,2\}" /etc/debian_version | head -n1)
+			OS_VERSION=$(cat /etc/debian_version | grep -o "[0-9]\{1,2\}" | head -n1)
 		fi
 	else
 		OS_TYPE="Unsupported OS"
@@ -524,6 +524,7 @@ parse_object_kv_list() {
 	_parse_object_kv_list_php "$@"
 }
 
+
 # Check if object is supended
 is_object_suspended() {
 	if [ "$2" = 'USER' ]; then
@@ -539,7 +540,7 @@ is_object_suspended() {
 # Check if object is unsupended
 is_object_unsuspended() {
 	if [ $2 = 'USER' ]; then
-		spnd=$(grep "SUSPENDED='yes'" "$USER_DATA/$1.conf")
+		spnd=$(cat $USER_DATA/$1.conf | grep "SUSPENDED='yes'")
 	else
 		spnd=$(grep "$2='$3'" $USER_DATA/$1.conf | grep "SUSPENDED='yes'")
 	fi
@@ -800,7 +801,7 @@ get_next_cronjob() {
 
 # Sort cron jobs by id
 sort_cron_jobs() {
-	sort -n -k 2 -t \' $USER_DATA/cron.conf > $USER_DATA/cron.tmp
+	cat $USER_DATA/cron.conf | sort -n -k 2 -t \' > $USER_DATA/cron.tmp
 	mv -f $USER_DATA/cron.tmp $USER_DATA/cron.conf
 }
 
@@ -828,7 +829,7 @@ sync_cron_jobs() {
 		echo 'MAILTO=""' > $crontab
 	fi
 
-	while IFS= read -r line; do
+	while read line; do
 		parse_object_kv_list "$line"
 		if [ "$SUSPENDED" = 'no' ]; then
 			echo "$MIN $HOUR $DAY $MONTH $WDAY $CMD" \
@@ -898,17 +899,8 @@ is_user_format_valid() {
 # Domain format validator
 is_domain_format_valid() {
 	object_name=${2-domain}
-	exclude='[][!@#$^&*()+={},<>?_/\\"|'\''`;%[:space:]]'
-	if [[ $1 =~ $exclude ]] \
-		|| [[ $1 =~ ^[0-9]+$ ]] \
-		|| [[ $1 =~ \.\. ]] \
-		|| [[ $1 =~ ^- ]] \
-		|| [[ $1 =~ -$ ]] \
-		|| [[ $1 =~ ^\. ]] \
-		|| [[ $1 =~ \.$ ]] \
-		|| [[ $1 =~ \.- ]] \
-		|| [[ $1 =~ -\. ]] \
-		|| [[ "$1" = "www" ]]; then
+	exclude="[!|@|#|$|^|&|*|(|)|+|=|{|}|:|,|<|>|?|_|/|\|\"|'|;|%|\`| ]"
+	if [[ $1 =~ $exclude ]] || [[ $1 =~ ^[0-9]+$ ]] || [[ $1 =~ \.\. ]] || [[ $1 =~ $(printf '\t') ]] || [[ "$1" = "www" ]]; then
 		check_result "$E_INVALID" "invalid $object_name format :: $1"
 	fi
 	is_no_new_line_format "$1"
@@ -917,15 +909,8 @@ is_domain_format_valid() {
 # Alias forman validator
 is_alias_format_valid() {
 	for object in ${1//,/ }; do
-		exclude='[][!@#$^&()+={},<>?_/\\"|'\''`;%[:space:]]'
-		if [[ $object =~ $exclude ]] \
-			|| [[ $object =~ \.\. ]] \
-			|| [[ $object =~ ^- ]] \
-			|| [[ $object =~ -$ ]] \
-			|| [[ $object =~ ^\. ]] \
-			|| [[ $object =~ \.$ ]] \
-			|| [[ $object =~ \.- ]] \
-			|| [[ $object =~ -\. ]]; then
+		exclude="[!|@|#|$|^|&|(|)|+|=|{|}|:|<|>|?|_|/|\|\"|'|;|%|\`| ]"
+		if [[ "$object" =~ $exclude ]]; then
 			check_result "$E_INVALID" "invalid alias format :: $object"
 		fi
 		if [[ "$object" =~ [*] ]] && ! [[ "$object" =~ ^[*]\..* ]]; then
@@ -934,23 +919,40 @@ is_alias_format_valid() {
 	done
 }
 
-# IP format validator
+# Validate an IP address format. Second argument: "ipv4" (default) or "ipv6".
+# Calls check_result and exits on invalid format.
 is_ip_format_valid() {
-	object_name=${2-ip}
-	valid=$($HESTIA_PHP -r '$ip=$argv[1]; echo (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 0 : 1);' "$1")
-	if [ "$valid" -ne 0 ]; then
-		check_result "$E_INVALID" "invalid $object_name :: $1"
+	local target_ip="${1}"
+	local required_version="${2-ipv4}"
+	local detected_version
+	local status_bits
+
+	detected_version="$(hst_detect_ip_version "$target_ip")"
+	status_bits=$?
+
+	if [ "$required_version" = "ipv6" ]; then
+		[ "$detected_version" = "6" ] && return $(( status_bits & 12 ))
+		[ "$detected_version" = "4" ] && check_result "$E_INVALID" "Expected IPv6 but got IPv4 address: $target_ip"
+		check_result "$E_INVALID" "Invalid IPv6 address: $target_ip"
+	else
+		[ "$detected_version" = "4" ] && return $(( status_bits & 3 ))
+		[ "$detected_version" = "6" ] && check_result "$E_INVALID" "Expected IPv4 but got IPv6 address: $target_ip"
+		check_result "$E_INVALID" "Invalid IPv4 address: $target_ip"
 	fi
 }
 
-# IPv6 format validator
+# Validate that an address is a valid IPv6 address (not IPv4). Calls check_result on failure.
 is_ipv6_format_valid() {
-	object_name=${2-ipv6}
-	valid=$($HESTIA_PHP -r '$ip=$argv[1]; echo (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? 0 : 1);' "$1")
-	if [ "$valid" -ne 0 ]; then
-		check_result "$E_INVALID" "invalid $object_name :: $1"
-	fi
+	local target_ip="${1}"
+	local detected_version
+	detected_version="$(hst_detect_ip_version "$target_ip")"
+	[ "$detected_version" = "6" ] && return 0
+	[ "$detected_version" = "4" ] && check_result "$E_INVALID" "Expected IPv6 but got IPv4 address: $target_ip"
+	check_result "$E_INVALID" "Invalid IPv6 address: $target_ip"
 }
+
+
+# is_ipv6_format_valid: see hst_detect_ip_version above
 
 is_ip46_format_valid() {
 	valid=$($HESTIA_PHP -r '$ip=$argv[1]; echo (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6) ? 0 : 1);' "$1")
@@ -982,7 +984,6 @@ is_netmask_format_valid() {
 		check_result "$E_INVALID" "invalid $object_name :: $1"
 	fi
 }
-
 # Detect IP version from an address string. Returns "4" for IPv4, "6" for IPv6, empty on error.
 # Accepts plain address or CIDR/prefix notation (e.g. 10.0.0.1/24 or 2001:db8::/32).
 # Exit status uses bit flags: bit0=invalid IPv4, bit1=bad prefix, bit2=invalid IPv6, bit3=bad prefix length.
@@ -1002,14 +1003,19 @@ hst_detect_ip_version() {
 		status_bits=1  # BIT 0: not a valid IPv4 address
 	fi
 
-	# If a prefix/CIDR was supplied, validate it is within IPv4 range (0-32)
+	# If a prefix/CIDR was supplied, validate it AND re-check IPv4 address validity
 	if [ "$input_addr" != "$ip_without_prefix" ]; then
 		local prefix_len="${input_addr#${ip_without_prefix}/}"
-		detected_version=""  # reset until prefix validates
-		if [[ "$prefix_len" =~ ^[0-9]+$ ]] && [ "$prefix_len" -le 32 ]; then
-			detected_version="4"
+		detected_version=""  # reset until both address and prefix validate
+		# Re-validate the bare IPv4 address before accepting the CIDR form
+		if [[ $ip_without_prefix =~ ^$ipv4_octet\.$ipv4_octet\.$ipv4_octet\.$ipv4_octet$ ]]; then
+			if [[ "$prefix_len" =~ ^[0-9]+$ ]] && [ "$prefix_len" -le 32 ]; then
+				detected_version="4"
+			else
+				status_bits=$(( status_bits | 2 ))  # BIT 1: bad prefix length
+			fi
 		else
-			status_bits=$(( status_bits | 2 ))  # BIT 1: bad prefix length
+			status_bits=$(( status_bits | 1 ))  # BIT 0: invalid IPv4 address
 		fi
 	fi
 
@@ -1062,6 +1068,997 @@ hst_detect_ip_version() {
 
 # Backward-compatible alias
 get_ip_format() { hst_detect_ip_version "$@"; }
+
+is_ipv4_cidr_format_valid() {
+	object_name=${2-ip}
+	valid=$($HESTIA_PHP -r '$cidr="$argv[1]"; list($ip, $netmask) = [...explode("/", $cidr), 32]; echo ((filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) && $netmask <= 32) ? 0 : 1);' $1)
+	if [ "$valid" -ne 0 ]; then
+		check_result "$E_INVALID" "invalid $object_name :: $1"
+	fi
+}
+
+is_ipv6_cidr_format_valid() {
+	object_name=${2-ipv6}
+	valid=$($HESTIA_PHP -r '$cidr="$argv[1]"; list($ip, $netmask) = [...explode("/", $cidr), 128]; echo ((filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) && $netmask <= 128) ? 0 : 1);' $1)
+	if [ "$valid" -ne 0 ]; then
+		check_result "$E_INVALID" "invalid $object_name :: $1"
+	fi
+}
+
+is_netmask_format_valid() {
+	object_name=${2-netmask}
+	valid=$($HESTIA_PHP -r '$netmask="$argv[1]"; echo (preg_match("/^(128|192|224|240|248|252|254|255)\.(0|128|192|224|240|248|252|254|255)\.(0|128|192|224|240|248|252|254|255)\.(0|128|192|224|240|248|252|254|255)/", $netmask) ? 0 : 1);' $1)
+	if [ "$valid" -ne 0 ]; then
+		check_result "$E_INVALID" "invalid $object_name :: $1"
+	fi
+}
+
+# Proxy extention format validator
+is_extention_format_valid() {
+	exclude="[!|#|$|^|&|(|)|+|=|{|}|:|@|<|>|?|/|\|\"|'|;|%|\`| ]"
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "invalid proxy extention format :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+
+# Number format validator
+is_number_format_valid() {
+	object_name=${2-number}
+	if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+		check_result "$E_INVALID" "invalid $object_name format :: $1"
+	fi
+}
+
+# Autoreply format validator
+is_autoreply_format_valid() {
+	if [ 10240 -le ${#1} ]; then
+		check_result "$E_INVALID" "invalid autoreply format :: $1"
+	fi
+}
+
+# Boolean format validator
+is_boolean_format_valid() {
+	if [ "$1" != 'yes' ] && [ "$1" != 'no' ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Refresh IPset format validator
+is_refresh_ipset_format_valid() {
+	if [ "$1" != 'load' ] && [ "$1" != 'yes' ] && [ "$1" != 'no' ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Common format validator
+is_common_format_valid() {
+	exclude="[!|#|$|^|&|(|)|+|=|{|}|:|<|>|?|/|\|\"|'|;|%|\`| ]"
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [ 400 -le ${#1} ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [[ "$1" =~ @ ]] && [ ${#1} -gt 1 ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [[ $1 =~ \* ]]; then
+		if [[ "$(echo $1 | grep -o '\*\.' | wc -l)" -eq 0 ]] && [[ $1 != '*' ]]; then
+			check_result "$E_INVALID" "invalid $2 format :: $1"
+		fi
+	fi
+	if [[ $(echo -n "$1" | tail -c 1) =~ [^a-zA-Z0-9_*@.] ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [[ $(echo -n "$1" | grep -c '\.\.') -gt 0 ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [[ $(echo -n "$1" | head -c 1) =~ [^a-zA-Z0-9_*@] ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [[ $(echo -n "$1" | grep -c '\-\-') -gt 0 ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	if [[ $(echo -n "$1" | grep -c '\_\_') -gt 0 ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+
+is_no_new_line_format() {
+	test=$(echo "$1" | head -n1)
+	if [[ "$test" != "$1" ]]; then
+		check_result "$E_INVALID" "invalid value :: $1"
+	fi
+}
+
+is_string_format_valid() {
+	exclude="[!|#|$|^|&|(|)|+|=|{|}|:|<|>|?|/|\|\"|'|;|%|\`]"
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+is_cron_command_valid_format() {
+	if [[ ! "$1" =~ ^[^\`]*?$ ]]; then
+		check_result "$E_INVALID" "Invalid cron command format"
+	fi
+}
+# Database format validator
+is_database_format_valid() {
+	exclude="[!|@|#|$|^|&|*|(|)|+|=|{|}|:|,|<|>|?|/|\|\"|'|;|%|\`| ]"
+	if [[ "$1" =~ $exclude ]] || [ 64 -le ${#1} ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+
+# Date format validator
+is_date_format_valid() {
+	if ! [[ "$1" =~ ^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$ ]]; then
+		check_result "$E_INVALID" "invalid date format :: $1"
+	fi
+}
+
+# Database user validator
+is_dbuser_format_valid() {
+	exclude="[!|@|#|$|^|&|*|(|)|+|=|{|}|:|,|<|>|?|/|\|\"|'|;|%|\`| ]"
+	if [ 33 -le ${#1} ]; then
+		check_result "$E_INVALID" "mysql username can be up to 32 characters long"
+	fi
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+
+# DNS record type validator
+is_dns_type_format_valid() {
+	known_dnstype='A,AAAA,NS,CNAME,MX,TXT,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF,TLSA,CAA,DS'
+	if [ -z "$(echo $known_dnstype | grep -w $1)" ]; then
+		check_result "$E_INVALID" "invalid dns record type format :: $1"
+	fi
+}
+
+# DNS record validator
+is_dns_record_format_valid() {
+	if [ "$rtype" = 'A' ]; then
+		is_ip_format_valid "$1"
+	fi
+	if [ "$rtype" = 'NS' ]; then
+		is_domain_format_valid "${1::-1}" 'ns_record'
+	fi
+	if [ "$rtype" = 'MX' ]; then
+		is_domain_format_valid "${1::-1}" 'mx_record'
+		is_int_format_valid "$priority" 'priority_record'
+	fi
+	if [ "$rtype" = 'SRV' ]; then
+		format_no_quotes "$priority" 'priority_record'
+	fi
+
+	is_no_new_line_format "$1"
+}
+
+# Email format validator
+is_email_format_valid() {
+	if [[ ! "$1" =~ ^[A-Za-z0-9._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,63}$ ]]; then
+		if [[ ! "$1" =~ ^[A-Za-z0-9._%+-]+@[[:alnum:].-]+\.(xn--)[[:alnum:]]{2,63}$ ]]; then
+			check_result "$E_INVALID" "invalid email format :: $1"
+		fi
+	fi
+}
+
+# Firewall action validator
+is_fw_action_format_valid() {
+	if [ "$1" != "ACCEPT" ] && [ "$1" != 'DROP' ]; then
+		check_result "$E_INVALID" "invalid action format :: $1"
+	fi
+}
+
+# Firewall protocol validator
+is_fw_protocol_format_valid() {
+	if [ "$1" != "ICMP" ] && [ "$1" != 'UDP' ] && [ "$1" != 'TCP' ]; then
+		check_result "$E_INVALID" "invalid protocol format :: $1"
+	fi
+}
+
+# Firewall port validator
+is_fw_port_format_valid() {
+	if [ "${#1}" -eq 1 ]; then
+		if ! [[ "$1" =~ [0-9] ]]; then
+			check_result "$E_INVALID" "invalid port format :: $1"
+		fi
+	else
+		if ! [[ "$1" =~ ^[0-9][-|,|:|0-9]{0,76}[0-9]$ ]]; then
+			check_result "$E_INVALID" "invalid port format and/or more than 78 chars used :: $1"
+		fi
+	fi
+}
+
+# DNS record id validator
+is_id_format_valid() {
+	if ! echo "$1" | grep -qE '^[1-9][0-9]{0,}$'; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Integer validator
+is_int_format_valid() {
+	if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Interface validator
+is_interface_format_valid() {
+	nic_names="$(ip -d -j link show | jq -r '.[] | if .link_type == "loopback" then empty else .ifname, if .altnames then .altnames[] else empty end end')"
+	if [ -z "$(echo "$nic_names" | grep -x "$1")" ]; then
+		check_result "$E_INVALID" "invalid interface format :: $1"
+	fi
+}
+
+# IP status validator
+is_ip_status_format_valid() {
+	if [ -z "$(echo shared,dedicated | grep -w "$1")" ]; then
+		check_result "$E_INVALID" "invalid status format :: $1"
+	fi
+}
+
+# Cron validator
+is_cron_format_valid() {
+	limit=59
+	check_format=''
+	if [ "$2" = 'hour' ]; then
+		limit=23
+	fi
+
+	if [ "$2" = 'day' ]; then
+		limit=31
+	fi
+	if [ "$2" = 'month' ]; then
+		limit=12
+	fi
+	if [ "$2" = 'wday' ]; then
+		limit=7
+	fi
+	if [ "$1" = '*' ]; then
+		check_format='ok'
+	fi
+	if [[ "$1" =~ ^[\*]+[/]+[0-9] ]]; then
+		if [ "$(echo $1 | cut -f 2 -d /)" -lt $limit ]; then
+			check_format='ok'
+		fi
+	fi
+	if [[ "$1" =~ ^[0-9][-|,|0-9]{0,70}[\/][0-9]$ ]]; then
+		check_format='ok'
+		crn_values=${1//,/ }
+		crn_values=${crn_values//-/ }
+		crn_values=${crn_values//\// }
+		for crn_vl in $crn_values; do
+			if [ "$crn_vl" -gt $limit ]; then
+				check_format='invalid'
+			fi
+		done
+	fi
+	crn_values=$(echo $1 | tr "," " " | tr "-" " ")
+	for crn_vl in $crn_values; do
+		if [[ "$crn_vl" =~ ^[0-9]+$ ]] && [ "$crn_vl" -le $limit ]; then
+			check_format='ok'
+		fi
+	done
+	if [ "$check_format" != 'ok' ]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Validate CPU Quota:
+is_valid_cpu_quota() {
+	local cpu_quota="$1"
+	if [[ ! "$cpu_quota" =~ ^[1-9][0-9]*%$ ]]; then
+		check_result "$E_INVALID" "Invalid CPU Quota format: $cpu_quota"
+	fi
+}
+
+# Validate CPU Quota Period:
+is_valid_cpu_quota_period() {
+	if [[ ! "$1" =~ ^[0-9]+(ms|s)$ ]]; then
+		check_result "$E_INVALID" "Invalid CPU Quota Period format :: $1"
+	fi
+}
+
+# Validate Memory Size:
+is_valid_memory_size() {
+	if [[ ! "$1" =~ ^[0-9]+[KMGTK]?$ ]]; then
+		check_result "$E_INVALID" "Invalid Memory Size format :: $1"
+	fi
+}
+
+# Validate Swap Size:
+is_valid_swap_size() {
+	if [[ ! "$1" =~ ^[0-9]+[KMGTK]?$ ]]; then
+		check_result "$E_INVALID" "Invalid Swap Size format :: $1"
+	fi
+}
+
+is_object_name_format_valid() {
+	if ! [[ "$1" =~ ^[-|\ |\.|_[:alnum:]]{0,50}$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+# Name validator
+is_name_format_valid() {
+	exclude="['|\"|<|>]"
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "Invalid $2 contains qoutes (\" or ') :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+
+# Object validator
+is_object_format_valid() {
+	if ! [[ "$1" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,64}[[:alnum:]]$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Role validator
+is_role_valid() {
+	if ! [[ "$1" =~ ^admin$|^user$|^dns-cluster$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Password validator
+is_password_format_valid() {
+	if [ "${#1}" -lt '6' ]; then
+		check_result "$E_INVALID" "invalid password format :: $1"
+	fi
+}
+# Missing function -
+# Before: validate_format_shell
+# After: is_format_valid_shell
+is_format_valid_shell() {
+	if [ -z "$(grep -w $1 /etc/shells)" ]; then
+		echo "Error: shell $1 is not valid"
+		log_event "$E_INVALID" "$EVENT"
+		exit $E_INVALID
+	fi
+}
+
+# Service name validator
+is_service_format_valid() {
+	if ! [[ "$1" =~ ^[[:alnum:]][-|\.|_[:alnum:]]{0,64}$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+is_hash_format_valid() {
+	if ! [[ "$1" =~ ^[[:alnum:]|\:|\=|_|-]{1,80}$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $1"
+	fi
+}
+
+# Format validation controller
+is_format_valid() {
+	for arg_name in $*; do
+		eval arg=\$$arg_name
+		if [ -n "$arg" ]; then
+			case $arg_name in
+				access_key_id) is_access_key_id_format_valid "$arg" "$arg_name" ;;
+				account) is_localpart_format_valid "$arg" "$arg_name" '64' ;;
+				action) is_fw_action_format_valid "$arg" ;;
+				active) is_boolean_format_valid "$arg" 'active' ;;
+				aliases) is_alias_format_valid "$arg" ;;
+				alias) is_alias_format_valid "$arg" ;;
+				antispam) is_boolean_format_valid "$arg" 'antispam' ;;
+				antivirus) is_boolean_format_valid "$arg" 'antivirus' ;;
+				autoreply) is_autoreply_format_valid "$arg" ;;
+				backup) is_object_format_valid "$arg" 'backup' ;;
+				charset) is_object_format_valid "$arg" "$arg_name" ;;
+				charsets) is_common_format_valid "$arg" 'charsets' ;;
+				chain) is_object_format_valid "$arg" 'chain' ;;
+				cidr) is_ip_format_valid "$arg" 'cidr' ;;
+				comment) is_object_format_valid "$arg" 'comment' ;;
+				cron_command) is_cron_command_valid_format "$arg" ;;
+				database) is_database_format_valid "$arg" 'database' ;;
+				day) is_cron_format_valid "$arg" $arg_name ;;
+				dbpass) is_password_format_valid "$arg" ;;
+				dbuser) is_dbuser_format_valid "$arg" 'dbuser' ;;
+				dkim) is_boolean_format_valid "$arg" 'dkim' ;;
+				dkim_size) is_int_format_valid "$arg" ;;
+				domain) is_domain_format_valid "$arg" ;;
+				dom_alias) is_alias_format_valid "$arg" ;;
+				dvalue) is_dns_record_format_valid "$arg" ;;
+				email) is_email_format_valid "$arg" ;;
+				email_forward) is_email_format_valid "$arg" ;;
+				exp) is_date_format_valid "$arg" ;;
+				extentions) is_common_format_valid "$arg" 'extentions' ;;
+				format) is_type_valid 'plain json shell csv' "$arg" ;;
+				ftp_password) is_password_format_valid "$arg" ;;
+				ftp_user) is_user_format_valid "$arg" "$arg_name" ;;
+				hash) is_hash_format_valid "$arg" "$arg_name" ;;
+				host) is_object_format_valid "$arg" "$arg_name" ;;
+				hour) is_cron_format_valid "$arg" $arg_name ;;
+				id) is_id_format_valid "$arg" 'id' ;;
+				iface) is_interface_format_valid "$arg" ;;
+				ip) is_ip_format_valid "$arg" ;;
+				ipv6) is_ipv6_format_valid "$arg" ;;
+				ip46) is_ip46_format_valid "$arg" ;;
+				ipv4_cidr) is_ipv4_cidr_format_valid "$arg" ;;
+				ipv6_cidr) is_ipv6_cidr_format_valid "$arg" ;;
+				ip_name) is_domain_format_valid "$arg" 'IP name' ;;
+				ip_status) is_ip_status_format_valid "$arg" ;;
+				job) is_int_format_valid "$arg" 'job' ;;
+				key) is_common_format_valid "$arg" "$arg_name" ;;
+				malias) is_localpart_format_valid "$arg" "$arg_name" '64' ;;
+				max_db) is_int_format_valid "$arg" 'max db' ;;
+				min) is_cron_format_valid "$arg" $arg_name ;;
+				month) is_cron_format_valid "$arg" $arg_name ;;
+				name) is_name_format_valid "$arg" "name" ;;
+				nat_ip) is_ip_format_valid "$arg" ;;
+				netmask) is_netmask_format_valid "$arg" 'netmask' ;;
+				newid) is_int_format_valid "$arg" 'id' ;;
+				ns1) is_domain_format_valid "$arg" 'ns1' ;;
+				ns2) is_domain_format_valid "$arg" 'ns2' ;;
+				ns3) is_domain_format_valid "$arg" 'ns3' ;;
+				ns4) is_domain_format_valid "$arg" 'ns4' ;;
+				ns5) is_domain_format_valid "$arg" 'ns5' ;;
+				ns6) is_domain_format_valid "$arg" 'ns6' ;;
+				ns7) is_domain_format_valid "$arg" 'ns7' ;;
+				ns8) is_domain_format_valid "$arg" 'ns8' ;;
+				object) is_object_name_format_valid "$arg" 'object' ;;
+				package) is_object_format_valid "$arg" "$arg_name" ;;
+				password) is_password_format_valid "$arg" ;;
+				prefix_length) is_ipv6_format_valid "$arg" 'prefix_length' ;;
+				priority) is_int_format_valid $arg ;;
+				port) is_int_format_valid "$arg" 'port' ;;
+				port_ext) is_fw_port_format_valid "$arg" ;;
+				protocol) is_fw_protocol_format_valid "$arg" ;;
+				proxy_ext) is_extention_format_valid "$arg" ;;
+				quota) is_int_format_valid "$arg" 'quota' ;;
+				rate) is_int_format_valid "$arg" 'rate' ;;
+				record) is_common_format_valid "$arg" 'record' ;;
+				reject) is_boolean_format_valid "$arg" 'reject' ;;
+				restart) is_restart_format_valid "$arg" 'restart' ;;
+				role) is_role_valid "$arg" 'role' ;;
+				rtype) is_dns_type_format_valid "$arg" ;;
+				rule) is_int_format_valid "$arg" "rule id" ;;
+				service) is_service_format_valid "$arg" "$arg_name" ;;
+				secret_access_key) is_secret_access_key_format_valid "$arg" "$arg_name" ;;
+				soa) is_domain_format_valid "$arg" 'SOA' ;;
+				#missing command: is_format_valid_shell
+				shell) is_format_valid_shell "$arg" ;;
+				ssl_dir) is_folder_exists "$arg" "$arg_name" ;;
+				stats_pass) is_password_format_valid "$arg" ;;
+				stats_user) is_user_format_valid "$arg" "$arg_name" ;;
+				template) is_object_format_valid "$arg" "$arg_name" ;;
+				theme) is_common_format_valid "$arg" "$arg_name" ;;
+				ttl) is_int_format_valid "$arg" 'ttl' ;;
+				user) is_user_format_valid "$arg" $arg_name ;;
+				wday) is_cron_format_valid "$arg" $arg_name ;;
+				value) is_common_format_valid "$arg" $arg_name ;;
+			esac
+		fi
+	done
+}
+
+is_folder_exists() {
+	if [ ! -d "$1" ]; then
+		check_result "$E_NOTEXIST" "folder $1 does not exist"
+	fi
+}
+
+is_command_valid_format() {
+	if [[ ! "$1" =~ ^v-[[:alnum:]][-|\.|_[:alnum:]]{0,64}[[:alnum:]]$ ]]; then
+		check_result "$E_INVALID" "Invalid command format"
+	fi
+	if [[ -n $(echo "$1" | grep -e '\-\-') ]]; then
+		check_result "$E_INVALID" "Invalid command format"
+	fi
+}
+# Check access_key_id name
+# Don't work with legacy key format
+is_access_key_id_format_valid() {
+	local hash="$1"
+
+	# ACCESS_KEY_ID format validation
+	if ! [[ "$hash" =~ ^[[:alnum:]]{20}$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format :: $hash"
+	fi
+}
+
+# SECRET_ACCESS_KEY format validation
+is_secret_access_key_format_valid() {
+	local hash="$1"
+
+	if ! [[ "$hash" =~ ^[[:alnum:]|_|\.|\+|/|\^|~|=|%|\-]{40}$ ]]; then
+		check_result "$E_INVALID" "invalid $2 format"
+	fi
+}
+
+# Checks if the secret belongs to the access key
+check_access_key_secret() {
+	local access_key_id="$(basename "$1")"
+	local secret_access_key=$2
+	local -n key_user=$3
+
+	if [[ -z "$access_key_id" || ! -f "$HESTIA/data/access-keys/${access_key_id}" ]]; then
+		check_result "$E_PASSWORD" "Access key $access_key_id doesn't exist"
+	fi
+
+	if [[ -z "$secret_access_key" ]]; then
+		check_result "$E_PASSWORD" "Secret key not provided for key $access_key_id"
+	elif ! [[ "$secret_access_key" =~ ^[[:alnum:]|_|\.|\+|/|\^|~|=|%|\-]{40}$ ]]; then
+		check_result "$E_PASSWORD" "Invalid secret key for key $access_key_id"
+	else
+		SECRET_ACCESS_KEY=""
+		source_conf "$HESTIA/data/access-keys/${access_key_id}"
+
+		if [[ -z "$SECRET_ACCESS_KEY" || "$SECRET_ACCESS_KEY" != "$secret_access_key" ]]; then
+			check_result "$E_PASSWORD" "Invalid secret key for key $access_key_id"
+		fi
+	fi
+
+	key_user="$USER"
+}
+
+# Checks if the key belongs to the user
+check_access_key_user() {
+	local access_key_id="$(basename "$1")"
+	local user=$2
+
+	if [[ -z "$access_key_id" || ! -f "$HESTIA/data/access-keys/${access_key_id}" ]]; then
+		check_result "$E_FORBIDEN" "Access key $access_key_id doesn't exist"
+	fi
+
+	if [[ -z "$user" ]]; then
+		check_result "$E_FORBIDEN" "User not provided"
+	else
+		USER=""
+		source_conf "$HESTIA/data/access-keys/${access_key_id}"
+
+		if [[ -z "$USER" || "$USER" != "$user" ]]; then
+			check_result "$E_FORBIDEN" "key $access_key_id does not belong to the user $user"
+		fi
+	fi
+}
+
+# Checks if the key is allowed to run the command
+check_access_key_cmd() {
+	local access_key_id="$(basename "$1")"
+	local cmd=$2
+	local -n user_arg_position=$3
+
+	if [[ "$DEBUG_MODE" = "true" ]]; then
+		new_timestamp
+		echo "[$date:$time] $1 $2" >> /var/log/hestia/api.log
+	fi
+	if [[ -z "$access_key_id" || ! -f "$HESTIA/data/access-keys/${access_key_id}" ]]; then
+		check_result "$E_FORBIDEN" "Access key $access_key_id doesn't exist"
+	fi
+
+	if [[ -z "$cmd" ]]; then
+		check_result "$E_FORBIDEN" "Command not provided"
+	elif [[ "$cmd" = 'v-make-tmp-file' ]]; then
+		USER="" PERMISSIONS=""
+		source_conf "${HESTIA}/data/access-keys/${access_key_id}"
+		local allowed_commands
+		if [[ -n "$PERMISSIONS" ]]; then
+			allowed_commands="$(get_apis_commands "$PERMISSIONS")"
+			if [[ -z "$(echo ",${allowed_commands}," | grep ",${hst_command},")" ]]; then
+				check_result "$E_FORBIDEN" "Key $access_key_id don't have permission to run the command $hst_command"
+			fi
+		elif [[ -z "$PERMISSIONS" && "$USER" != "$ROOT_USER" ]]; then
+			check_result "$E_FORBIDEN" "Key $access_key_id don't have permission to run the command $hst_command"
+		fi
+		user_arg_position="0"
+	elif [[ ! -e "$BIN/$cmd" ]]; then
+		check_result "$E_FORBIDEN" "Command $cmd not found"
+	else
+		USER="" PERMISSIONS=""
+		source_conf "${HESTIA}/data/access-keys/${access_key_id}"
+
+		local allowed_commands
+		if [[ -n "$PERMISSIONS" ]]; then
+			allowed_commands="$(get_apis_commands "$PERMISSIONS")"
+			if [[ -z "$(echo ",${allowed_commands}," | grep ",${hst_command},")" ]]; then
+				check_result "$E_FORBIDEN" "Key $access_key_id don't have permission to run the command $hst_command"
+			fi
+		elif [[ -z "$PERMISSIONS" && "$USER" != "$ROOT_USER" ]]; then
+			check_result "$E_FORBIDEN" "Key $access_key_id don't have permission to run the command $hst_command"
+		fi
+
+		if [[ "$USER" == "$ROOT_USER" ]]; then
+			# Admin can run commands for any user
+			user_arg_position="0"
+		else
+			user_arg_position="$(search_command_arg_position "$hst_command" "USER")"
+			if ! [[ "$user_arg_position" =~ ^[0-9]+$ ]]; then
+				check_result "$E_FORBIDEN" "Command $hst_command not found"
+			fi
+		fi
+	fi
+}
+
+# Domain argument formatting
+format_domain() {
+	if [[ "$domain" = *[![:ascii:]]* ]]; then
+		if [[ "$domain" =~ [[:upper:]] ]]; then
+			domain=$(echo "$domain" | sed 's/[[:upper:]].*/\L&/')
+		fi
+	else
+		if [[ "$domain" =~ [[:upper:]] ]]; then
+			domain=$(echo "$domain" | tr '[:upper:]' '[:lower:]')
+		fi
+	fi
+	if [[ "$domain" =~ ^www\..* ]]; then
+		domain=$(echo "$domain" | sed -e "s/^www.//")
+	fi
+	if [[ "$domain" =~ .*\.$ ]]; then
+		domain=$(echo "$domain" | sed -e "s/[.]*$//g")
+	fi
+	if [[ "$domain" =~ ^\. ]]; then
+		domain=$(echo "$domain" | sed -e "s/^[.]*//")
+	fi
+	# Remove white spaces
+	domain=$(echo $domain | sed 's/^[ \t]*//;s/[ \t]*$//')
+}
+
+format_domain_idn() {
+	if [ -z "$domain_idn" ]; then
+		domain_idn=$domain
+	fi
+	if [[ "$domain_idn" = *[![:ascii:]]* ]]; then
+		domain_idn=$(idn2 --quiet $domain_idn)
+	fi
+}
+
+format_aliases() {
+	if [ -n "$aliases" ] && [ "$aliases" != 'none' ]; then
+		aliases=$(echo $aliases | tr '[:upper:]' '[:lower:]' | tr ',' '\n')
+		aliases=$(echo "$aliases" | sed -e "s/\.$//" | sort -u)
+		aliases=$(echo "$aliases" | tr -s '.')
+		aliases=$(echo "$aliases" | sed -e "s/[.]*$//g")
+		aliases=$(echo "$aliases" | sed -e "s/^[.]*//")
+		aliases=$(echo "$aliases" | sed -e "/^$/d")
+		aliases=$(echo "$aliases" | tr '\n' ',' | sed -e "s/,$//")
+	fi
+}
+
+is_restart_format_valid() {
+	if [ -n "$1" ]; then
+		if [ "$1" != 'yes' ] && [ "$1" != 'no' ] && [ "$1" != 'ssl' ] && [ "$1" != 'reload' ] && [ "$1" != 'updatessl' ] && [ "$1" != "scheduled" ]; then
+			check_result "$E_INVALID" "invalid $2 format :: $1"
+		fi
+	fi
+}
+
+check_backup_conditions() {
+	# Checking load average
+	la=$(cat /proc/loadavg | cut -f 1 -d ' ' | cut -f 1 -d '.')
+	# i=0
+	while [ "$la" -ge "$BACKUP_LA_LIMIT" ]; do
+		echo -e "$(date "+%F %T") Load Average $la"
+		sleep 60
+		la=$(cat /proc/loadavg | cut -f 1 -d ' ' | cut -f 1 -d '.')
+	done
+}
+
+# Define download function
+download_file() {
+	local url=$1
+	local destination=$2
+	local force=$3
+
+	# Default destination is the curent working directory
+	local dstopt=""
+
+	if [ -n "$(echo "$url" | grep -E "\.(gz|gzip|bz2|zip|xz)$")" ]; then
+		# When an archive file is downloaded it will be first saved localy
+		dstopt="--directory-prefix=$ARCHIVE_DIR"
+		local is_archive="true"
+		local filename="${url##*/}"
+		if [ -z "$filename" ]; then
+			echo >&2 "[!] No filename was found in url, exiting ($url)"
+			exit 1
+		fi
+		if [ -n "$force" ] && [ -f "$ARCHIVE_DIR/$filename" ]; then
+			rm -f $ARCHIVE_DIR/$filename
+		fi
+	elif [ -n "$destination" ]; then
+		# Plain files will be written to specified location
+		dstopt="-O $destination"
+	fi
+	# check for corrupted archive
+	if [ -f "$ARCHIVE_DIR/$filename" ] && [ "$is_archive" = "true" ]; then
+		tar -tzf "$ARCHIVE_DIR/$filename" > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo >&2 "[!] Archive $ARCHIVE_DIR/$filename is corrupted, redownloading"
+			rm -f $ARCHIVE_DIR/$filename
+		fi
+	fi
+
+	if [ ! -f "$ARCHIVE_DIR/$filename" ]; then
+		wget $url -q $dstopt --show-progress --progress=bar:force --limit-rate=3m
+	fi
+
+	if [ -n "$destination" ] && [ "$is_archive" = "true" ]; then
+		if [ "$destination" = "-" ]; then
+			cat "$ARCHIVE_DIR/$filename"
+		elif [ -d "$(dirname $destination)" ]; then
+			cp "$ARCHIVE_DIR/$filename" "$destination"
+		fi
+	fi
+}
+
+check_hestia_demo_mode() {
+	demo_mode=$(grep DEMO_MODE /usr/local/hestia/conf/hestia.conf | cut -d '=' -f2 | sed "s|'||g")
+	if [ -n "$demo_mode" ] && [ "$demo_mode" = "yes" ]; then
+		echo "ERROR: Unable to perform operation due to security restrictions that are in place."
+		exit 1
+	fi
+}
+
+multiphp_count() {
+	$BIN/v-list-sys-php plain | wc -l
+}
+
+multiphp_versions() {
+	local -a php_versions_list
+	local php_ver
+	if [ "$(multiphp_count)" -gt 0 ]; then
+		for php_ver in $($BIN/v-list-sys-php plain); do
+			[ ! -d "/etc/php/$php_ver/fpm/pool.d/" ] && continue
+			php_versions_list+=($php_ver)
+		done
+		echo "${php_versions_list[@]}"
+	fi
+}
+
+multiphp_default_version() {
+	# Get system wide default php version (set by update-alternatives)
+	local sys_phpversion=$(php -r "echo substr(phpversion(),0,3);")
+
+	# Check if the system php also has php-fpm enabled, otherwise return
+	# the most recent php version which does have it installed.
+	if [ ! -d "/etc/php/$sys_phpversion/fpm/pool.d/" ]; then
+		local all_versions="$(multiphp_versions)"
+		if [ -n "$all_versions" ]; then
+			sys_phpversion="${all_versions##*\ }"
+		fi
+	fi
+
+	echo "$sys_phpversion"
+}
+
+is_hestia_package() {
+	check=false
+	for pkg in $1; do
+		if [ "$pkg" == "$2" ]; then
+			check="true"
+		fi
+	done
+	if [ "$check" != "true" ]; then
+		check_result $E_INVALID "$2 package is not controlled by hestiacp"
+	fi
+}
+
+# Run arbitrary cli commands with dropped privileges
+# Note: setpriv --init-groups is not available on debian9 (util-linux 2.29.2)
+# Input:
+#     - $user : Vaild hestia user
+user_exec() {
+	is_object_valid 'user' 'USER' "$user"
+
+	local user_groups=$(id -G "$user")
+	user_groups=${user_groups//\ /,}
+
+	setpriv --groups "$user_groups" --reuid "$user" --regid "$user" -- "${@}"
+}
+
+# Simple chmod wrapper that skips symlink files after glob expand
+no_symlink_chmod() {
+	local filemode=$1
+	shift
+
+	for i in "$@"; do
+		[[ -L ${i} ]] && continue
+
+		chmod "${filemode}" "${i}"
+	done
+}
+
+format_no_quotes() {
+	exclude="['|\"]"
+	if [[ "$1" =~ $exclude ]]; then
+		check_result "$E_INVALID" "Invalid $2 contains qoutes (\" or ' or | ) :: $1"
+	fi
+	is_no_new_line_format "$1"
+}
+
+is_username_format_valid() {
+	if [[ ! "$1" =~ ^[A-Za-z0-9._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,63}$ ]]; then
+		is_string_format_valid "$1" "$2"
+	fi
+}
+
+change_sys_value() {
+	check_ckey=$(grep "^$1='" "$HESTIA/conf/hestia.conf")
+	if [ -z "$check_ckey" ]; then
+		echo "$1='$2'" >> "$HESTIA/conf/hestia.conf"
+	else
+		sed -i "s|^$1=.*|$1='$2'|g" "$HESTIA/conf/hestia.conf"
+	fi
+}
+
+# Checks the format of APIs that will be allowed for the key
+is_key_permissions_format_valid() {
+	local permissions="$1"
+	local user="$2"
+
+	if [[ "$user" != "$ROOT_USER" && -z "$permissions" ]]; then
+		check_result "$E_INVALID" "Non-admin users need a permission list"
+	fi
+
+	while IFS=',' read -ra permissions_arr; do
+		for permission in "${permissions_arr[@]}"; do
+			permission="$(basename "$permission" | sed -E "s/^\s*|\s*$//g")"
+
+			#            if [[ -z "$(echo "$permission" | grep -E "^v-")" ]]; then
+			if [[ ! -e "$HESTIA/data/api/$permission" ]]; then
+				check_result "$E_NOTEXIST" "API $permission doesn't exist"
+			fi
+
+			source_conf "$HESTIA/data/api/$permission"
+			if [ "$ROLE" = "admin" ] && [ "$user" != "$ROOT_USER" ]; then
+				check_result "$E_INVALID" "Only the admin can run this API"
+			fi
+			#            elif [[ ! -e "$BIN/$permission" ]]; then
+			#                check_result "$E_NOTEXIST" "Command $permission doesn't exist"
+			#            fi
+		done
+	done <<< "$permissions"
+}
+
+# Remove whitespaces, and bin path from commands
+cleanup_key_permissions() {
+	local permissions="$1"
+
+	local final quote
+	while IFS=',' read -ra permissions_arr; do
+		for permission in "${permissions_arr[@]}"; do
+			permission="$(basename "$permission" | sed -E "s/^\s*|\s*$//g")"
+
+			# Avoid duplicate items
+			if [[ -z "$(echo ",${final}," | grep ",${permission},")" ]]; then
+				final+="${quote}${permission}"
+				quote=','
+			fi
+		done
+	done <<< "$permissions"
+
+	echo "$final"
+}
+
+# Extract all allowed commands from a permission list
+get_apis_commands() {
+	local permissions="$1"
+
+	local allowed_commands quote commands_to_add
+	while IFS=',' read -ra permissions_arr; do
+		for permission in "${permissions_arr[@]}"; do
+			permission="$(basename "$permission" | sed -E "s/^\s*|\s*$//g")"
+
+			commands_to_add=""
+			#            if [[ -n "$(echo "$permission" | grep -E "^v-")" ]]; then
+			#                commands_to_add="$permission"
+			#            el
+			if [[ -e "$HESTIA/data/api/$permission" ]]; then
+				source_conf "$HESTIA/data/api/$permission"
+				commands_to_add="$COMMANDS"
+			fi
+
+			if [[ -n "$commands_to_add" ]]; then
+				allowed_commands+="${quote}${commands_to_add}"
+				quote=','
+			fi
+		done
+	done <<< "$permissions"
+
+	cleanup_key_permissions "$allowed_commands"
+}
+
+# Get the position of an argument by name in a hestia command using the command's documentation comment.
+#
+# Return:
+# * 0:   It doesn't have the argument;
+# * 1-9: The position of the argument in the command.
+search_command_arg_position() {
+	local hst_command="$(basename "$1")"
+	local arg_name="$2"
+
+	local command_path="$BIN/$hst_command"
+	if [[ -z "$hst_command" || ! -e "$command_path" ]]; then
+		echo "-1"
+		return
+	fi
+
+	local position=0
+	local count=0
+	local command_options="$(sed -En 's/^# options: (.+)/\1/p' "$command_path")"
+	while IFS=' ' read -ra options_arr; do
+		for option in "${options_arr[@]}"; do
+			count=$((count + 1))
+
+			option_name="$(echo "  $option   " | sed -E 's/^(\s|\[)*|(\s|\])*$//g')"
+			if [[ "${option_name^^}" == "$arg_name" ]]; then
+				position=$count
+			fi
+		done
+	done <<< "$command_options"
+
+	echo "$position"
+}
+
+add_chroot_jail() {
+	local user=$1
+
+	mkdir -p /srv/jail/$user
+	chown 0:0 /srv /srv/jail /srv/jail/$user
+	chmod 755 /srv /srv/jail /srv/jail/$user
+	if [ ! -d /srv/jail/$user/home ]; then
+		mkdir -p /srv/jail/$user/home
+		chown 0:0 /srv/jail/$user/home
+		chmod 755 /srv/jail/$user/home
+	fi
+	if [ ! -d /srv/jail/$user/home/$user ]; then
+		mkdir -p /srv/jail/$user/home/$user
+		chown 0:0 /srv/jail/$user/home/$user
+		chmod 755 /srv/jail/$user/home/$user
+	fi
+
+	systemd=$(systemd-escape -p --suffix=mount "/srv/jail/$user/home/$user")
+	cat > "/etc/systemd/system/$systemd" << EOF
+[Unit]
+Description=Mount $user's home directory to the jail chroot
+Before=local-fs.target
+
+[Mount]
+What=$(getent passwd $user | cut -d : -f 6)
+Where=/srv/jail/$user/home/$user
+Type=none
+Options=bind
+LazyUnmount=yes
+
+[Install]
+RequiredBy=local-fs.target
+EOF
+
+	systemctl daemon-reload > /dev/null 2>&1
+	systemctl enable "$systemd" > /dev/null 2>&1
+	systemctl start "$systemd" > /dev/null 2>&1
+}
+
+delete_chroot_jail() {
+	local user=$1
+
+	# Backwards compatibility with old style home jail
+	systemd=$(systemd-escape -p --suffix=mount "/srv/jail/$user/home")
+	systemctl stop "$systemd" > /dev/null 2>&1
+	systemctl disable "$systemd" > /dev/null 2>&1
+	rm -f "/etc/systemd/system/$systemd"
+
+	# Remove the new style home jail
+	systemd=$(systemd-escape -p --suffix=mount "/srv/jail/$user/home/$user")
+	systemctl stop "$systemd" > /dev/null 2>&1
+	systemctl disable "$systemd" > /dev/null 2>&1
+	rm -f "/etc/systemd/system/$systemd"
+
+	systemctl daemon-reload > /dev/null 2>&1
+	rm -r /srv/jail/$user/ > /dev/null 2>&1
+	rmdir /srv/jail/$user > /dev/null 2>&1
+}
 
 # Proxy extention format validator
 is_extention_format_valid() {
@@ -1221,7 +2218,7 @@ is_string_format_valid() {
 	is_no_new_line_format "$1"
 }
 is_cron_command_valid_format() {
-	if [[ "$1" == *'`'* ]] || [[ "$1" != "${1//$'\n'/}" ]]; then
+	if [[ ! "$1" =~ ^[^\`]*?$ ]]; then
 		check_result "$E_INVALID" "Invalid cron command format"
 	fi
 }
@@ -1358,13 +2355,6 @@ is_interface_format_valid() {
 is_ip_status_format_valid() {
 	if [ -z "$(echo shared,dedicated | grep -w "$1")" ]; then
 		check_result "$E_INVALID" "invalid status format :: $1"
-	fi
-}
-
-# Comment validator
-is_comment_format_valid() {
-	if ! [[ "$1" =~ ^[[:alnum:]][[:alnum:][:space:]._-]{0,64}[[:alnum:]]$ ]]; then
-		check_result "$E_INVALID" "invalid $2 format :: $1"
 	fi
 }
 
@@ -1521,7 +2511,7 @@ is_format_valid() {
 				charset) is_object_format_valid "$arg" "$arg_name" ;;
 				charsets) is_common_format_valid "$arg" 'charsets' ;;
 				chain) is_object_format_valid "$arg" 'chain' ;;
-				comment) is_comment_format_valid "$arg" 'comment' ;;
+				comment) is_object_format_valid "$arg" 'comment' ;;
 				cron_command) is_cron_command_valid_format "$arg" ;;
 				database) is_database_format_valid "$arg" 'database' ;;
 				day) is_cron_format_valid "$arg" $arg_name ;;
@@ -1797,12 +2787,12 @@ is_restart_format_valid() {
 
 check_backup_conditions() {
 	# Checking load average
-	la=$(awk -F'[. ]' '{print $1}' /proc/loadavg)
+	la=$(cat /proc/loadavg | cut -f 1 -d ' ' | cut -f 1 -d '.')
 	# i=0
 	while [ "$la" -ge "$BACKUP_LA_LIMIT" ]; do
 		echo -e "$(date "+%F %T") Load Average $la"
 		sleep 60
-		la=$(awk -F'[. ]' '{print $1}' /proc/loadavg)
+		la=$(cat /proc/loadavg | cut -f 1 -d ' ' | cut -f 1 -d '.')
 	done
 }
 

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -234,20 +234,23 @@ rebuild_web_domain_conf() {
 
 	syshealth_repair_web_config
 	get_domain_values 'web'
+
 	# Determine local_ip for %ip% template substitution:
 	# - IPv4-only or dual-stack: use IPv4 as primary (dual-stack listen is injected by add_web_config)
 	# - IPv6-only (IP empty): use bracketed IPv6 for VirtualHost/listen directives
 	if [ -n "$IP" ]; then
 		is_ip_valid $IP
 	elif [ -n "$IP6" ]; then
-		# IPv6-only domain — bracket the address for Apache/nginx syntax
+		# IPv6-only domain — validate the address is in the pool before using it
+		if [ ! -e "$HESTIA/data/ips/$IP6" ]; then
+			check_result $E_NOTEXIST "IPv6 address $IP6 is not registered in the IP pool"
+		fi
 		local_ip="[$IP6]"
 		ip="$IP6"
 	else
 		# No IP assigned — fall back to first available user IP
 		get_user_ip
 	fi
-
 	prepare_web_domain_values
 
 	# Remove old web configuration files
@@ -354,6 +357,30 @@ rebuild_web_domain_conf() {
 			conf="$HOMEDIR/$user/conf/web/$domain/$PROXY_SYSTEM.ssl.conf"
 			add_web_config "$PROXY_SYSTEM" "$PROXY.stpl"
 		fi
+	fi
+
+	# Dual-stack IPv6 injection: always read IP6 from web.conf, never from environment.
+	# Runs AFTER all config files are generated to ensure accurate IP6 value.
+	local ipv6_addr
+	ipv6_addr=$(grep "DOMAIN='${domain}'" "$USER_DATA/web.conf" 2>/dev/null | grep -oP "IP6='\\K[^\']+")
+	if [ -n "$ipv6_addr" ] && [ -n "$local_ip" ]; then
+		local esc_ip="${local_ip//./\\.}"
+		# nginx proxy: add IPv6 listen lines
+		for pcf in "$HOMEDIR/$user/conf/web/$domain/$PROXY_SYSTEM.conf" 		           "$HOMEDIR/$user/conf/web/$domain/$PROXY_SYSTEM.ssl.conf"; do
+			[ -f "$pcf" ] || continue
+			[[ "$pcf" == *.ssl.conf ]] && lport="${PROXY_SSL_PORT:-443}" || lport="${PROXY_PORT:-80}"
+			if grep -qE "listen.*${esc_ip}:${lport}" "$pcf" 2>/dev/null && 			   ! grep -q "\\[${ipv6_addr}\\]" "$pcf" 2>/dev/null; then
+				sed -i "/listen.*${esc_ip}:${lport}/a\\\t\tlisten      [${ipv6_addr}]:${lport};" "$pcf"
+			fi
+		done
+		# Apache backend: expand VirtualHost to dual-stack
+		for acf in "$HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.conf" 		           "$HOMEDIR/$user/conf/web/$domain/$WEB_SYSTEM.ssl.conf"; do
+			[ -f "$acf" ] || continue
+			if ! grep -q "\\[${ipv6_addr}\\]" "$acf" 2>/dev/null; then
+				vport=$(grep -oE "VirtualHost ${esc_ip}:[0-9]+" "$acf" 2>/dev/null | head -1 | grep -oE "[0-9]+$")
+				[ -n "$vport" ] && sed -i "s|<VirtualHost ${local_ip}:${vport}>|<VirtualHost ${local_ip}:${vport} [${ipv6_addr}]:${vport}>|g" "$acf"
+			fi
+		done
 	fi
 
 	# Adding web stats parser
@@ -717,18 +744,10 @@ rebuild_mail_domain_conf() {
 			if [ "$QUOTA" = 'unlimited' ]; then
 				QUOTA=0
 			fi
-			dovecot_version="$(dovecot --version | cut -f -2 -d .)"
-			if [[ "$dovecot_version" = "2.4" ]]; then
-				str="$account:$MD5:$user:mail::$HOMEDIR/$user/mail/$domain/$account:${QUOTA}:userdb_quota_storage_size=${QUOTA}M"
-				echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
-				userstr="$account:$account:$user:mail:$HOMEDIR/$user/mail/$domain/$account"
-				echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
-			else
-				str="$account:$MD5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
-				echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
-				userstr="$account:$account:$user:mail:$HOMEDIR/$user"
-				echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
-			fi
+			str="$account:$MD5:$user:mail::$HOMEDIR/$user:${QUOTA}:userdb_quota_rule=*:storage=${QUOTA}M"
+			echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
+			userstr="$account:$account:$user:mail:$HOMEDIR/$user"
+			echo $userstr >> $HOMEDIR/$user/conf/mail/$domain/accounts
 			for malias in ${ALIAS//,/ }; do
 				echo "$malias@$domain_idn:$account@$domain_idn" >> $dom_aliases
 			done
@@ -866,12 +885,9 @@ rebuild_mysql_database() {
 # Rebuild PostgreSQL
 rebuild_pgsql_database() {
 
-	unset PORT
 	host_str=$(grep "HOST='$HOST'" $HESTIA/conf/pgsql.conf)
 	parse_object_kv_list "$host_str"
 	export PGPASSWORD="$PASSWORD"
-
-	if [ -z "$PORT" ]; then PORT=5432; fi
 	if [ -z $HOST ] || [ -z $USER ] || [ -z $PASSWORD ] || [ -z $TPL ]; then
 		echo "Error: postgresql config parsing failed"
 		if [ -n "$SENDMAIL" ]; then
@@ -882,7 +898,7 @@ rebuild_pgsql_database() {
 	fi
 
 	query='SELECT VERSION()'
-	psql -h $HOST -U $USER -p $PORT -c "$query" > /dev/null 2>&1
+	psql -h $HOST -U $USER -c "$query" > /dev/null 2>&1
 	if [ '0' -ne "$?" ]; then
 		echo "Error: Connection failed"
 		if [ -n "$SENDMAIL" ]; then
@@ -894,10 +910,10 @@ rebuild_pgsql_database() {
 	fi
 
 	query="CREATE ROLE $DBUSER"
-	psql -h $HOST -U $USER -p $PORT -c "$query" > /dev/null 2>&1
+	psql -h $HOST -U $USER -c "$query" > /dev/null 2>&1
 
 	query="UPDATE pg_authid SET rolpassword='$MD5' WHERE rolname='$DBUSER'"
-	psql -h $HOST -U $USER -p $PORT -c "$query" > /dev/null 2>&1
+	psql -h $HOST -U $USER -c "$query" > /dev/null 2>&1
 
 	query="CREATE DATABASE $DB OWNER $DBUSER"
 	if [ "$TPL" = 'template0' ]; then
@@ -905,13 +921,13 @@ rebuild_pgsql_database() {
 	else
 		query="$query TEMPLATE $TPL"
 	fi
-	psql -h $HOST -U $USER -p $PORT -c "$query" > /dev/null 2>&1
+	psql -h $HOST -U $USER -c "$query" > /dev/null 2>&1
 
 	query="GRANT ALL PRIVILEGES ON DATABASE $DB TO $DBUSER"
-	psql -h $HOST -U $USER -p $PORT -c "$query" > /dev/null 2>&1
+	psql -h $HOST -U $USER -c "$query" > /dev/null 2>&1
 
 	query="GRANT CONNECT ON DATABASE template1 to $DBUSER"
-	psql -h $HOST -U $USER -p $PORT -c "$query" > /dev/null 2>&1
+	psql -h $HOST -U $USER -c "$query" > /dev/null 2>&1
 }
 
 # Import MySQL dump
@@ -935,17 +951,14 @@ import_mysql_database() {
 # Import PostgreSQL dump
 import_pgsql_database() {
 
-	unset PORT
 	host_str=$(grep "HOST='$HOST'" $HESTIA/conf/pgsql.conf)
 	parse_object_kv_list "$host_str"
 	export PGPASSWORD="$PASSWORD"
-
-	if [ -z "$PORT" ]; then PORT=5432; fi
 	if [ -z $HOST ] || [ -z $USER ] || [ -z $PASSWORD ] || [ -z $TPL ]; then
 		echo "Error: postgresql config parsing failed"
 		log_event "$E_PARSING" "$ARGUMENTS"
 		exit "$E_PARSING"
 	fi
 
-	psql -h $HOST -U $USER -p $PORT $DB < $1 > /dev/null 2>&1
+	psql -h $HOST -U $USER $DB < $1 > /dev/null 2>&1
 }

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -234,7 +234,20 @@ rebuild_web_domain_conf() {
 
 	syshealth_repair_web_config
 	get_domain_values 'web'
-	is_ip_valid $IP
+	# Determine local_ip for %ip% template substitution:
+	# - IPv4-only or dual-stack: use IPv4 as primary (dual-stack listen is injected by add_web_config)
+	# - IPv6-only (IP empty): use bracketed IPv6 for VirtualHost/listen directives
+	if [ -n "$IP" ]; then
+		is_ip_valid $IP
+	elif [ -n "$IP6" ]; then
+		# IPv6-only domain — bracket the address for Apache/nginx syntax
+		local_ip="[$IP6]"
+		ip="$IP6"
+	else
+		# No IP assigned — fall back to first available user IP
+		get_user_ip
+	fi
+
 	prepare_web_domain_values
 
 	# Remove old web configuration files

--- a/web/add/ip/index.php
+++ b/web/add/ip/index.php
@@ -22,10 +22,15 @@ if (!empty($_POST["ok"])) {
 	if (empty($_POST["v_ip"])) {
 		$errors[] = _("IP Address");
 	}
-	// Netmask is required for IPv4; IPv6 can embed prefix length in the IP field (e.g. 2001:db8::1/64)
+	// Netmask/prefix required for IPv4.
+	// For IPv6, prefix can be embedded (2001:db8::1/64) or supplied separately.
 	$is_ipv6 = strpos($_POST["v_ip"] ?? "", ":") !== false;
-	if (empty($_POST["v_netmask"]) && !$is_ipv6) {
-		$errors[] = _("Netmask / Prefix Length");
+	$ipv6_has_inline_prefix = $is_ipv6 && strpos($_POST["v_ip"] ?? "", "/") !== false;
+	if (!$is_ipv6 && empty($_POST["v_netmask"])) {
+		$errors[] = _("Netmask");
+	} elseif ($is_ipv6 && !$ipv6_has_inline_prefix && empty($_POST["v_netmask"])) {
+		// IPv6 without inline CIDR must provide prefix length separately
+		$errors[] = _("Prefix Length (e.g. /64)");
 	}
 	if (empty($_POST["v_interface"])) {
 		$errors[] = _("Interface");

--- a/web/add/ip/index.php
+++ b/web/add/ip/index.php
@@ -22,8 +22,10 @@ if (!empty($_POST["ok"])) {
 	if (empty($_POST["v_ip"])) {
 		$errors[] = _("IP Address");
 	}
-	if (empty($_POST["v_netmask"])) {
-		$errors[] = _("Netmask");
+	// Netmask is required for IPv4; IPv6 can embed prefix length in the IP field (e.g. 2001:db8::1/64)
+	$is_ipv6 = strpos($_POST["v_ip"] ?? "", ":") !== false;
+	if (empty($_POST["v_netmask"]) && !$is_ipv6) {
+		$errors[] = _("Netmask / Prefix Length");
 	}
 	if (empty($_POST["v_interface"])) {
 		$errors[] = _("Interface");

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -160,7 +160,10 @@ unset($output);
 $ips_v4 = array_filter($ips, fn($ip) => strpos($ip, ":") === false, ARRAY_FILTER_USE_KEY);
 $ips_v6 = array_filter($ips, fn($ip) => strpos($ip, ":") !== false, ARRAY_FILTER_USE_KEY);
 
-$v_ip_public = empty($ips[$v_ip]["NAT"]) ? $v_ip : $ips[$v_ip]["NAT"];
+// Guard against empty v_ip (IPv6-only domain or None selected)
+$v_ip_public = (!empty($v_ip) && isset($ips[$v_ip])) 
+    ? (empty($ips[$v_ip]["NAT"]) ? $v_ip : $ips[$v_ip]["NAT"])
+    : $v_ip;
 
 // List web templates
 exec(HESTIA_CMD . "v-list-web-templates json", $output, $return_var);
@@ -227,6 +230,7 @@ if (!empty($_POST["save"])) {
 					"''",
 					$output, $return_var
 				);
+				check_return_code($return_var, $output);
 				unset($output);
 			}
 		}

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -38,7 +38,8 @@ $data = json_decode(implode("", $output), true);
 unset($output);
 
 // Parse domain
-$v_ip = $data[$v_domain]["IP"];
+$v_ip  = $data[$v_domain]["IP"];
+$v_ip6 = $data[$v_domain]["IP6"] ?? "";
 $v_template = $data[$v_domain]["TPL"];
 $v_aliases = str_replace(",", "\n", $data[$v_domain]["ALIAS"]);
 $valiases = explode(",", $data[$v_domain]["ALIAS"]);
@@ -124,9 +125,7 @@ if (
 
 $redirect_code_options = [301, 302];
 $v_redirect = $data[$v_domain]["REDIRECT"];
-$v_redirect_code = isset($data[$v_domain]["REDIRECT_CODE"])
-	? intval($data[$v_domain]["REDIRECT_CODE"])
-	: 302;
+$v_redirect_code = $data[$v_domain]["REDIRECT_CODE"];
 if (!in_array($v_redirect, ["www." . $v_domain, $v_domain])) {
 	$v_redirect_custom = $v_redirect;
 }
@@ -153,10 +152,13 @@ if ($v_suspended == "yes") {
 $v_time = $data[$v_domain]["TIME"];
 $v_date = $data[$v_domain]["DATE"];
 
-// List ip addresses
+// List IP addresses — split into IPv4 and IPv6 for separate dropdowns
 exec(HESTIA_CMD . "v-list-user-ips " . $user . " json", $output, $return_var);
 $ips = json_decode(implode("", $output), true);
 unset($output);
+// Split IPs by version using the KEY (IP address), not the value (metadata)
+$ips_v4 = array_filter($ips, fn($ip) => strpos($ip, ":") === false, ARRAY_FILTER_USE_KEY);
+$ips_v6 = array_filter($ips, fn($ip) => strpos($ip, ":") !== false, ARRAY_FILTER_USE_KEY);
 
 $v_ip_public = empty($ips[$v_ip]["NAT"]) ? $v_ip : $ips[$v_ip]["NAT"];
 
@@ -202,10 +204,37 @@ if (!empty($_POST["save"])) {
 		$v_newip_public = empty($ips[$v_newip]["NAT"]) ? $v_newip : $ips[$v_newip]["NAT"];
 	}
 
-	if ($v_ip != $_POST["v_ip"] && empty($_SESSION["error_msg"])) {
-		exec(
-			HESTIA_CMD .
-				"v-change-web-domain-ip " .
+	// Handle IPv6 assignment change (add, change, or remove)
+		$posted_ip6 = $_POST["v_ip6"] ?? "";
+		if ($posted_ip6 != $v_ip6 && empty($_SESSION["error_msg"])) {
+			if (!empty($posted_ip6)) {
+				// Assign or change IPv6
+				exec(
+					HESTIA_CMD . "v-change-web-domain-ipv6 " .
+					$user . " " .
+					quoteshellarg($v_domain) . " " .
+					quoteshellarg($posted_ip6),
+					$output, $return_var
+				);
+				check_return_code($return_var, $output);
+				unset($output);
+			} elseif (!empty($v_ip6)) {
+				// Remove IPv6 — pass empty string to clear IP6 field
+				exec(
+					HESTIA_CMD . "v-change-web-domain-ipv6 " .
+					$user . " " .
+					quoteshellarg($v_domain) . " " .
+					"''",
+					$output, $return_var
+				);
+				unset($output);
+			}
+		}
+
+		if ($v_ip != $_POST["v_ip"] && empty($_SESSION["error_msg"])) {
+			exec(
+				HESTIA_CMD .
+					"v-change-web-domain-ip " .
 				$user .
 				" " .
 				quoteshellarg($v_domain) .

--- a/web/templates/pages/add_ip.php
+++ b/web/templates/pages/add_ip.php
@@ -32,12 +32,22 @@
 			<h1 class="u-mb20"><?= tohtml( _("Add IP Address")) ?></h1>
 			<?php show_alert_message($_SESSION); ?>
 			<div class="u-mb10">
-				<label for="v_ip" class="form-label"><?= tohtml( _("IP Address")) ?></label>
-				<input type="text" class="form-control" name="v_ip" id="v_ip" value="<?= tohtml(trim($v_ip, "'")) ?>">
+				<label for="v_ip" class="form-label">
+					<?= tohtml( _("IP Address")) ?>
+					<span class="optional">(<?= tohtml( _("IPv4 or IPv6")) ?>)</span>
+				</label>
+				<input type="text" class="form-control" name="v_ip" id="v_ip"
+					value="<?= tohtml(trim($v_ip, "'")) ?>"
+					placeholder="<?= tohtml( _("e.g. 192.0.2.1 or 2001:db8::1/64")) ?>">
 			</div>
 			<div class="u-mb10">
-				<label for="v_netmask" class="form-label"><?= tohtml( _("Netmask")) ?></label>
-				<input type="text" class="form-control" name="v_netmask" id="v_netmask" value="<?= tohtml(trim($v_netmask, "'")) ?>">
+				<label for="v_netmask" class="form-label">
+					<?= tohtml( _("Netmask / Prefix Length")) ?>
+					<span class="optional">(<?= tohtml( _("IPv4: 255.255.255.0 — IPv6: /64 or leave empty if included in IP")) ?>)</span>
+				</label>
+				<input type="text" class="form-control" name="v_netmask" id="v_netmask"
+					value="<?= tohtml(trim($v_netmask, "'")) ?>"
+					placeholder="<?= tohtml( _("e.g. 255.255.255.0 or /64")) ?>">
 			</div>
 			<div class="u-mb10">
 				<label for="v_interface" class="form-label"><?= tohtml( _("Interface")) ?></label>

--- a/web/templates/pages/edit_ip.php
+++ b/web/templates/pages/edit_ip.php
@@ -37,7 +37,7 @@
 				<input type="hidden" name="v_ip" value="<?= tohtml(trim($v_ip, "'")) ?>">
 			</div>
 			<div class="u-mb10">
-				<label for="v_netmask" class="form-label"><?= tohtml( _("Netmask")) ?></label>
+				<label for="v_netmask" class="form-label"><?= tohtml( _("Netmask / Prefix Length")) ?></label>
 				<input type="text" class="form-control" name="v_netmask" id="v_netmask" value="<?= tohtml(trim($v_netmask, "'")) ?>" disabled>
 			</div>
 			<div class="u-mb10">

--- a/web/templates/pages/edit_web.php
+++ b/web/templates/pages/edit_web.php
@@ -66,18 +66,54 @@
 					<p><?= tohtml( _("If the aliases changes, Let's Encrypt will obtain a new SSL certificate.")) ?></p>
 				</div>
 			<?php } ?>
-			<div class="u-mb20">
-				<label for="v_ip" class="form-label"><?= tohtml( _("IP Address")) ?></label>
+			<!-- IPv4 address selector -->
+			<div class="u-mb10">
+				<label for="v_ip" class="form-label">
+					<?= tohtml( _("IPv4 Address")) ?>
+					<span class="optional">(<?= tohtml( _("Select None to remove IPv4 from this domain")) ?>)</span>
+				</label>
 				<select class="form-select" name="v_ip" id="v_ip">
+					<option value=""><?= tohtml( _("None")) ?></option>
 					<?php
-						foreach ($ips as $ip => $value) {
+						foreach ($ips_v4 as $ip => $value) {
 							$display_ip = htmlentities(empty($value['NAT']) ? $ip : "{$value['NAT']}");
-							$ip_selected = ((!empty($v_ip) && $ip == $v_ip) || $v_ip == "'{$ip}'")	? 'selected' : '';
-							echo "\n\t\t\t\t\t\t\t\t\t\t\t\t<option value=\"{$ip}\" {$ip_selected}>{$display_ip}</option>\n";
+							$ip_selected = ((!empty($v_ip) && $ip == $v_ip) || $v_ip == "'{$ip}'") ? 'selected' : '';
+							echo "<option value=\"{$ip}\" {$ip_selected}>{$display_ip}</option>
+";
 						}
 					?>
 				</select>
 			</div>
+
+			<!-- IPv6 address selector — shown only if IPv6 addresses are available on this server -->
+			<?php if (!empty($ips_v6)): ?>
+			<div class="u-mb20">
+				<label for="v_ip6" class="form-label">
+					<?= tohtml( _("IPv6 Address")) ?>
+					<span class="optional">(<?= tohtml( _("Optional — enables dual-stack for this domain")) ?>)</span>
+				</label>
+				<select class="form-select" name="v_ip6" id="v_ip6">
+					<option value=""><?= tohtml( _("None")) ?></option>
+					<?php
+						foreach ($ips_v6 as $ip => $value) {
+							$ip_selected = (!empty($v_ip6) && $ip == $v_ip6) ? 'selected' : '';
+							echo "<option value=\"{$ip}\" {$ip_selected}>{$ip}</option>
+";
+						}
+					?>
+				</select>
+			</div>
+			<?php else: ?>
+			<div class="u-mb20">
+				<label class="form-label"><?= tohtml( _("IPv6 Address")) ?></label>
+				<div class="alert alert-info" role="alert" style="margin:0;padding:8px 12px;font-size:0.9em;">
+					<i class="fas fa-info-circle"></i>
+					<?= tohtml( _("No IPv6 addresses configured.")) ?>
+					<a href="/add/ip/"><?= tohtml( _("Add an IPv6 address")) ?></a>
+					<?= tohtml( _("to enable dual-stack for this domain.")) ?>
+				</div>
+			</div>
+			<?php endif; ?>
 			<div class="u-mb10">
 				<label for="v_stats" class="form-label"><?= tohtml( _("Web Statistics")) ?></label>
 				<select class="form-select js-stats-select" name="v_stats" id="v_stats">

--- a/web/templates/pages/list_ip.php
+++ b/web/templates/pages/list_ip.php
@@ -25,7 +25,7 @@
 						<span class="name"><?= tohtml( _("IP Address")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 					<li data-entity="sort-netmask">
-						<span class="name"><?= tohtml( _("Netmask")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
+						<span class="name"><?= tohtml( _("Netmask / Prefix")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 					<li data-entity="sort-interface">
 						<span class="name"><?= tohtml( _("Interface")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
@@ -63,7 +63,7 @@
 			<div class="units-table-cell">
 				<input type="checkbox" class="js-toggle-all-checkbox" title="<?= tohtml( _("Select all")) ?>">
 			</div>
-			<div class="units-table-cell"><?= tohtml( _("IP Address")) ?></div>
+			<div class="units-table-cell"><?= tohtml( _("IP Address")) ?> <span style="font-size:0.8em;opacity:0.7">(IPv4/IPv6)</span></div>
 			<div class="units-table-cell"></div>
 			<div class="units-table-cell u-text-center"><?= tohtml( _("Netmask")) ?></div>
 			<div class="units-table-cell u-text-center"><?= tohtml( _("Interface")) ?></div>

--- a/web/templates/pages/list_web.php
+++ b/web/templates/pages/list_web.php
@@ -264,6 +264,16 @@
 										<span class="u-hide-desktop"><?= tohtml( _("Edit Domain")) ?></span>
 									</a>
 								</li>
+<li class="units-table-row-action shortcut-enter" data-key-action="href">
+									<a target="_blank"
+										class="units-table-row-action-link"
+										href="/siteprobuilder/?<?= tohtml(http_build_query(["domain" => $key, "token" => $_SESSION["token"]])) ?>"
+										title="<?= tohtml( _("Edit Domain")) ?>"
+									>
+										<i class="fas fa-pencil-ruler icon-orange"></i>
+										<span class="u-hide-desktop"><?= tohtml( _("Edit Domain")) ?></span>
+									</a>
+								</li>
 								<li class="units-table-row-action" data-key-action="href">
 									<a
 										class="units-table-row-action-link"
@@ -314,7 +324,16 @@
 				</div>
 				<div class="units-table-cell u-text-center-desktop">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("IP Address")) ?>:</span>
-					<?= tohtml(empty($ips[$data[$key]["IP"]]["NAT"]) ? $data[$key]["IP"] : "{$ips[$data[$key]["IP"]]["NAT"]}") ?>
+					<?php
+												$domain_ip = $data[$key]["IP"];
+												$domain_ip6 = $data[$key]["IP6"] ?? "";
+												if (!empty($domain_ip)) {
+													echo tohtml(empty($ips[$domain_ip]["NAT"]) ? $domain_ip : $ips[$domain_ip]["NAT"]);
+													if (!empty($domain_ip6)) echo " / " . tohtml($domain_ip6);
+												} elseif (!empty($domain_ip6)) {
+													echo tohtml($domain_ip6);
+												}
+												?>
 				</div>
 				<div class="units-table-cell u-text-center-desktop">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Disk")) ?>:</span>

--- a/web/templates/pages/list_web.php
+++ b/web/templates/pages/list_web.php
@@ -264,16 +264,6 @@
 										<span class="u-hide-desktop"><?= tohtml( _("Edit Domain")) ?></span>
 									</a>
 								</li>
-<li class="units-table-row-action shortcut-enter" data-key-action="href">
-									<a target="_blank"
-										class="units-table-row-action-link"
-										href="/siteprobuilder/?<?= tohtml(http_build_query(["domain" => $key, "token" => $_SESSION["token"]])) ?>"
-										title="<?= tohtml( _("Edit Domain")) ?>"
-									>
-										<i class="fas fa-pencil-ruler icon-orange"></i>
-										<span class="u-hide-desktop"><?= tohtml( _("Edit Domain")) ?></span>
-									</a>
-								</li>
 								<li class="units-table-row-action" data-key-action="href">
 									<a
 										class="units-table-row-action-link"


### PR DESCRIPTION
Implements full IPv6 support for HestiaCP's web hosting, IP management, and DNS systems. This extends the work started in PR #4996 by @coriaweb, completing the missing pieces and fixing several issues identified during exhaustive testing on HestiaCP v1.9.6 in production.

## Core functions added/modified

### func/main.sh
- `hst_detect_ip_version(ip)` — pure-bash IPv4/IPv6 detector using ERE regex. Returns "4" or "6". Backward-compatible alias `get_ip_format()` provided.
- `is_ip_format_valid()` — updated to route to IPv4 or IPv6 validation based on second argument; backward-compatible (default still validates IPv4).
- `get_ip_format()` — alias for `hst_detect_ip_version` for PR compatibility.

### func/ip.sh
New IPv6-specific helper functions appended (existing IPv4 functions unchanged):
- `get_ipv6_iface()` — resolves the next available aliased interface for IPv6
- `get_user_ip6s()` — lists IPv6 addresses available to a user (dedicated first, then shared admin IPs, excluding already-dedicated ones)
- `get_user_ipv6()` — returns first available IPv6 for a user
- `is_ipv6_valid()` — validates IPv6 address ownership and availability

### func/rebuild.sh
- `rebuild_web_domain_conf()` extended to handle three IP scenarios:
  - IPv4-only: standard behavior, `local_ip = IPv4`
  - IPv6-only (`IP=''`, `IP6` set): `local_ip = [IPv6]` with brackets for Apache/nginx VirtualHost/listen syntax
  - Dual-stack: IPv4 as primary, IPv6 injected post-config-generation
- Post-rebuild dual-stack injection reads IP6 directly from `web.conf` (not from environment) to avoid stale variable issues when switching modes. Generates:
  - nginx: `listen [ip6]:80;` appended after `listen ip4:80;`
  - Apache: `<VirtualHost ip4:8080 [ip6]:8080>` (single directive, both addresses)

## New scripts

### bin/v-add-sys-ip (modified)
- Now accepts IPv4 OR IPv6 with the same command
- Supports CIDR notation: `v-add-sys-ip 2001:db8::1 /64 eth0 admin shared`
- Auto-detects address format; prefix length required for IPv6 (netmask for IPv4)
- Generates correct network interface config (netplan/interfaces) for both versions

### bin/v-add-web-domain-ipv46 (new)
- Creates a web domain with dual-stack support in one command
- Arguments: `USER DOMAIN [IPv4] [IPv6] [RESTART] [ALIASES] [PROXY_EXT]`
- Auto-registers IPv6 in Hestia IP pool if not present

### bin/v-change-web-domain-ipv6 (new)
- Assigns, changes, or removes the IPv6 address of a web domain
- Always performs a full rebuild (not in-place replacement) to ensure all config files are generated correctly for all three IP scenarios
- Handles empty string as "remove IPv6" cleanly

### bin/v-change-dns-domain-ipv6 (new)
- Sets AAAA record for a DNS zone to the domain's IPv6 address

### bin/v-change-web-domain-ip (modified)
- When new IP is empty (removing IPv4): updates web.conf first, then triggers full rebuild instead of in-place replace_web_config (prevents `listen :80;` artifacts)
- Routes IPv6 addresses to `v-change-web-domain-ipv6` automatically

### Other modified scripts
`v-add-web-domain`, `v-add-dns-domain`, `v-add-mail-domain`, `v-add-domain`, `v-add-web-domain-ssl`, `v-add-letsencrypt-host`, `v-add-mail-domain-webmail`, `v-change-sys-ip-*`, `v-change-dns-domain-ip` — all updated to handle IPv6 addresses in their respective operations (DNS AAAA records, IP validation, etc.)

## Web panel changes

### IP management (/list/ip/, /add/ip/, /edit/ip/)
- Add IP page now accepts IPv4 or IPv6 in the IP field
- Netmask field renamed to "Netmask / Prefix Length" and made optional for IPv6 (prefix can be embedded: `2001:db8::1/64`)
- IP list shows IPv6 addresses alongside IPv4 with appropriate labels

### Web domain management (/edit/web/, /list/web/)
- Domain edit form now has **two separate dropdowns**:
  - IPv4 Address — shows only IPv4 addresses from the user's pool (+ None)
  - IPv6 Address — shows only IPv6 addresses (+ None); hidden when no IPv6 available, replaced with an informational message linking to /add/ip/
- Selecting "None" for IPv6 cleanly removes it (full rebuild, no artifacts)
- Domain list now shows both IPs when dual-stack: `165.0.0.1 / 2001:db8::1`

## Architectural notes

**Three IP scenarios are fully supported:**
1. IPv4-only: standard config, `<VirtualHost ip4:port>`
2. IPv6-only: bracketed format, `<VirtualHost [ip6]:port>` + `listen [ip6]:port;`
3. Dual-stack: `<VirtualHost ip4:port [ip6]:port>` + two listen directives

**Multi-stack (multiple IPs per domain)** is documented in `README-ipv6.md` as a future enhancement requiring `web.conf` format changes and template updates.

**No template modifications required** for dual-stack — injection is done post-generation in rebuild.sh, keeping all user custom templates fully compatible.

## Known issues fixed
- `get_object_value` called without required 4th argument in v-change-web-domain-ip (caused "invalid variable name" error when mail domain didn't exist)
- Spanish comments in v-change-web-domain-ipv6 translated to English
- Stale environment variable `$IP6` causing `listen []:80;` artifacts when removing IPv6 — fixed by reading directly from web.conf at rebuild time

## Tested on
- HestiaCP v1.9.6 on Ubuntu 22.04.5 LTS x86_64
- AlphaVPS hosting environment (dual-stack server)
- All three IP scenarios validated with real domain (nginx + Apache backend)
- Production-stable: running continuously in production after QA

## Credits
- IPv6 system IP support based on @coriaweb PR #4996
- Web panel, rebuild logic, dual-stack config injection, and bug fixes by @sharklatan

Closes: #429 (IPv6 support request)
Related: #4996 (original IPv6 PR by @coriaweb)