### PR TITLE
Fix: Prevent truncation of database hostnames with underscores in RRD charts

### DIFF
--- a/bin/v-export-rrd
+++ b/bin/v-export-rrd
@@ -145,7 +145,7 @@ else
 fi
 end=$(date +%s)
 
-host=$(echo $chart | cut -d'_' -f2)
+host=$(echo $chart | cut -d'_' -f2-)
 chart=$(echo $chart | cut -d'_' -f1)
 
 case $chart in

--- a/bin/v-list-sys-rrd
+++ b/bin/v-list-sys-rrd
@@ -52,7 +52,7 @@ json_list() {
 			if [ "$type" = 'db' ]; then
 				db_type=$(echo $rrd | cut -f 1 -d _ | sed -e 's/mysql/MySQL/g' \
 					-e 's/pgsql/PostgreSQL/g')
-				db_host=$(echo $rrd | cut -f 2 -d _)
+				db_host=$(echo $rrd | cut -f 2- -d _)
 				title="$db_type Usage on $db_host"
 			fi
 			echo -e "\t\"$i\": {"


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where database hostnames containing underscores (e.g., `MySQL_Endpoint_Server`) were being incorrectly truncated when parsing RRD filenames. This truncation caused the `/list/rrd` AJAX endpoint to fail with an HTTP 500 error and rendered an incorrect title for the database usage chart.

### Why is this needed?
When the database host is parsed from the RRD filename (e.g., `mysql_MySQL_Endpoint_Server.rrd`), `bin/v-list-sys-rrd` and `bin/v-export-rrd` were using `cut -d'_' -f2`. If the hostname contained an underscore, `cut` would drop everything after the first underscore in the hostname itself.

This resulted in two issues:
1. **Incorrect UI Title:** The hostname would be displayed truncated in the panel (e.g., `"MySQL Usage on MySQL"` instead of `"MySQL Usage on MySQL_Endpoint_Server"`).
2. **500 Server Error:** `v-export-rrd` would try to fetch an RRD file using the truncated hostname (e.g., `mysql_MySQL.rrd`). Because the file didn't exist, the script exited with an error, causing `ajax.php` to throw an HTTP 500 error and the graph to fail to load.

### How was this fixed?
Updated the `cut` commands in both `bin/v-list-sys-rrd` and `bin/v-export-rrd` to use `-f2-` (instead of `-f2`). This ensures that `cut` captures everything *after* the first underscore to the end of the string, correctly preserving the entire hostname.