### PR TITLE
Bump Roundcube to version 1.6.17

### DIFF
--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -50,7 +50,7 @@ pga_v='7.14.6'
 
 # Set version of RoundCube (Webmail) to update during upgrade if not already installed
 # Note: only applies to "non-apt installs >= 1.4.0 or manually phased out"
-rc_v='1.6.16'
+rc_v='1.6.17'
 
 # Set version of SnappyMail (Webmail) to update during upgrade if not already installed
 sm_v='2.38.2'


### PR DESCRIPTION
This is a security update to the LTS version 1.6 of Roundcube Webmail. It provides fixes to recently reported security vulnerabilities:

    Fix an infinite loop in TNEF (winmail.dat) decoder (#10193), reported by stafra.
    Fix various vulnerabilities in the password plugin using session-injected username, reported by Glendaenri and peppersghost.
    Fix stored XSS via unescaped attachment MIME type on the attachment-validation warning page [CVE-2026-54432], reported by Bohdan Kurinnoy, Samsung R&D Instit
    Fix SSRF bypass via specific local address URLs - two new cases, reported by Leenear.
    Fix zero-click stored XSS in plain-text rendering [CVE-2026-54433], reported by Bohdan Kurinnoy, Samsung R&D Institute Ukraine (SRUKR).
    Fix DoS via crafted compressed-RTF size in the TNEF (winmail.dat) file, reported by h0rk1p.

This version is considered stable and we recommend to update all productive installations of Roundcube 1.6.x with it. Please do backup your data before updating!