### PR TITLE
Fix nginx 403 error page

### DIFF
--- a/install/deb/nginx/nginx.conf
+++ b/install/deb/nginx/nginx.conf
@@ -94,7 +94,7 @@ http {
 	resolver                        1.0.0.1 8.8.4.4 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
 	resolver_timeout                5s;
 	# Error pages
-	error_page                      403 /error/404.html;
+	error_page                      403 /error/403.html;
 	error_page                      404 /error/404.html;
 	error_page                      410 /error/410.html;
 	error_page                      500 501 502 503 504 505 /error/50x.html;


### PR DESCRIPTION
Point nginx 403 errors to `/error/403.html` instead of the 404 page.