### PR TITLE
fix: build restic repo path as $REPO/$user in restic scripts (#5100)

### DIFF
--- a/bin/v-add-backup-host-restic
+++ b/bin/v-add-backup-host-restic
@@ -82,6 +82,10 @@ if [[ $repo == "rclone:"* ]]; then
 	fi
 fi
 
+# Normalize repository path by removing any trailing slash so the
+# per-user repo path is always built as "$REPO/$user" (see #5100)
+repo="${repo%/}"
+
 echo "REPO='$repo'" > /usr/local/hestia/conf/restic.conf
 echo "SNAPSHOTS='$snapshots'" >> /usr/local/hestia/conf/restic.conf
 echo "KEEP_DAILY='$daily'" >> /usr/local/hestia/conf/restic.conf

--- a/bin/v-backup-user-restic
+++ b/bin/v-backup-user-restic
@@ -55,13 +55,13 @@ if [ ! -f "$USER_DATA/restic.conf" ]; then
 	password=$(generate_password '' '32')
 	echo "$password" > $USER_DATA/restic.conf
 
-	restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf init
+	restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf init
 	if [ $? -ne 0 ]; then
 		check_result $E_CONNECT "Unable to create restic repo"
 	fi
 else
 	# Check if repo exists and is accessible with restic key
-	restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf --json snapshots > /dev/null
+	restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf --json snapshots > /dev/null
 	if [ $? -ne 0 ]; then
 		# Send an email
 		echo "Unable to open restic backup. It might not exists or key is incorrect" | $SENDMAIL -s "$subj" "$email" "yes"
@@ -73,7 +73,7 @@ fi
 $BIN/v-backup-user-config $user
 export GOMAXPROCS=2
 export RESTIC_READ_CONCURRENCY=2
-ionice -c2 -n7 nice -n 19 restic --repo "$REPO$user" --limit-upload 10240 --read-concurrency 2 --password-file $USER_DATA/restic.conf backup /home/$user
+ionice -c2 -n7 nice -n 19 restic --repo "${REPO%/}/$user" --limit-upload 10240 --read-concurrency 2 --password-file $USER_DATA/restic.conf backup /home/$user
 
 if [ $? -ne 0 ]; then
 	echo "Unable to create the backup" | $SENDMAIL -s "$subj" "$email" "yes"
@@ -96,7 +96,7 @@ if [[ -n "$KEEP_YEARLY" && "$KEEP_YEARLY" -ge 0 ]]; then
 	restic_prune="$restic_prune --keep-yearly $KEEP_YEARLY"
 fi
 
-restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf forget $restic_prune --prune
+restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf forget $restic_prune --prune
 
 # Send notification
 if [ -e "$BACKUP/$user.log" ] && [ "$notify" = "yes" ]; then

--- a/bin/v-delete-user-backup-restic
+++ b/bin/v-delete-user-backup-restic
@@ -50,13 +50,13 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download from snapshot"
 	fi
 fi
 
-restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" forget "$snapshot"
+restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" forget "$snapshot"
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-list-user-backup-restic
+++ b/bin/v-list-user-backup-restic
@@ -86,7 +86,7 @@ plain_list() {
 
 source_conf $HESTIA/conf/restic.conf
 
-restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf --json dump $snapshot /home/$user/backup/backup.conf > /home/$user/tmp/backup.conf
+restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf --json dump $snapshot /home/$user/backup/backup.conf > /home/$user/tmp/backup.conf
 
 parse_object_kv_list $(cat /home/$user/tmp/backup.conf)
 

--- a/bin/v-list-user-backups-restic
+++ b/bin/v-list-user-backups-restic
@@ -47,11 +47,11 @@ check_hestia_demo_mode
 source_conf $HESTIA/conf/restic.conf
 
 function json_list() {
-	restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf --json snapshots
+	restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf --json snapshots
 }
 
 function plain_list() {
-	restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf snapshots
+	restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf snapshots
 }
 
 # Listing data

--- a/bin/v-list-user-files-restic
+++ b/bin/v-list-user-files-restic
@@ -47,7 +47,7 @@ check_hestia_demo_mode
 
 source_conf $HESTIA/conf/restic.conf
 
-restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf --json ls $snapshot $folder
+restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf --json ls $snapshot $folder
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-restore-cron-job-restic
+++ b/bin/v-restore-cron-job-restic
@@ -49,7 +49,7 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 
-restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/cron/cron.conf" > "$tmpdir/cron.conf"
+restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/cron/cron.conf" > "$tmpdir/cron.conf"
 
 # Restoring cron jobs
 cp "$tmpdir/cron.conf" "$USER_DATA/cron.conf"

--- a/bin/v-restore-database-restic
+++ b/bin/v-restore-database-restic
@@ -49,7 +49,7 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download snapshot"
 	fi
@@ -65,7 +65,7 @@ for db in $DB; do
 	if [[ "${IFS}${databases_array[*]}${IFS}" =~ "${IFS}${db}${IFS}" || "$databases_array" = '*' ]]; then
 		check_config=$(grep "DB='$db'" $USER_DATA/db.conf)
 		if [ -z "$check_config" ]; then
-			restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/db/$db/hestia/db.conf" > "$tmpdir/db.conf"
+			restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/db/$db/hestia/db.conf" > "$tmpdir/db.conf"
 			if [ "$?" -ne 0 ]; then
 				check_result "$E_NOTEXIST" "Unable to download user data"
 			fi
@@ -81,13 +81,13 @@ for db in $DB; do
 
 		# Download databse
 		if [ "$BACKUP_MODE" = "zstd" ]; then
-			restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/db/$db/$db.$TYPE.sql.zst" > $tmpdir/$db.$TYPE.sql.zst
+			restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/db/$db/$db.$TYPE.sql.zst" > $tmpdir/$db.$TYPE.sql.zst
 			if [ "$?" -ne 0 ]; then
 				check_result $E_NOTEXIST "Unable to download database"
 			fi
 			pzstd -d "$tmpdir/$db.$TYPE.sql.zst"
 		else
-			restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/db/$db/$db.$TYPE.sql.gz" > $tmpdir/$db.$TYPE.sql.gz
+			restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/db/$db/$db.$TYPE.sql.gz" > $tmpdir/$db.$TYPE.sql.gz
 			if [ "$?" -ne 0 ]; then
 				check_result $E_NOTEXIST "Unable to download database"
 			fi

--- a/bin/v-restore-dns-domain-restic
+++ b/bin/v-restore-dns-domain-restic
@@ -49,7 +49,7 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download snapshot data"
 	fi
@@ -76,7 +76,7 @@ for domain in $domains; do
 				check_result "$E_PARSING" "$error"
 			fi
 		fi
-		restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/dns/$domain" --target "$tmpdir"
+		restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/dns/$domain" --target "$tmpdir"
 		if [ "$?" -ne 0 ]; then
 			check_result $E_NOTEXIST "Unable to download domain from snapshot"
 		fi

--- a/bin/v-restore-file-restic
+++ b/bin/v-restore-file-restic
@@ -49,13 +49,13 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf dump $snapshot /home/$user/backup/backup.conf > $tmpdir/backup.conf
+	restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf dump $snapshot /home/$user/backup/backup.conf > $tmpdir/backup.conf
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download snapshot data"
 	fi
 fi
 
-restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf restore $snapshot --include $file --target /
+restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf restore $snapshot --include $file --target /
 
 #----------------------------------------------------------#
 #                       Hestia                             #

--- a/bin/v-restore-mail-domain-restic
+++ b/bin/v-restore-mail-domain-restic
@@ -52,7 +52,7 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p "/home/$user/tmp/" -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > $tmpdir/backup.conf
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > $tmpdir/backup.conf
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download snapshot"
 	fi
@@ -85,7 +85,7 @@ for domain in $domains; do
 			fi
 		fi
 
-		restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/mail/$domain" --target "$tmpdir"
+		restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/mail/$domain" --target "$tmpdir"
 		if [ "$?" -ne 0 ]; then
 			check_result $E_NOTEXIST "Unable to download domain from snapshot"
 		fi
@@ -203,7 +203,7 @@ for domain in $domains; do
 		chmod u+w "$HOMEDIR/$user/mail/$domain_idn"
 		chown $user:$user "$HOMEDIR/$user/mail/$domain_idn"
 
-		restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include /home/$user/mail/$domain_idn --target /
+		restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include /home/$user/mail/$domain_idn --target /
 		if [ "$?" -ne 0 ]; then
 			check_result "$E_NOTEXIST" "Unable to download user data"
 		fi

--- a/bin/v-restore-user-full-restic
+++ b/bin/v-restore-user-full-restic
@@ -56,7 +56,7 @@ if [ -n "$check_user" ]; then
 
 	echo "$key" > $USER_DATA/restic.conf
 
-	restic --repo "$REPO$user" --password-file $USER_DATA/restic.conf snapshots
+	restic --repo "${REPO%/}/$user" --password-file $USER_DATA/restic.conf snapshots
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_PASSWORD" "Invalid Restic repository / encryption key"
 	fi
@@ -64,14 +64,14 @@ fi
 
 tmpdir=$(mktemp -p "/home/$user/tmp/" -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Invalid snapshot"
 	fi
 fi
 
 # Download user data
-restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/" --target "$tmpdir"
+restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/" --target "$tmpdir"
 if [ "$?" -ne 0 ]; then
 	check_result "$E_NOTEXIST" "Unable to download user data"
 fi
@@ -96,7 +96,7 @@ $BIN/v-restore-database-restic "$user" "$snapshot" '*'
 echo "[ * ] Restore Cronjobs"
 $BIN/v-restore-cron-job-restic "$user" "$snapshot"
 echo "[ * ] Restore user files"
-restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --exclude "/home/$user/web/" --exclude "/home/$user/conf" --exclude "/home/$user/mail" --target /
+restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --exclude "/home/$user/web/" --exclude "/home/$user/conf" --exclude "/home/$user/mail" --target /
 if [ "$?" -ne 0 ]; then
 	check_result "$E_NOTEXIST" "Unable to download user folders"
 fi

--- a/bin/v-restore-user-restic
+++ b/bin/v-restore-user-restic
@@ -54,14 +54,14 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Invalid snapshot"
 	fi
 fi
 
 # Download user data
-restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/" --target "$tmpdir"
+restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/" --target "$tmpdir"
 if [ "$?" -ne 0 ]; then
 	check_result "$E_NOTEXIST" "Unable to download user data"
 fi
@@ -81,7 +81,7 @@ if [ -n "$cron" ]; then
 fi
 if [ "$udir" = "yes" ]; then
 	echo "[ * ] Restore user files"
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --exclude "/home/$user/web/" --exclude "/home/$user/conf" --exclude "/home/$user/mail" --target /
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --exclude "/home/$user/web/" --exclude "/home/$user/conf" --exclude "/home/$user/mail" --target /
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download user folders"
 	fi

--- a/bin/v-restore-web-domain-restic
+++ b/bin/v-restore-web-domain-restic
@@ -54,12 +54,12 @@ source_conf $HESTIA/conf/restic.conf
 
 tmpdir=$(mktemp -p /home/$user/tmp/ -d)
 if [ ! -f "$tmpdir/backup.conf" ]; then
-	restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
+	restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/backup.conf" > "$tmpdir/backup.conf"
 	if [ "$?" -ne 0 ]; then
 		check_result "$E_NOTEXIST" "Unable to download from snapshot"
 	fi
 fi
-restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/pam/passwd" > "$tmpdir/passwd"
+restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" dump "$snapshot" "/home/$user/backup/pam/passwd" > "$tmpdir/passwd"
 old_uid=$(cut -f 3 -d : $tmpdir/passwd)
 
 domains=""
@@ -84,7 +84,7 @@ for domain in $domains; do
 				check_result "$E_PARSING" "$error"
 			fi
 		fi
-		restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/web/$domain" --target "$tmpdir"
+		restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/backup/web/$domain" --target "$tmpdir"
 		if [ "$?" -ne 0 ]; then
 			check_result $E_NOTEXIST "Unable to download domain from snapshot"
 		fi
@@ -209,7 +209,7 @@ for domain in $domains; do
 
 		[[ -d $HOMEDIR/$user/web/$domain/stats ]] && chmod u+w "$HOMEDIR/$user/web/$domain/stats"
 
-		restic --repo "$REPO$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/web/$domain" --target /
+		restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" restore "$snapshot" --include "/home/$user/web/$domain" --target /
 		if [ "$?" -ne 0 ]; then
 			check_result "$E_NOTEXIST" "Unable to download user data"
 		fi


### PR DESCRIPTION
## What

The restic backup/restore scripts built the per-user repository path by directly concatenating `$REPO` and `$user` (`"$REPO$user"`). All 33 occurrences are now built as `"${REPO%/}/$user"`, and `v-add-backup-host-restic` strips any trailing slash before storing `REPO`.

## Why

When the configured `REPO` has no trailing slash, `"$REPO$user"` produces a malformed path — e.g. `rclone:target:/folderuser` instead of `rclone:target:/folder/user` — so each user's snapshots land in the wrong repository, or restic fails to find them. The docs example happens to use a trailing slash, which masks the bug for some setups but not others. `${REPO%/}/` normalizes both forms, so existing `restic.conf` files keep working without any rewrite.

## Affected scripts

- Path fix (`"$REPO$user"` → `"${REPO%/}/$user"`): `v-backup-user-restic`, `v-delete-user-backup-restic`, `v-list-user-backup-restic`, `v-list-user-backups-restic`, `v-list-user-files-restic`, `v-restore-cron-job-restic`, `v-restore-database-restic`, `v-restore-dns-domain-restic`, `v-restore-file-restic`, `v-restore-mail-domain-restic`, `v-restore-user-full-restic`, `v-restore-user-restic`, `v-restore-web-domain-restic`
- Add-time normalization: `v-add-backup-host-restic`

## Manual test steps

1. `v-add-backup-host-restic '/backup/restic' 30 8 5 3 -1` (note: **no** trailing slash) and confirm `conf/restic.conf` stores `REPO='/backup/restic'`.
2. `v-backup-user-restic <user>` and confirm the repo initializes at `/backup/restic/<user>` (previously `/backup/restic<user>`).
3. `v-list-user-backups-restic <user>` lists the snapshot, and `v-restore-user-restic <user> <snapshot>` restores successfully.
4. Repeat with a trailing-slash host (`'/backup/restic/'`) and confirm the same `/backup/restic/<user>` path — no regression for existing configs.

Fixes #5100
