### PR TITLE
fix: readable file manager upload popup in dark theme (#5095)

### DIFF
--- a/install/deb/filemanager/filegator/dist/css/hst-custom.css
+++ b/install/deb/filemanager/filegator/dist/css/hst-custom.css
@@ -332,3 +332,15 @@ pre[class*="language-"]::selection,
 pre[class*="language-"] ::selection {
 	background: #3a3a3a !important;
 }
+
+/* ------------------------------ */
+
+/*        Upload popup         */
+
+/* ------------------------------ */
+
+@media (prefers-color-scheme: dark) {
+	.progress-box .box {
+		color: #fff !important;
+	}
+}


### PR DESCRIPTION
### What

Makes the File Manager (FileGator) upload popup text readable when the browser/OS is in dark mode by forcing white text on the popup's dark box.

### Why

FileGator's dark theme sets the `.box` background to a dark surface color (`#282828`) but does not add `.box` to its `color: var(--color-text)` list, so the upload progress popup (`.progress-box > .box`) keeps Bulma's default dark-gray text (`#4a4a4a`) on a dark background — effectively unreadable (see screenshot in #5095). The fix layers a scoped white-text rule onto Hestia's existing `hst-custom.css` override, using the same `@media (prefers-color-scheme: dark)` mechanism every other dark-mode rule in that file already uses. It's scoped to `.progress-box .box` so only the reported popup is affected.

### How to test

1. Set your OS/browser to dark mode (macOS: System Settings → Appearance → Dark; or Chrome DevTools → Rendering → "Emulate CSS prefers-color-scheme: dark").
2. In Hestia, open **Files** (the File Manager) for any account.
3. Click **Upload** and add a file (or drag-and-drop). The upload progress popup appears docked at the bottom of the screen.
4. Before this change: the filename and "Uploading files / Done / N successful…" text is dark-on-dark and unreadable. After: the text is white and clearly legible. Verify light mode is unchanged.

Fixes #5095
