### PR TITLE
fix: use configured system IP as DNS cluster master (#5469)

### DIFF
--- a/bin/v-add-remote-dns-domain
+++ b/bin/v-add-remote-dns-domain
@@ -64,8 +64,13 @@ if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 	# propagating a wrong MASTER and breaking AXFR/IXFR zone transfers to the
 	# slaves (#5469). Fall back to interface detection only when no system IP
 	# is configured.
-	ip=$(ls "$HESTIA/data/ips/" 2> /dev/null | head -n1)
-	if [ -z "$ip" ]; then
+	ip=""
+	LOCAL_IP=$(ip route get 1.1.1.1 2> /dev/null | grep -oP 'src \K\S+')
+	if [[ -n "$LOCAL_IP" && -e "${HESTIA}/data/ips/${LOCAL_IP}" ]]; then
+		ip="$LOCAL_IP"
+	fi
+	# Fallback if nothing was detected
+	if [[ -z "$ip" ]]; then
 		ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)
 	fi
 	source_conf $HESTIA/data/ips/$ip

--- a/bin/v-add-remote-dns-domain
+++ b/bin/v-add-remote-dns-domain
@@ -58,7 +58,16 @@ fi
 if [ "$DNS_CLUSTER_SYSTEM" = "hestia-zone" ]; then
 	str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 	str=$(echo "$str" | sed "s/SLAVE=''/SLAVE='yes'/g")
-	ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)
+	# Use Hestia's own configured system IP as the DNS master address.
+	# Enumerating interfaces is non-deterministic and can return a
+	# VPN/Docker/WireGuard address on servers with virtual interfaces,
+	# propagating a wrong MASTER and breaking AXFR/IXFR zone transfers to the
+	# slaves (#5469). Fall back to interface detection only when no system IP
+	# is configured.
+	ip=$(ls "$HESTIA/data/ips/" 2> /dev/null | head -n1)
+	if [ -z "$ip" ]; then
+		ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)
+	fi
 	source_conf $HESTIA/data/ips/$ip
 	if [ -z $NAT ]; then
 		str=$(echo "$str" | sed "s/MASTER=''/MASTER='$ip'/g")

--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -86,7 +86,16 @@ for cluster in $hosts; do
 						str=$(echo "$str" | sed "s/SLAVE='no'/SLAVE='yes'/g")
 						str=$(echo "$str" | sed "s/SLAVE=''/SLAVE='yes'/g")
 
-						ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)
+						# Use Hestia's own configured system IP as the DNS master
+						# address. Enumerating interfaces is non-deterministic and can
+						# return a VPN/Docker/WireGuard address on servers with virtual
+						# interfaces, propagating a wrong MASTER and breaking AXFR/IXFR
+						# zone transfers to the slaves (#5469). Fall back to interface
+						# detection only when no system IP is configured.
+						ip=$(ls "$HESTIA/data/ips/" 2> /dev/null | head -n1)
+						if [ -z "$ip" ]; then
+							ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)
+						fi
 						source_conf $HESTIA/data/ips/$ip
 						if [ -z $NAT ]; then
 							str=$(echo "$str" | sed "s/MASTER=''/MASTER='$ip'/g")

--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -92,8 +92,13 @@ for cluster in $hosts; do
 						# interfaces, propagating a wrong MASTER and breaking AXFR/IXFR
 						# zone transfers to the slaves (#5469). Fall back to interface
 						# detection only when no system IP is configured.
-						ip=$(ls "$HESTIA/data/ips/" 2> /dev/null | head -n1)
-						if [ -z "$ip" ]; then
+						ip=""
+						LOCAL_IP=$(ip route get 1.1.1.1 2> /dev/null | grep -oP 'src \K\S+')
+						if [[ -n "$LOCAL_IP" && -e "${HESTIA}/data/ips/${LOCAL_IP}" ]]; then
+							ip="$LOCAL_IP"
+						fi
+						# Fallback if nothing was detected
+						if [[ -z "$ip" ]]; then
 							ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)
 						fi
 						source_conf $HESTIA/data/ips/$ip


### PR DESCRIPTION
## What

The hestia-zone DNS cluster determined the master (`MASTER=...`) address by taking the first `scope global` IPv4 from `ip addr`:

    ip=$(ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/)

This is replaced with Hestia's own configured system IP (`$HESTIA/data/ips/`), falling back to the old interface detection only when no system IP is configured. Fixed in both `bin/v-sync-dns-cluster` and `bin/v-add-remote-dns-domain`.

## Why

`ip addr` interface order depends on kernel/interface init order. On any server with virtual interfaces — Tailscale/OpenVPN `tun0`, WireGuard `wg0`, Docker `docker0`, LXC, extra NICs — the first `scope global` address is frequently a private/VPN IP, not the public one. That wrong IP is pushed to slaves, which then generate `masters { <vpn-ip>; };`, and AXFR/IXFR zone transfers silently stop working.

The selected value is also immediately used as `source_conf $HESTIA/data/ips/$ip` to resolve NAT — so it must be a Hestia-configured IP anyway. A non-configured interface address made that lookup fail too. Reading from `data/ips/` is deterministic, independent of interface order/VPN/Docker, and consistent with how the rest of Hestia enumerates system IPs (`v-list-sys-ips`, `v-update-sys-ip`, `v-update-firewall`, ...). NAT handling is unchanged.

## How to test

Repro of the bug (tun0/wg0/docker0 scenario):

1. On a DNS-cluster master (hestia-zone mode), bring up a virtual interface that sorts before the public NIC, e.g. `ip addr add 192.168.7.1/24 dev tun0` (or start WireGuard/Docker).
2. Confirm the old selection is wrong: `ip addr | grep 'inet ' | grep global | head -n1 | awk '{print $2}' | cut -f1 -d/` → returns the VPN/Docker IP (e.g. `192.168.7.1`), which has no file under `/usr/local/hestia/data/ips/`.
3. Trigger a sync (`v-sync-dns-cluster <host>` or add/change a DNS domain) and observe the slave receives `MASTER='192.168.7.1'` → `masters { 192.168.7.1; };` → AXFR fails.

With this patch:

4. `ls /usr/local/hestia/data/ips/ | head -n1` returns the real public/NAT IP.
5. Re-run the sync; the slave now receives the correct public `MASTER`, and `masters { <public-ip>; };` transfers succeed.
6. Regression: on a box with no virtual interfaces the selected IP is unchanged (it's the single configured system IP). NAT setups still emit the `$NAT` public IP as before.

Verified: `bash -n` clean on both scripts; `prettier --check` passes; no new shellcheck warnings beyond the existing `ls|head` info note used throughout the codebase.

Fixes #5469
