### PR TITLE
Adds cross-architecture and multi-OS package building

### DIFF
--- a/docs/docs/contributing/building.md
+++ b/docs/docs/contributing/building.md
@@ -89,12 +89,10 @@ apt install -f
 
 ## Building for other architectures or OS releases on the same machine
 
-`hst_autocompile.sh` only ever builds for the environment it's actually running in (its own `--cross` flag just makes the architecture-independent `hestia` package build for both AMD64 and ARM64 directly, with no emulation needed). To also build `hestia-nginx`, `hestia-php` or `hestia-web-terminal` (which contain compiled native code) for **other** architectures or OS releases on the same machine, use `chroot_build_all.sh` instead — it spins up the other environments and runs the unmodified `hst_autocompile.sh` inside each one.
-
-Pass `--all-os` to build for every supported OS release (Debian 12/13, Ubuntu 22.04/24.04/26.04) on both architectures — up to 10 combinations from one invocation:
+`hst_autocompile.sh` only ever builds for the environment it's actually running in (its own `--cross` flag just makes the architecture-independent `hestia` package build for both AMD64 and ARM64 directly, with no emulation needed). To also build `hestia-nginx`, `hestia-php` or `hestia-web-terminal` (which contain compiled native code) for **other** architectures or OS releases on the same machine, use `chroot_build_all.sh` instead — it spins up and runs the unmodified `hst_autocompile.sh` inside each one.
 
 ```bash
-./chroot_build_all.sh --all --all-os '~localsrc'
+./chroot_build_all.sh --all '~localsrc'
 ```
 
-Every combination is built inside a QEMU-emulated chroot (debootstrap + `qemu-user-static`). The first run downloads/bootstraps a minimal root filesystem per combination under `/var/lib/hestiacp-build-chroot/<distro>-<release>-<arch>`; subsequent runs reuse it, so only the first build of a given combination is slow. `--all-os` always covers both architectures.
+Every combination is built inside a QEMU-emulated chroot (debootstrap + `qemu-user-static`). The first run downloads/bootstraps a minimal root filesystem per combination under `/var/lib/hestiacp-build-chroot/<distro>-<release>-<arch>`; subsequent runs reuse it, so only the first build of a given combination is slow.

--- a/docs/docs/contributing/building.md
+++ b/docs/docs/contributing/building.md
@@ -91,25 +91,10 @@ apt install -f
 
 `hst_autocompile.sh` only ever builds for the environment it's actually running in (its own `--cross` flag just makes the architecture-independent `hestia` package build for both AMD64 and ARM64 directly, with no emulation needed). To also build `hestia-nginx`, `hestia-php` or `hestia-web-terminal` (which contain compiled native code) for **other** architectures or OS releases on the same machine, use `chroot_build_all.sh` instead — it spins up the other environments and runs the unmodified `hst_autocompile.sh` inside each one.
 
-Pass `--cross` to also build for the other architecture (AMD64<->ARM64), same OS release as the host:
-
-```bash
-./chroot_build_all.sh --all --noinstall --keepbuild --cross '~localsrc'
-```
-
 Pass `--all-os` to build for every supported OS release (Debian 12/13, Ubuntu 22.04/24.04/26.04) on both architectures — up to 10 combinations from one invocation:
 
 ```bash
-./chroot_build_all.sh --all --noinstall --keepbuild --all-os '~localsrc'
+./chroot_build_all.sh --all --all-os '~localsrc'
 ```
 
-In both cases, the combination matching the host's own OS/release/architecture is built directly; every other combination is built inside a QEMU-emulated chroot (debootstrap + `qemu-user-static`). The first run downloads/bootstraps a minimal root filesystem per combination under `/var/lib/hestiacp-build-chroot/<distro>-<release>-<arch>`; subsequent runs reuse it, so only the first build of a given combination is slow. `--all-os` always covers both architectures, so combining it with `--cross` has no extra effect.
-
-Since a package can share the same name/version/arch across OS releases, `--all-os` writes each release's packages to their own subdirectory instead of the usual flat `deb/`:
-
-```text
-/tmp/hestiacp-src/deb/<release>/<package>_<version>_<arch>.deb
-# e.g.
-/tmp/hestiacp-src/deb/bookworm/hestia-nginx_1.2.3_amd64.deb
-/tmp/hestiacp-src/deb/noble/hestia-nginx_1.2.3_arm64.deb
-```
+Every combination is built inside a QEMU-emulated chroot (debootstrap + `qemu-user-static`). The first run downloads/bootstraps a minimal root filesystem per combination under `/var/lib/hestiacp-build-chroot/<distro>-<release>-<arch>`; subsequent runs reuse it, so only the first build of a given combination is slow. `--all-os` always covers both architectures.

--- a/docs/docs/contributing/building.md
+++ b/docs/docs/contributing/building.md
@@ -86,3 +86,30 @@ To solve this issue, run:
 ```bash
 apt install -f
 ```
+
+## Building for other architectures or OS releases on the same machine
+
+`hst_autocompile.sh` only ever builds for the environment it's actually running in (its own `--cross` flag just makes the architecture-independent `hestia` package build for both AMD64 and ARM64 directly, with no emulation needed). To also build `hestia-nginx`, `hestia-php` or `hestia-web-terminal` (which contain compiled native code) for **other** architectures or OS releases on the same machine, use `chroot_build_all.sh` instead — it spins up the other environments and runs the unmodified `hst_autocompile.sh` inside each one.
+
+Pass `--cross` to also build for the other architecture (AMD64<->ARM64), same OS release as the host:
+
+```bash
+./chroot_build_all.sh --all --noinstall --keepbuild --cross '~localsrc'
+```
+
+Pass `--all-os` to build for every supported OS release (Debian 12/13, Ubuntu 22.04/24.04/26.04) on both architectures — up to 10 combinations from one invocation:
+
+```bash
+./chroot_build_all.sh --all --noinstall --keepbuild --all-os '~localsrc'
+```
+
+In both cases, the combination matching the host's own OS/release/architecture is built directly; every other combination is built inside a QEMU-emulated chroot (debootstrap + `qemu-user-static`). The first run downloads/bootstraps a minimal root filesystem per combination under `/var/lib/hestiacp-build-chroot/<distro>-<release>-<arch>`; subsequent runs reuse it, so only the first build of a given combination is slow. `--all-os` always covers both architectures, so combining it with `--cross` has no extra effect.
+
+Since a package can share the same name/version/arch across OS releases, `--all-os` writes each release's packages to their own subdirectory instead of the usual flat `deb/`:
+
+```text
+/tmp/hestiacp-src/deb/<release>/<package>_<version>_<arch>.deb
+# e.g.
+/tmp/hestiacp-src/deb/bookworm/hestia-nginx_1.2.3_amd64.deb
+/tmp/hestiacp-src/deb/noble/hestia-nginx_1.2.3_arm64.deb
+```

--- a/src/chroot_build_all.sh
+++ b/src/chroot_build_all.sh
@@ -24,8 +24,6 @@ BUILD_DIR="${BUILD_DIR:-/tmp/hestiacp-src}"
 CHROOT_BASE_DIR='/var/lib/hestiacp-build-chroot'
 ACTIVE_CHROOTS=()
 
-# 	"debian bookworm"
-#	"debian trixie"
 # Supported OS releases for --all-os, as "distro codename" pairs.
 ALLOS_DISTRO_RELEASES=(
 
@@ -53,18 +51,26 @@ usage() {
 	echo "    --php           Build only the backend php engine package"
 	echo "    --web-terminal  Build only the backend web terminal websocket package"
 	echo "  Options:"
-	echo "    --cross         Also build for the other architecture (AMD64<->ARM64),"
-	echo "                    same OS as the host. nginx/php/web-terminal are built"
-	echo "                    for the other arch inside a QEMU-emulated chroot."
 	echo "    --all-os        Build for every supported OS release (Debian 12/13,"
 	echo "                    Ubuntu 22.04/24.04/26.04) and both architectures, using"
 	echo "                    a QEMU-emulated chroot for every combination other than"
-	echo "                    the host's own. Implies --cross."
+	echo "                    the host's own."
 	echo "    --install       Install the packages built for the host's own OS/arch"
 	echo "    --noinstall     Don't install (default)"
 	echo "    --keepbuild     Don't delete downloaded source and build folders"
 	echo "    --debug         Debug mode"
-	echo "    --dontinstalldeps  Skip installing build dependencies"
+	echo "    --pkgrev <n>    Set the package revision number (default: 1)."
+	echo "                    Replaces the '-1' in the version suffix"
+	echo "                    (e.g. --pkgrev 2 → 1.0.0-2+deb12)."
+	echo "    --release <id>  Set a release identifier appended to the package version"
+	echo "                    as '~<id>' (e.g. --release myci1 → 1.0.0-1+deb12~myci1)."
+	echo "                    Useful to distinguish custom or CI builds from official ones."
+	echo "                    If the hestia control file's Version already has a '~<tag>'"
+	echo "                    suffix (e.g. 1.1.0~alpha) and --release is NOT given, that"
+	echo "                    detected tag (e.g. 'alpha') is used automatically as the"
+	echo "                    release identifier for ALL packages. If --release IS given,"
+	echo "                    it overrides/replaces the detected '~<tag>' suffix instead."
+	echo "                    Can be combined: --pkgrev 2 --release myci1 → 1.0.0-2+deb12~myci1."
 	echo ""
 	echo "Example: ./chroot_build_all.sh --all --all-os --noinstall --keepbuild '~localsrc'"
 }
@@ -345,24 +351,19 @@ for i in "$@"; do
 		--debug)
 			HESTIA_DEBUG='true'
 			;;
-		--install | Y)
-			install='true'
-			;;
-		--noinstall | N)
-			install='false'
-			;;
-		--keepbuild)
-			KEEPBUILD='true'
-			;;
-		--cross)
-			CROSS='true'
-			;;
 		--all-os)
 			ALL_OS='true'
 			;;
-		--dontinstalldeps)
-			dontinstalldeps='true'
+
+		--release)
+			shift
+			release_tag="$1"
 			;;
+		--pkgrev)
+			shift
+			pkg_rev="$1"
+			;;
+
 		--help | -h)
 			usage
 			exit 1
@@ -391,7 +392,7 @@ HOST_RELEASE=$(lsb_release -sc)
 # own, since packages can share the same name/version/arch across releases.
 NATIVE_DEB_DIR=""
 if [ "$ALL_OS" = "true" ]; then
-	NATIVE_DEB_DIR="$BUILD_DIR/deb/$HOST_RELEASE"
+	NATIVE_DEB_DIR="$BUILD_DIR/deb/"
 	mkdir -p "$NATIVE_DEB_DIR"
 fi
 
@@ -401,27 +402,12 @@ NATIVE_FLAGS=""
 [ "$NGINX_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --nginx"
 [ "$PHP_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --php"
 [ "$WEB_TERMINAL_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --web-terminal"
-# hestia has no native code, so it's cheap to let hst_autocompile.sh's own
-# --cross loop build it for both archs directly, without needing a chroot.
-# Skip that on --all-os though: each OS in the matrix rebuilds hestia itself.
-[ "$CROSS" = "true" ] && [ "$ALL_OS" != "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --cross"
 [ "$HESTIA_DEBUG" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --debug"
 [ "$KEEPBUILD" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --keepbuild"
-[ "$dontinstalldeps" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --dontinstalldeps"
 if [ "$install" = "true" ]; then
 	NATIVE_FLAGS="$NATIVE_FLAGS --install"
 else
 	NATIVE_FLAGS="$NATIVE_FLAGS --noinstall"
-fi
-
-if [ -n "$NATIVE_DEB_DIR" ]; then
-	DEB_DIR="$NATIVE_DEB_DIR" "$__DIR__/hst_autocompile.sh" $NATIVE_FLAGS "$branch"
-else
-	"$__DIR__/hst_autocompile.sh" $NATIVE_FLAGS "$branch"
-fi
-if [ $? -ne 0 ]; then
-	echo >&2 "[!] Native build for the host's own OS/arch failed"
-	exit 1
 fi
 
 # Build every other (distro, release, arch) combination via chroot.
@@ -452,9 +438,6 @@ if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
 			distro="${dr%% *}"
 			release="${dr#* }"
 			for a in amd64 arm64; do
-				if [ "$distro" = "$HOST_DISTRO" ] && [ "$release" = "$HOST_RELEASE" ] && [ "$a" = "$HOST_ARCH" ]; then
-					continue
-				fi
 				TARGET_COMBOS+=("$distro:$release:$a")
 			done
 		done
@@ -471,6 +454,20 @@ if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
 		rest="${combo#*:}"
 		release="${rest%%:*}"
 		target_arch="${rest#*:}"
-		run_cross_build "$distro" "$release" "$target_arch" $PKG_FLAGS "$branch"
+		run_cross_build "$distro" "$release" "$target_arch" $PKG_FLAGS $release_tag $pkg_rev "$branch"
+	done
+fi
+
+# When done move all build packages located in /tmp/hestiacp-src-{os}-{release}-{arch}/deb to /tmp/hestiacp-src/deb/ to have all packages in one place
+if [ "$ALL_OS" = "true" ]; then
+	for dr in "${ALLOS_DISTRO_RELEASES[@]}"; do
+		distro="${dr%% *}"
+		release="${dr#* }"
+		for a in amd64 arm64; do
+			src_deb_dir="${BUILD_DIR}-${distro}-${release}-${a}/deb"
+			if [ -d "$src_deb_dir" ]; then
+				mv "$src_deb_dir"/* "$NATIVE_DEB_DIR"
+			fi
+		done
 	done
 fi

--- a/src/chroot_build_all.sh
+++ b/src/chroot_build_all.sh
@@ -1,0 +1,476 @@
+#!/bin/bash
+
+#
+# Orchestrates cross-architecture (--cross) and multi-OS (--all-os) builds of
+# Hestia packages on a single machine. hst_autocompile.sh only ever builds for
+# the environment it's actually running in; this script is what spins up the
+# *other* environments needed for --cross/--all-os, using QEMU-emulated
+# chroots (debootstrap + qemu-user-static), and runs the unmodified
+# hst_autocompile.sh inside each one. The combination matching the host's own
+# OS/release/architecture is built directly, no chroot needed.
+#
+# Usage:
+#   ./chroot_build_all.sh (--all|--hestia|--nginx|--php|--web-terminal) \
+#       (--cross|--all-os) [--install|--noinstall] [--keepbuild] [--debug] [branch]
+#
+# Examples:
+#   ./chroot_build_all.sh --all --cross --noinstall --keepbuild '~localsrc'
+#   ./chroot_build_all.sh --all --all-os --noinstall --keepbuild '~localsrc'
+#
+
+__DIR__="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_DIR="$(cd "$__DIR__/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-/tmp/hestiacp-src}"
+CHROOT_BASE_DIR='/var/lib/hestiacp-build-chroot'
+ACTIVE_CHROOTS=()
+
+# 	"debian bookworm"
+#	"debian trixie"
+# Supported OS releases for --all-os, as "distro codename" pairs.
+ALLOS_DISTRO_RELEASES=(
+
+	"debian bookworm"
+	"debian trixie"
+	"ubuntu jammy"
+	"ubuntu noble"
+	"ubuntu resolute"
+)
+
+architecture="$(arch)"
+if [ "$architecture" = 'aarch64' ]; then
+	HOST_ARCH='arm64'
+else
+	HOST_ARCH='amd64'
+fi
+
+usage() {
+	echo "Usage:"
+	echo "    $0 (--all|--hestia|--nginx|--php|--web-terminal) (--cross|--all-os) [options] [branch]"
+	echo ""
+	echo "    --all           Build all hestia packages."
+	echo "    --hestia        Build only the Control Panel package."
+	echo "    --nginx         Build only the backend nginx engine package."
+	echo "    --php           Build only the backend php engine package"
+	echo "    --web-terminal  Build only the backend web terminal websocket package"
+	echo "  Options:"
+	echo "    --cross         Also build for the other architecture (AMD64<->ARM64),"
+	echo "                    same OS as the host. nginx/php/web-terminal are built"
+	echo "                    for the other arch inside a QEMU-emulated chroot."
+	echo "    --all-os        Build for every supported OS release (Debian 12/13,"
+	echo "                    Ubuntu 22.04/24.04/26.04) and both architectures, using"
+	echo "                    a QEMU-emulated chroot for every combination other than"
+	echo "                    the host's own. Implies --cross."
+	echo "    --install       Install the packages built for the host's own OS/arch"
+	echo "    --noinstall     Don't install (default)"
+	echo "    --keepbuild     Don't delete downloaded source and build folders"
+	echo "    --debug         Debug mode"
+	echo "    --dontinstalldeps  Skip installing build dependencies"
+	echo ""
+	echo "Example: ./chroot_build_all.sh --all --all-os --noinstall --keepbuild '~localsrc'"
+}
+
+qemu_static_name() {
+	case "$1" in
+		arm64) echo "qemu-aarch64-static" ;;
+		amd64) echo "qemu-x86_64-static" ;;
+	esac
+}
+
+# Best-effort unmount of a single path, falling back to a lazy unmount if a
+# plain umount fails (e.g. the mount is still busy). A path left mounted here
+# isn't just a leak: callers immediately rm -rf the chroot dir afterwards, and
+# files under a still-active bind mount of /proc, /sys or /dev can't be
+# unlinked at all (sysfs/procfs refuse it outright, even as root) -- so a
+# silently-failed umount turns into confusing "Operation not permitted" rm
+# errors instead.
+safe_umount() {
+	local path=$1
+	mountpoint -q "$path" || return 0
+	umount "$path" 2> /dev/null && return 0
+	umount -l "$path" 2> /dev/null
+	mountpoint -q "$path" && return 1
+	return 0
+}
+
+# Unmount everything prepare_chroot may have bind-mounted under a given
+# chroot dir. Order matters: children (dev/pts, the bind mounts) before
+# their parents (dev).
+unmount_chroot_dir() {
+	local chroot_dir=$1
+	safe_umount "$chroot_dir$REPO_DIR"
+	safe_umount "$chroot_dir$BUILD_DIR"
+	safe_umount "$chroot_dir/dev/pts"
+	safe_umount "$chroot_dir/sys"
+	safe_umount "$chroot_dir/proc"
+	safe_umount "$chroot_dir/dev"
+}
+
+cleanup_chroots() {
+	local chroot_dir
+	for chroot_dir in "${ACTIVE_CHROOTS[@]}"; do
+		unmount_chroot_dir "$chroot_dir"
+	done
+}
+trap cleanup_chroots EXIT
+
+# One-time setup of the host tools needed for any chroot build.
+ensure_cross_build_deps() {
+	[ "$CROSS_DEPS_READY" = "true" ] && return
+	echo >&2 "Installing debootstrap/qemu-user-static for cross/multi-OS builds..."
+	apt-get -qq update > /dev/null 2>&1
+	apt-get -qq install -y debootstrap qemu-user-static binfmt-support > /dev/null 2>&1
+	CROSS_DEPS_READY='true'
+}
+
+# Make sure binaries for $target_arch actually get routed through QEMU.
+# "systemctl restart systemd-binfmt" (the usual way qemu-user-static's
+# registration gets activated) silently does nothing on hosts without
+# systemd as PID 1, e.g. inside a container — so register directly via
+# update-binfmt and verify it actually took, instead of finding out much
+# later via a cryptic "Exec format error" deep inside debootstrap.
+register_binfmt() {
+	local target_arch=$1
+	[ "$target_arch" = "$HOST_ARCH" ] && return
+
+	local binfmt_name
+	case "$target_arch" in
+		arm64) binfmt_name="qemu-aarch64" ;;
+		amd64) binfmt_name="qemu-x86_64" ;;
+	esac
+
+	if [ ! -d /proc/sys/fs/binfmt_misc ]; then
+		mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc >&2
+	fi
+
+	if [ ! -e "/proc/sys/fs/binfmt_misc/$binfmt_name" ]; then
+		update-binfmt --enable "$binfmt_name" >&2
+	fi
+
+	if [ ! -e "/proc/sys/fs/binfmt_misc/$binfmt_name" ]; then
+		echo >&2 "[!] Could not register binfmt_misc handler '$binfmt_name' for $target_arch."
+		echo >&2 "    This host/container can't run foreign-architecture binaries via"
+		echo >&2 "    QEMU. If you're inside an LXC container (e.g. on Proxmox), this is"
+		echo >&2 "    a host-level kernel facility that unprivileged containers normally"
+		echo >&2 "    can't register themselves — either make the container privileged,"
+		echo >&2 "    register '$binfmt_name' on the Proxmox host instead (it'll then be"
+		echo >&2 "    inherited by containers automatically), or run this in a VM instead"
+		echo >&2 "    of an LXC container."
+		exit 1
+	fi
+}
+
+# Sets the global PREPARED_CHROOT_DIR instead of echoing the path back,
+# since callers must NOT invoke this via "x=$(prepare_chroot ...)" — that
+# forks a subshell, which would (a) swallow this function's "exit 1" on
+# failure instead of stopping the script, and (b) silently drop the
+# ACTIVE_CHROOTS append below, since it'd only exist in the subshell's copy.
+prepare_chroot() {
+	local distro=$1
+	local release=$2
+	local target_arch=$3
+	local chroot_dir="$CHROOT_BASE_DIR/$distro-$release-$target_arch"
+	PREPARED_CHROOT_DIR="$chroot_dir"
+
+	ensure_cross_build_deps
+	register_binfmt "$target_arch"
+
+	# Use our own marker rather than e.g. "-d $chroot_dir/usr" to decide
+	# whether bootstrapping is done: a chroot left behind by a failed stage-2
+	# run already has /usr populated but is not actually usable.
+	if [ ! -f "$chroot_dir/.hestiacp-chroot-ready" ]; then
+		echo >&2 "Bootstrapping $distro/$release/$target_arch chroot at $chroot_dir (first run only, this can take a while)..."
+		# A previous run may have left this mounted (e.g. an interrupted
+		# build, or an older version of this script); rm -rf can't remove
+		# anything under an active mountpoint.
+		unmount_chroot_dir "$chroot_dir"
+		if mountpoint -q "$chroot_dir/dev" || mountpoint -q "$chroot_dir/proc" || mountpoint -q "$chroot_dir/sys"; then
+			echo >&2 "[!] Could not unmount stale bind mounts under $chroot_dir; refusing to"
+			echo >&2 "    delete it, since rm -rf would hit a live /dev, /proc or /sys and fail"
+			echo >&2 "    with confusing 'Operation not permitted' errors. Unmount it manually"
+			echo >&2 "    (e.g. umount -l $chroot_dir/sys) and re-run."
+			exit 1
+		fi
+		rm -rf "$chroot_dir"
+		mkdir -p "$chroot_dir"
+		local mirror
+		local components_opt=""
+		case "$distro" in
+			ubuntu)
+				if [ "$target_arch" = "amd64" ]; then
+					mirror="http://archive.ubuntu.com/ubuntu"
+				else
+					mirror="http://ports.ubuntu.com/ubuntu-ports"
+				fi
+				# Unlike Debian, Ubuntu splits a lot of common -dev packages
+				# (e.g. libzip-dev) out of "main" into "universe". debootstrap
+				# only enables "main" by default, both for what it can pull
+				# during bootstrap and for the sources.list it writes out —
+				# so without this, later apt-get installs for those packages
+				# fail with "Unable to locate package".
+				components_opt="--components=main,universe,restricted,multiverse"
+				;;
+			*)
+				mirror="http://deb.debian.org/debian"
+				;;
+		esac
+
+		if [ "$target_arch" != "$HOST_ARCH" ]; then
+			# Foreign arch: debootstrap's second stage execs target-arch
+			# binaries (dpkg, postinsts, ...) to finish unpacking, which only
+			# works once the qemu interpreter is in place inside the chroot.
+			# So do this as two stages: unpack packages (--foreign), drop in
+			# qemu-*-static, then run the second stage via chroot.
+			debootstrap --foreign $components_opt --arch="$target_arch" "$release" "$chroot_dir" "$mirror" >&2
+			if [ $? -ne 0 ]; then
+				echo >&2 "[!] Failed to bootstrap (stage 1) $distro/$release/$target_arch chroot"
+				exit 1
+			fi
+
+			local qemu_bin
+			qemu_bin=$(qemu_static_name "$target_arch")
+			mkdir -p "$chroot_dir/usr/bin"
+			cp -f "/usr/bin/$qemu_bin" "$chroot_dir/usr/bin/"
+
+			chroot "$chroot_dir" /debootstrap/debootstrap --second-stage >&2
+			if [ $? -ne 0 ]; then
+				echo >&2 "[!] Failed to bootstrap (stage 2) $distro/$release/$target_arch chroot"
+				exit 1
+			fi
+		else
+			debootstrap $components_opt --arch="$target_arch" "$release" "$chroot_dir" "$mirror" >&2
+			if [ $? -ne 0 ]; then
+				echo >&2 "[!] Failed to bootstrap $distro/$release/$target_arch chroot"
+				exit 1
+			fi
+		fi
+
+		touch "$chroot_dir/.hestiacp-chroot-ready"
+	fi
+
+	if [ "$target_arch" != "$HOST_ARCH" ]; then
+		local qemu_bin
+		qemu_bin=$(qemu_static_name "$target_arch")
+		mkdir -p "$chroot_dir/usr/bin"
+		cp -f "/usr/bin/$qemu_bin" "$chroot_dir/usr/bin/"
+	fi
+
+	mkdir -p "$chroot_dir/dev" "$chroot_dir/proc" "$chroot_dir/sys" "$chroot_dir/dev/pts"
+	mountpoint -q "$chroot_dir/dev" || mount --bind /dev "$chroot_dir/dev"
+	mountpoint -q "$chroot_dir/dev/pts" || mount --bind /dev/pts "$chroot_dir/dev/pts"
+	mountpoint -q "$chroot_dir/proc" || mount --bind /proc "$chroot_dir/proc"
+	mountpoint -q "$chroot_dir/sys" || mount --bind /sys "$chroot_dir/sys"
+
+	# Each combo gets its own host-side build directory bind-mounted onto the
+	# same in-chroot path ($BUILD_DIR, e.g. /tmp/hestiacp-src). They must NOT
+	# share one physical directory: with --keepbuild forced on every chroot
+	# leg, a later combo would otherwise reuse an earlier combo's configured
+	# source tree (e.g. PHP's) as-is, including its already-built, wrong-
+	# arch/OS binaries that the build process then tries to execute itself.
+	local host_build_dir="${BUILD_DIR}-${distro}-${release}-${target_arch}"
+	mkdir -p "$host_build_dir" "$chroot_dir$BUILD_DIR" "$chroot_dir$REPO_DIR"
+	mountpoint -q "$chroot_dir$BUILD_DIR" || mount --bind "$host_build_dir" "$chroot_dir$BUILD_DIR"
+	mountpoint -q "$chroot_dir$REPO_DIR" || mount --bind "$REPO_DIR" "$chroot_dir$REPO_DIR"
+
+	# debootstrap doesn't populate a resolver config, so without this DNS
+	# resolution fails inside the chroot and apt-get update/install fail
+	# silently (errors get redirected away in hst_autocompile.sh), which then
+	# surfaces much later as confusing "command not found" errors. Refresh it
+	# on every prepare, not just first bootstrap, in case the host's own
+	# resolv.conf changed since (e.g. a new DHCP lease).
+	mkdir -p "$chroot_dir/etc"
+	cp -f /etc/resolv.conf "$chroot_dir/etc/resolv.conf"
+
+	ACTIVE_CHROOTS+=("$chroot_dir")
+}
+
+run_cross_build() {
+	local distro=$1
+	local release=$2
+	local target_arch=$3
+	shift 3
+	prepare_chroot "$distro" "$release" "$target_arch"
+	local chroot_dir="$PREPARED_CHROOT_DIR"
+
+	# This combo's build artifacts live under their own host_build_dir (see
+	# prepare_chroot), not the shared $BUILD_DIR — so DEB_DIR must always be
+	# pointed back at the shared location explicitly, or it'd default to
+	# host_build_dir/deb instead. With --all-os, give each OS release its own
+	# subdirectory there too, since packages can share the same
+	# name/version/arch across releases (codenames are unique across distros,
+	# so $release alone is enough, no need for a distro prefix).
+	local target_deb_dir="$BUILD_DIR/deb"
+	[ "$ALL_OS" = "true" ] && target_deb_dir="$target_deb_dir/$release"
+	mkdir -p "$target_deb_dir"
+	local deb_dir_export="export DEB_DIR='$target_deb_dir'; "
+
+	# /proc is bind-mounted from the host (see prepare_chroot), so
+	# hst_autocompile.sh's own cpu-core detection would see the host's full
+	# core count. Under QEMU user-mode emulation each cc1 process uses far
+	# more memory than native, so building with that many parallel jobs
+	# reliably triggers the OOM killer ("Killed signal terminated program
+	# cc1"). Force single-job compiles for foreign-arch (emulated) builds.
+	if [ "$target_arch" != "$HOST_ARCH" ]; then
+		deb_dir_export="${deb_dir_export}export NUM_CPUS=$(grep "^core id" /proc/cpuinfo | sort -u | wc -l); "
+	fi
+
+	echo "Cross-building $distro/$release/$target_arch inside $chroot_dir..."
+	chroot "$chroot_dir" /bin/bash -c "${deb_dir_export}cd '$REPO_DIR/src' && DEBIAN_FRONTEND=noninteractive ./hst_autocompile.sh $* --noinstall --keepbuild"
+	if [ $? -ne 0 ]; then
+		echo >&2 "[!] Cross build for $distro/$release/$target_arch failed"
+		exit 1
+	fi
+}
+
+# Set packages to compile
+for i in "$@"; do
+	case "$i" in
+		--all)
+			NGINX_B='true'
+			PHP_B='true'
+			WEB_TERMINAL_B='true'
+			HESTIA_B='true'
+			;;
+		--nginx)
+			NGINX_B='true'
+			;;
+		--php)
+			PHP_B='true'
+			;;
+		--web-terminal)
+			WEB_TERMINAL_B='true'
+			;;
+		--hestia)
+			HESTIA_B='true'
+			;;
+		--debug)
+			HESTIA_DEBUG='true'
+			;;
+		--install | Y)
+			install='true'
+			;;
+		--noinstall | N)
+			install='false'
+			;;
+		--keepbuild)
+			KEEPBUILD='true'
+			;;
+		--cross)
+			CROSS='true'
+			;;
+		--all-os)
+			ALL_OS='true'
+			;;
+		--dontinstalldeps)
+			dontinstalldeps='true'
+			;;
+		--help | -h)
+			usage
+			exit 1
+			;;
+		*)
+			branch="$i"
+			;;
+	esac
+done
+
+if [ $# -eq 0 ] || { [ "$CROSS" != "true" ] && [ "$ALL_OS" != "true" ]; }; then
+	usage
+	exit 1
+fi
+
+if [ -z "$branch" ]; then
+	echo -n "Please enter the name of the branch to build from (e.g. main): "
+	read -r branch
+fi
+
+HOST_DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+HOST_RELEASE=$(lsb_release -sc)
+
+# With --all-os, give every OS release its own deb output subdirectory
+# (release codenames don't collide across distros), including the host's
+# own, since packages can share the same name/version/arch across releases.
+NATIVE_DEB_DIR=""
+if [ "$ALL_OS" = "true" ]; then
+	NATIVE_DEB_DIR="$BUILD_DIR/deb/$HOST_RELEASE"
+	mkdir -p "$NATIVE_DEB_DIR"
+fi
+
+# Build for the host's own OS/release/architecture directly, no chroot needed.
+NATIVE_FLAGS=""
+[ "$HESTIA_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --hestia"
+[ "$NGINX_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --nginx"
+[ "$PHP_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --php"
+[ "$WEB_TERMINAL_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --web-terminal"
+# hestia has no native code, so it's cheap to let hst_autocompile.sh's own
+# --cross loop build it for both archs directly, without needing a chroot.
+# Skip that on --all-os though: each OS in the matrix rebuilds hestia itself.
+[ "$CROSS" = "true" ] && [ "$ALL_OS" != "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --cross"
+[ "$HESTIA_DEBUG" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --debug"
+[ "$KEEPBUILD" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --keepbuild"
+[ "$dontinstalldeps" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --dontinstalldeps"
+if [ "$install" = "true" ]; then
+	NATIVE_FLAGS="$NATIVE_FLAGS --install"
+else
+	NATIVE_FLAGS="$NATIVE_FLAGS --noinstall"
+fi
+
+if [ -n "$NATIVE_DEB_DIR" ]; then
+	DEB_DIR="$NATIVE_DEB_DIR" "$__DIR__/hst_autocompile.sh" $NATIVE_FLAGS "$branch"
+else
+	"$__DIR__/hst_autocompile.sh" $NATIVE_FLAGS "$branch"
+fi
+if [ $? -ne 0 ]; then
+	echo >&2 "[!] Native build for the host's own OS/arch failed"
+	exit 1
+fi
+
+# Build every other (distro, release, arch) combination via chroot.
+PKG_FLAGS=""
+NEEDS_CHROOT_BUILD='false'
+if [ "$HESTIA_B" = "true" ] && [ "$ALL_OS" = "true" ]; then
+	PKG_FLAGS="$PKG_FLAGS --hestia"
+	NEEDS_CHROOT_BUILD='true'
+fi
+if [ "$NGINX_B" = "true" ]; then
+	PKG_FLAGS="$PKG_FLAGS --nginx"
+	NEEDS_CHROOT_BUILD='true'
+fi
+if [ "$PHP_B" = "true" ]; then
+	PKG_FLAGS="$PKG_FLAGS --php"
+	NEEDS_CHROOT_BUILD='true'
+fi
+if [ "$WEB_TERMINAL_B" = "true" ]; then
+	PKG_FLAGS="$PKG_FLAGS --web-terminal"
+	NEEDS_CHROOT_BUILD='true'
+fi
+[ "$HESTIA_DEBUG" = "true" ] && PKG_FLAGS="$PKG_FLAGS --debug"
+
+if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
+	TARGET_COMBOS=()
+	if [ "$ALL_OS" = "true" ]; then
+		for dr in "${ALLOS_DISTRO_RELEASES[@]}"; do
+			distro="${dr%% *}"
+			release="${dr#* }"
+			for a in amd64 arm64; do
+				if [ "$distro" = "$HOST_DISTRO" ] && [ "$release" = "$HOST_RELEASE" ] && [ "$a" = "$HOST_ARCH" ]; then
+					continue
+				fi
+				TARGET_COMBOS+=("$distro:$release:$a")
+			done
+		done
+	else
+		if [ "$HOST_ARCH" = "amd64" ]; then
+			TARGET_COMBOS=("$HOST_DISTRO:$HOST_RELEASE:arm64")
+		else
+			TARGET_COMBOS=("$HOST_DISTRO:$HOST_RELEASE:amd64")
+		fi
+	fi
+
+	for combo in "${TARGET_COMBOS[@]}"; do
+		distro="${combo%%:*}"
+		rest="${combo#*:}"
+		release="${rest%%:*}"
+		target_arch="${rest#*:}"
+		run_cross_build "$distro" "$release" "$target_arch" $PKG_FLAGS "$branch"
+	done
+fi

--- a/src/chroot_build_all.sh
+++ b/src/chroot_build_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Orchestrates cross-architecture (--cross) and multi-OS (--all-os) builds of
+# Orchestrates cross-architecture multi-OS (--all-os) builds of
 # Hestia packages on a single machine. hst_autocompile.sh only ever builds for
 # the environment it's actually running in; this script is what spins up the
 # *other* environments needed for --cross/--all-os, using QEMU-emulated
@@ -11,11 +11,10 @@
 #
 # Usage:
 #   ./chroot_build_all.sh (--all|--hestia|--nginx|--php|--web-terminal) \
-#       (--cross|--all-os) [--install|--noinstall] [--keepbuild] [--debug] [branch]
+#   [--debug] [branch]
 #
 # Examples:
-#   ./chroot_build_all.sh --all --cross --noinstall --keepbuild '~localsrc'
-#   ./chroot_build_all.sh --all --all-os --noinstall --keepbuild '~localsrc'
+#   ./chroot_build_all.sh --all '~localsrc'
 #
 
 __DIR__="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
@@ -26,7 +25,7 @@ ACTIVE_CHROOTS=()
 
 # Supported OS releases for --all-os, as "distro codename" pairs.
 ALLOS_DISTRO_RELEASES=(
-
+	"debian bullseye"
 	"debian bookworm"
 	"debian trixie"
 	"ubuntu jammy"
@@ -43,7 +42,7 @@ fi
 
 usage() {
 	echo "Usage:"
-	echo "    $0 (--all|--hestia|--nginx|--php|--web-terminal) (--cross|--all-os) [options] [branch]"
+	echo "    $0 (--all|--hestia|--nginx|--php|--web-terminal) [--debug] [branch]"
 	echo ""
 	echo "    --all           Build all hestia packages."
 	echo "    --hestia        Build only the Control Panel package."
@@ -55,9 +54,6 @@ usage() {
 	echo "                    Ubuntu 22.04/24.04/26.04) and both architectures, using"
 	echo "                    a QEMU-emulated chroot for every combination other than"
 	echo "                    the host's own."
-	echo "    --install       Install the packages built for the host's own OS/arch"
-	echo "    --noinstall     Don't install (default)"
-	echo "    --keepbuild     Don't delete downloaded source and build folders"
 	echo "    --debug         Debug mode"
 	echo "    --pkgrev <n>    Set the package revision number (default: 1)."
 	echo "                    Replaces the '-1' in the version suffix"
@@ -72,7 +68,7 @@ usage() {
 	echo "                    it overrides/replaces the detected '~<tag>' suffix instead."
 	echo "                    Can be combined: --pkgrev 2 --release myci1 → 1.0.0-2+deb12~myci1."
 	echo ""
-	echo "Example: ./chroot_build_all.sh --all --all-os --noinstall --keepbuild '~localsrc'"
+	echo "Example: ./chroot_build_all.sh --all '~localsrc'"
 }
 
 qemu_static_name() {
@@ -348,7 +344,7 @@ run_cross_build() {
 	# This combo's build artifacts live under their own host_build_dir (see
 	# prepare_chroot), not the shared $BUILD_DIR — so DEB_DIR must always be
 	# pointed back at the shared location explicitly, or it'd default to
-	# host_build_dir/deb instead. With --all-os, give each OS release its own
+	# host_build_dir/deb instead. Give each OS release its own
 	# subdirectory there too, since packages can share the same
 	# name/version/arch across releases (codenames are unique across distros,
 	# so $release alone is enough, no need for a distro prefix).
@@ -372,6 +368,19 @@ run_cross_build() {
 		echo >&2 "[!] Cross build for $distro/$release/$target_arch failed"
 		exit 1
 	fi
+
+	# Unmount and drop this chroot's bind mounts as soon as its build is
+	# done, rather than leaving every combo mounted until the whole
+	# loop finishes: the private /dev tmpfs and (for foreign
+	# arches) the qemu-user interpreter emulating the target both hold real
+	# RAM, and that adds up fast across a dozen combos. The bootstrapped
+	# rootfs itself is left on disk (see .hestiacp-chroot-ready in
+	# prepare_chroot) so a later run can reuse it without re-debootstrapping.
+	unmount_chroot_dir "$chroot_dir"
+	local i
+	for i in "${!ACTIVE_CHROOTS[@]}"; do
+		[ "${ACTIVE_CHROOTS[$i]}" = "$chroot_dir" ] && unset 'ACTIVE_CHROOTS[i]'
+	done
 }
 
 # Set packages to compile
@@ -399,9 +408,6 @@ while [ $# -gt 0 ]; do
 		--debug)
 			HESTIA_DEBUG='true'
 			;;
-		--all-os)
-			ALL_OS='true'
-			;;
 
 		--release)
 			shift
@@ -423,11 +429,6 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
-if [ "$ARGC" -eq 0 ] || { [ "$CROSS" != "true" ] && [ "$ALL_OS" != "true" ]; }; then
-	usage
-	exit 1
-fi
-
 if [ -z "$branch" ]; then
 	echo -n "Please enter the name of the branch to build from (e.g. main): "
 	read -r branch
@@ -448,7 +449,7 @@ fi
 # Build every other (distro, release, arch) combination via chroot.
 PKG_FLAGS=""
 NEEDS_CHROOT_BUILD='false'
-if [ "$HESTIA_B" = "true" ] && [ "$ALL_OS" = "true" ]; then
+if [ "$HESTIA_B" = "true" ]; then
 	PKG_FLAGS="$PKG_FLAGS --hestia"
 	NEEDS_CHROOT_BUILD='true'
 fi
@@ -470,21 +471,13 @@ fi
 
 if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
 	TARGET_COMBOS=()
-	if [ "$ALL_OS" = "true" ]; then
-		for dr in "${ALLOS_DISTRO_RELEASES[@]}"; do
-			distro="${dr%% *}"
-			release="${dr#* }"
-			for a in amd64 arm64; do
-				TARGET_COMBOS+=("$distro:$release:$a")
-			done
+	for dr in "${ALLOS_DISTRO_RELEASES[@]}"; do
+		distro="${dr%% *}"
+		release="${dr#* }"
+		for a in amd64 arm64; do
+			TARGET_COMBOS+=("$distro:$release:$a")
 		done
-	else
-		if [ "$HOST_ARCH" = "amd64" ]; then
-			TARGET_COMBOS=("$HOST_DISTRO:$HOST_RELEASE:arm64")
-		else
-			TARGET_COMBOS=("$HOST_DISTRO:$HOST_RELEASE:amd64")
-		fi
-	fi
+	done
 
 	for combo in "${TARGET_COMBOS[@]}"; do
 		distro="${combo%%:*}"
@@ -496,16 +489,15 @@ if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
 fi
 
 # When done move all build packages located in /tmp/hestiacp-src-{os}-{release}-{arch}/deb to /tmp/hestiacp-src/deb/ to have all packages in one place
-if [ "$ALL_OS" = "true" ]; then
-	for dr in "${ALLOS_DISTRO_RELEASES[@]}"; do
-		distro="${dr%% *}"
-		release="${dr#* }"
-		for a in amd64 arm64; do
-			src_deb_dir="${BUILD_DIR}-${distro}-${release}-${a}/deb"
-			if [ ! -d "$NATIVE_DEB_DIR/${release}/" ]; then
-				mkdir -p "$NATIVE_DEB_DIR/${release}/"
-			fi
-			mv "$src_deb_dir"/* "$NATIVE_DEB_DIR/${release}/"
-		done
+
+for dr in "${ALLOS_DISTRO_RELEASES[@]}"; do
+	distro="${dr%% *}"
+	release="${dr#* }"
+	for a in amd64 arm64; do
+		src_deb_dir="${BUILD_DIR}-${distro}-${release}-${a}/deb"
+		if [ ! -d "$NATIVE_DEB_DIR/${release}/" ]; then
+			mkdir -p "$NATIVE_DEB_DIR/${release}/"
+		fi
+		mv "$src_deb_dir"/* "$NATIVE_DEB_DIR/${release}/"
 	done
-fi
+done

--- a/src/chroot_build_all.sh
+++ b/src/chroot_build_all.sh
@@ -85,9 +85,9 @@ qemu_static_name() {
 # Best-effort unmount of a single path, falling back to a lazy unmount if a
 # plain umount fails (e.g. the mount is still busy). A path left mounted here
 # isn't just a leak: callers immediately rm -rf the chroot dir afterwards, and
-# files under a still-active bind mount of /proc, /sys or /dev can't be
-# unlinked at all (sysfs/procfs refuse it outright, even as root) -- so a
-# silently-failed umount turns into confusing "Operation not permitted" rm
+# files under a still-active mount of /proc, /sys or /dev can't be
+# unlinked at all (sysfs/procfs/tmpfs refuse it outright, even as root) -- so
+# a silently-failed umount turns into confusing "Operation not permitted" rm
 # errors instead.
 safe_umount() {
 	local path=$1
@@ -98,11 +98,34 @@ safe_umount() {
 	return 0
 }
 
-# Unmount everything prepare_chroot may have bind-mounted under a given
-# chroot dir. Order matters: children (dev/pts, the bind mounts) before
-# their parents (dev).
+# Terminate any processes still running with their root inside a chroot dir
+# (e.g. an interrupted qemu-emulated build after Ctrl-C, or a daemon left
+# behind by a package postinst) before unmounting it. Without this, a busy
+# mount just falls back to a lazy unmount in safe_umount, which only detaches
+# the mountpoint from view -- the process (and, for foreign-arch builds, the
+# RAM-heavy qemu-user interpreter emulating it) keeps running invisibly,
+# since `mount`/`ps` no longer associate it with the chroot.
+kill_chroot_processes() {
+	local chroot_dir
+	chroot_dir="$(cd "$1" 2> /dev/null && pwd -P)" || return 0
+	local pid root_link pids_to_kill=()
+	for pid_dir in /proc/[0-9]*; do
+		pid="${pid_dir#/proc/}"
+		root_link=$(readlink "$pid_dir/root" 2> /dev/null) || continue
+		[ "$root_link" = "$chroot_dir" ] && pids_to_kill+=("$pid")
+	done
+	[ ${#pids_to_kill[@]} -eq 0 ] && return 0
+	echo >&2 "Killing ${#pids_to_kill[@]} leftover process(es) still running inside $chroot_dir..."
+	kill "${pids_to_kill[@]}" 2> /dev/null
+	sleep 2
+	kill -9 "${pids_to_kill[@]}" 2> /dev/null
+}
+
+# Unmount everything prepare_chroot may have mounted under a given chroot
+# dir. Order matters: children (dev/pts) before their parents (dev).
 unmount_chroot_dir() {
 	local chroot_dir=$1
+	kill_chroot_processes "$chroot_dir"
 	safe_umount "$chroot_dir$REPO_DIR"
 	safe_umount "$chroot_dir$BUILD_DIR"
 	safe_umount "$chroot_dir/dev/pts"
@@ -190,7 +213,7 @@ prepare_chroot() {
 		# anything under an active mountpoint.
 		unmount_chroot_dir "$chroot_dir"
 		if mountpoint -q "$chroot_dir/dev" || mountpoint -q "$chroot_dir/proc" || mountpoint -q "$chroot_dir/sys"; then
-			echo >&2 "[!] Could not unmount stale bind mounts under $chroot_dir; refusing to"
+			echo >&2 "[!] Could not unmount stale mounts under $chroot_dir; refusing to"
 			echo >&2 "    delete it, since rm -rf would hit a live /dev, /proc or /sys and fail"
 			echo >&2 "    with confusing 'Operation not permitted' errors. Unmount it manually"
 			echo >&2 "    (e.g. umount -l $chroot_dir/sys) and re-run."
@@ -260,9 +283,34 @@ prepare_chroot() {
 		cp -f "/usr/bin/$qemu_bin" "$chroot_dir/usr/bin/"
 	fi
 
-	mkdir -p "$chroot_dir/dev" "$chroot_dir/proc" "$chroot_dir/sys" "$chroot_dir/dev/pts"
-	mountpoint -q "$chroot_dir/dev" || mount --bind /dev "$chroot_dir/dev"
-	mountpoint -q "$chroot_dir/dev/pts" || mount --bind /dev/pts "$chroot_dir/dev/pts"
+	mkdir -p "$chroot_dir/dev" "$chroot_dir/proc" "$chroot_dir/sys"
+
+	# Give the chroot its own private /dev instead of bind-mounting the host's.
+	# Package installs inside routinely run maintainer scripts (udev, systemd
+	# postinst hooks, tmpfiles-setup-dev, ...) that reconcile /dev/pts --
+	# unmounting/recreating it, pruning stale pty nodes, resetting perms. With
+	# a bind-mounted /dev those land on the HOST's real /dev/pts (same
+	# superblock), which can break pty allocation for the host's own SSH
+	# sessions. A private tmpfs + a "newinstance" devpts keeps every chroot's
+	# /dev fully isolated -- the same approach pbuilder/sbuild use.
+	if ! mountpoint -q "$chroot_dir/dev"; then
+		mount -t tmpfs -o mode=0755,nosuid tmpfs "$chroot_dir/dev"
+		mknod -m 666 "$chroot_dir/dev/null" c 1 3
+		mknod -m 666 "$chroot_dir/dev/zero" c 1 5
+		mknod -m 666 "$chroot_dir/dev/full" c 1 7
+		mknod -m 666 "$chroot_dir/dev/random" c 1 8
+		mknod -m 666 "$chroot_dir/dev/urandom" c 1 9
+		mknod -m 666 "$chroot_dir/dev/tty" c 5 0
+		mknod -m 600 "$chroot_dir/dev/console" c 5 1
+		ln -sf /proc/self/fd "$chroot_dir/dev/fd"
+		ln -sf /proc/self/fd/0 "$chroot_dir/dev/stdin"
+		ln -sf /proc/self/fd/1 "$chroot_dir/dev/stdout"
+		ln -sf /proc/self/fd/2 "$chroot_dir/dev/stderr"
+		mkdir -p "$chroot_dir/dev/pts" "$chroot_dir/dev/shm"
+		chmod 1777 "$chroot_dir/dev/shm"
+	fi
+	mountpoint -q "$chroot_dir/dev/pts" || mount -t devpts -o newinstance,ptmxmode=0666,mode=0620,gid=5 devpts "$chroot_dir/dev/pts"
+	ln -sf pts/ptmx "$chroot_dir/dev/ptmx"
 	mountpoint -q "$chroot_dir/proc" || mount --bind /proc "$chroot_dir/proc"
 	mountpoint -q "$chroot_dir/sys" || mount --bind /sys "$chroot_dir/sys"
 
@@ -305,7 +353,6 @@ run_cross_build() {
 	# name/version/arch across releases (codenames are unique across distros,
 	# so $release alone is enough, no need for a distro prefix).
 	local target_deb_dir="$BUILD_DIR/deb"
-	[ "$ALL_OS" = "true" ] && target_deb_dir="$target_deb_dir/$release"
 	mkdir -p "$target_deb_dir"
 	local deb_dir_export="export DEB_DIR='$target_deb_dir'; "
 
@@ -328,8 +375,9 @@ run_cross_build() {
 }
 
 # Set packages to compile
-for i in "$@"; do
-	case "$i" in
+ARGC=$#
+while [ $# -gt 0 ]; do
+	case "$1" in
 		--all)
 			NGINX_B='true'
 			PHP_B='true'
@@ -369,12 +417,13 @@ for i in "$@"; do
 			exit 1
 			;;
 		*)
-			branch="$i"
+			branch="$1"
 			;;
 	esac
+	shift
 done
 
-if [ $# -eq 0 ] || { [ "$CROSS" != "true" ] && [ "$ALL_OS" != "true" ]; }; then
+if [ "$ARGC" -eq 0 ] || { [ "$CROSS" != "true" ] && [ "$ALL_OS" != "true" ]; }; then
 	usage
 	exit 1
 fi
@@ -394,20 +443,6 @@ NATIVE_DEB_DIR=""
 if [ "$ALL_OS" = "true" ]; then
 	NATIVE_DEB_DIR="$BUILD_DIR/deb/"
 	mkdir -p "$NATIVE_DEB_DIR"
-fi
-
-# Build for the host's own OS/release/architecture directly, no chroot needed.
-NATIVE_FLAGS=""
-[ "$HESTIA_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --hestia"
-[ "$NGINX_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --nginx"
-[ "$PHP_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --php"
-[ "$WEB_TERMINAL_B" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --web-terminal"
-[ "$HESTIA_DEBUG" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --debug"
-[ "$KEEPBUILD" = "true" ] && NATIVE_FLAGS="$NATIVE_FLAGS --keepbuild"
-if [ "$install" = "true" ]; then
-	NATIVE_FLAGS="$NATIVE_FLAGS --install"
-else
-	NATIVE_FLAGS="$NATIVE_FLAGS --noinstall"
 fi
 
 # Build every other (distro, release, arch) combination via chroot.
@@ -430,6 +465,8 @@ if [ "$WEB_TERMINAL_B" = "true" ]; then
 	NEEDS_CHROOT_BUILD='true'
 fi
 [ "$HESTIA_DEBUG" = "true" ] && PKG_FLAGS="$PKG_FLAGS --debug"
+[ -n "$release_tag" ] && PKG_FLAGS="$PKG_FLAGS --release $release_tag"
+[ -n "$pkg_rev" ] && PKG_FLAGS="$PKG_FLAGS --pkgrev $pkg_rev"
 
 if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
 	TARGET_COMBOS=()
@@ -454,7 +491,7 @@ if [ "$NEEDS_CHROOT_BUILD" = "true" ]; then
 		rest="${combo#*:}"
 		release="${rest%%:*}"
 		target_arch="${rest#*:}"
-		run_cross_build "$distro" "$release" "$target_arch" $PKG_FLAGS $release_tag $pkg_rev "$branch"
+		run_cross_build "$distro" "$release" "$target_arch" "$PKG_FLAGS" --noinstall "$branch"
 	done
 fi
 
@@ -465,9 +502,10 @@ if [ "$ALL_OS" = "true" ]; then
 		release="${dr#* }"
 		for a in amd64 arm64; do
 			src_deb_dir="${BUILD_DIR}-${distro}-${release}-${a}/deb"
-			if [ -d "$src_deb_dir" ]; then
-				mv "$src_deb_dir"/* "$NATIVE_DEB_DIR"
+			if [ ! -d "$NATIVE_DEB_DIR/${release}/" ]; then
+				mkdir -p "$NATIVE_DEB_DIR/${release}/"
 			fi
+			mv "$src_deb_dir"/* "$NATIVE_DEB_DIR/${release}/"
 		done
 	done
 fi

--- a/src/chroot_build_all.sh
+++ b/src/chroot_build_all.sh
@@ -440,11 +440,8 @@ HOST_RELEASE=$(lsb_release -sc)
 # With --all-os, give every OS release its own deb output subdirectory
 # (release codenames don't collide across distros), including the host's
 # own, since packages can share the same name/version/arch across releases.
-NATIVE_DEB_DIR=""
-if [ "$ALL_OS" = "true" ]; then
-	NATIVE_DEB_DIR="$BUILD_DIR/deb/"
-	mkdir -p "$NATIVE_DEB_DIR"
-fi
+NATIVE_DEB_DIR="$BUILD_DIR/deb/"
+mkdir -p "$NATIVE_DEB_DIR"
 
 # Build every other (distro, release, arch) combination via chroot.
 PKG_FLAGS=""

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -474,6 +474,12 @@ branch_dash=$(echo "$branch" | sed 's/\//-/g')
 #################################################################################
 
 if [ "$NGINX_B" = true ]; then
+
+	echo "Building hestia-nginx package..."
+	if [ "$CROSS" = "true" ]; then
+		echo "Cross compile not supported for hestia-nginx, hestia-php or hestia-web-terminal"
+		exit 1
+	fi
 	# Change to build directory
 	cd $BUILD_DIR
 
@@ -598,6 +604,10 @@ fi
 
 if [ "$PHP_B" = true ]; then
 	echo "Building hestia-php package..."
+	if [ "$CROSS" = "true" ]; then
+		echo "Cross compile not supported for hestia-nginx, hestia-php or hestia-web-terminal"
+		exit 1
+	fi
 
 	BUILD_DIR_HESTIAPHP=$BUILD_DIR/hestia-php_$PHP_V
 
@@ -715,8 +725,11 @@ fi
 #################################################################################
 
 if [ "$WEB_TERMINAL_B" = true ]; then
-
 	echo "Building hestia-web-terminal package..."
+	if [ "$CROSS" = "true" ]; then
+		echo "Cross compile not supported for hestia-nginx, hestia-php or hestia-web-terminal"
+		exit 1
+	fi
 
 	BUILD_DIR_HESTIA_TERMINAL=$BUILD_DIR/hestia-web-terminal_$WEB_TERMINAL_V
 

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -117,6 +117,10 @@ usage() {
 	echo "Example: bash hst_autocompile.sh --hestia develop Y"
 	echo "This would install a Hestia Control Panel package compiled with the"
 	echo "develop branch code."
+	echo ""
+	echo "To cross-build hestia-nginx/hestia-php/hestia-web-terminal for the other"
+	echo "architecture, or for other OS releases, on the same machine, use"
+	echo "./chroot_build_all.sh instead."
 }
 
 get_distro_suffix() {
@@ -213,7 +217,8 @@ if [ $architecture == 'aarch64' ]; then
 else
 	BUILD_ARCH='amd64'
 fi
-DEB_DIR="$BUILD_DIR/deb"
+
+DEB_DIR="${DEB_DIR:-$BUILD_DIR/deb}"
 
 # Set packages to compile
 for i in $*; do
@@ -366,14 +371,20 @@ timestamp() {
 if [ "$dontinstalldeps" != 'true' ]; then
 	# Install needed software
 	# Set package dependencies for compiling
-	SOFTWARE='wget tar git curl build-essential libxml2-dev libz-dev libzip-dev libgmp-dev libcurl4-gnutls-dev unzip openssl libssl-dev pkg-config libsqlite3-dev libonig-dev rpm lsb-release'
-
+	SOFTWARE='wget tar git curl ca-certificates build-essential libxml2-dev libz-dev libzip-dev libgmp-dev libcurl4-gnutls-dev unzip openssl libssl-dev pkg-config libsqlite3-dev libonig-dev lsb-release'
 	echo "Updating system APT repositories..."
-	apt-get -qq update > /dev/null 2>&1
+	apt-get -qq update
 	echo "Installing dependencies for compilation..."
-	apt-get -qq install -y $SOFTWARE > /dev/null 2>&1
+	apt-get -qq install -y $SOFTWARE
 
-	# Installing Node.js 20.x repo
+	# In a minimal/freshly-debootstrapped chroot, dpkg trigger processing
+	# (which normally re-runs ldconfig after installing shared libs) can be
+	# deferred or skipped, leaving the dynamic linker's cache stale even
+	# though e.g. libzip.so.5 is genuinely on disk. Refresh it explicitly so
+	# binaries built against these libs (php, nginx, ...) can actually run.
+	ldconfig
+
+	# Installing Node.js 24.x repo
 	apt="/etc/apt/sources.list.d"
 	codename="$(lsb_release -s -c)"
 
@@ -382,8 +393,23 @@ if [ "$dontinstalldeps" != 'true' ]; then
 	fi
 
 	echo "Installing Node.js..."
-	apt-get -qq update > /dev/null 2>&1
-	apt -qq install -y nodejs > /dev/null 2>&1
+	apt-get -qq update > /dev/null
+	apt-get -qq install -y nodejs
+
+	# NodeSource's nodejs package bundles npm, but Debian/Ubuntu's own nodejs
+	# package doesn't (used if the NodeSource repo above failed to register,
+	# e.g. no network). Only fall back to the distro's separate npm package
+	# when npm is actually missing — requesting it unconditionally alongside
+	# nodejs in one apt-get call conflicts with NodeSource's bundled npm and
+	# fails the whole install.
+	if [ -z "$(which "npm")" ]; then
+		apt-get -qq install -y npm
+	fi
+
+	if [ -z "$(which "node")" ] || [ -z "$(which "npm")" ]; then
+		echo "Failed to install Node.js/npm"
+		exit 1
+	fi
 
 	nodejs_version=$(/usr/bin/node -v | cut -f1 -d'.' | sed 's/v//g')
 
@@ -400,8 +426,11 @@ if [ "$dontinstalldeps" != 'true' ]; then
 	fi
 fi
 
-# Get system cpu cores
-NUM_CPUS=$(grep "^cpu cores" /proc/cpuinfo | uniq | awk '{print $4}')
+# Get system cpu cores. Callers running this inside a QEMU-emulated chroot
+# (cross-arch builds) can pre-set NUM_CPUS to override this: /proc is
+# bind-mounted from the host, so the detected count would otherwise be the
+# host's real core count, not a safe parallelism level for emulated compiles.
+NUM_CPUS="${NUM_CPUS:-$(grep "^cpu cores" /proc/cpuinfo | uniq | awk '{print $4}')}"
 
 if [ "$HESTIA_DEBUG" ]; then
 	echo "OS type          : Debian / Ubuntu"
@@ -445,12 +474,6 @@ branch_dash=$(echo "$branch" | sed 's/\//-/g')
 #################################################################################
 
 if [ "$NGINX_B" = true ]; then
-	echo "Building hestia-nginx package..."
-	if [ "$CROSS" = "true" ]; then
-		echo "Cross compile not supported for hestia-nginx, hestia-php or hestia-web-terminal"
-		exit 1
-	fi
-
 	# Change to build directory
 	cd $BUILD_DIR
 
@@ -461,7 +484,7 @@ if [ "$NGINX_B" = true ]; then
 		BUILD_DIR_NGINX=$BUILD_DIR/nginx-$(echo $NGINX_V | cut -d"~" -f1)
 	fi
 
-	if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIANGINX" ]; then
+	if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIANGINX" ] || [ ! -f "$BUILD_DIR_NGINX/Makefile" ]; then
 		# Check if target directory exist
 		if [ -d "$BUILD_DIR_HESTIANGINX" ]; then
 			#mv $BUILD_DIR/hestia-nginx_$NGINX_V $BUILD_DIR/hestia-nginx_$NGINX_V-$(timestamp)
@@ -574,11 +597,6 @@ fi
 #################################################################################
 
 if [ "$PHP_B" = true ]; then
-	if [ "$CROSS" = "true" ]; then
-		echo "Cross compile not supported for hestia-nginx, hestia-php or hestia-web-terminal"
-		exit 1
-	fi
-
 	echo "Building hestia-php package..."
 
 	BUILD_DIR_HESTIAPHP=$BUILD_DIR/hestia-php_$PHP_V
@@ -591,7 +609,7 @@ if [ "$PHP_B" = true ]; then
 		BUILD_DIR_PHP=$BUILD_DIR/php-$(echo $PHP_V | cut -d"~" -f1)
 	fi
 
-	if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIAPHP" ]; then
+	if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIAPHP" ] || [ ! -f "$BUILD_DIR_PHP/Makefile" ]; then
 		# Check if target directory exist
 		if [ -d $BUILD_DIR_HESTIAPHP ]; then
 			rm -r $BUILD_DIR_HESTIAPHP
@@ -697,10 +715,6 @@ fi
 #################################################################################
 
 if [ "$WEB_TERMINAL_B" = true ]; then
-	if [ "$CROSS" = "true" ]; then
-		echo "Cross compile not supported for hestia-nginx, hestia-php or hestia-web-terminal"
-		exit 1
-	fi
 
 	echo "Building hestia-web-terminal package..."
 

--- a/src/lxd_build_all.sh
+++ b/src/lxd_build_all.sh
@@ -14,9 +14,9 @@
 
 # Configs:
 # Use focal and jammy instead of "20.04 an 22.04"
-oslist=('debian=10,11' 'ubuntu=18.04,focal,jammy')
-branch='main'
-
+oslist=('debian=12,13' 'ubuntu=jammy,noble,racoon')
+branch=$(git -C "${__DIR__}" rev-parse --abbrev-ref HEAD 2> /dev/null || echo main)
+echo "Branch: $branch"
 function setup_container() {
 	if [ "$osname" = 'ubuntu' ]; then
 		lxc init $osname:$osver "${containername}"


### PR DESCRIPTION
### Summary of Changes

This pull request introduces a new script, `chroot_build_all.sh`, to enable comprehensive cross-architecture and multi-OS package compilation for Hestia. It orchestrates builds within QEMU-emulated chroot environments for various Debian and Ubuntu releases across AMD64 and ARM64 architectures. Supporting changes are included in `hst_autocompile.sh` to facilitate these new build workflows,

### Notes: 

* Adding new supported operating system can be managed trough updating the OS list in chroot_build_all.sh 
* Building is slow compared on the the old system due to inefficies with arm emulation on x86 it takes about 4 / 5 hours to complete the build. To prevent issues with  ssh disconnects I suggest running it with screen.. 

### Key Features and Improvements

*   **New `chroot_build_all.sh` script**: Orchestrates builds for supported Debian (12, 13) and Ubuntu (22.04, 24.04, 26.04) releases on both AMD64 and ARM64 architectures.
    *   Leverages QEMU-emulated `debootstrap` chroots to create isolated and consistent build environments for each target combination.
    *   Includes comprehensive chroot lifecycle management, ensuring proper setup, process termination, and unmounting.
    *   Optimizes build parallelism for emulated environments to prevent Out-Of-Memory issues.
*   **`hst_autocompile.sh` adaptations**:
    *   Refactors the main compilation script to be invoked effectively within chroot environments, allowing flexible overrides for output directories and CPU core utilization.
    *   Updates Node.js installation to version 24.x, enhancing npm detection and installation robustness.
    *   Ensures shared library caches are refreshed with `ldconfig` after dependency installation, crucial for new chroots.
    *   Improves build directory checks for Nginx and PHP compilation, enhancing reliability for incremental builds.
    *   Updates build dependencies by adding `ca-certificates` and removing `rpm`.

### Other Changes

*   **Documentation**: Adds a new section to the contributing guide explaining the usage and benefits of `chroot_build_all.sh` for cross-architecture and multi-OS builds.