### PR TITLE
fix: keep IFS local in restic web restore so nginx conf is valid (#4986)

### DIFF
--- a/bin/v-restore-web-domain-restic
+++ b/bin/v-restore-web-domain-restic
@@ -64,11 +64,9 @@ old_uid=$(cut -f 3 -d : $tmpdir/passwd)
 
 domains=""
 parse_object_kv_list $(cat $tmpdir/backup.conf)
-IFS=','
-read -a domains_array <<< "$web"
-read -a domains <<< "$WEB"
-for domain in $domains; do
-	if [[ "${IFS}${domains_array[*]}${IFS}" =~ "${IFS}${domain}${IFS}" || "$web" = '*' ]]; then
+IFS=',' read -a domains <<< "$WEB"
+for domain in "${domains[@]}"; do
+	if [[ ",$web," == *",$domain,"* || "$web" = '*' ]]; then
 		# Cleanup previous domain keys
 		unset -v DOMAIN IP IP6 ALIAS TPL SSL SSL_HOME LETSENCRYPT FTP_USER FTP_MD5 BACKEND PROXY PROXY_EXT STATS STATS_USER STATS_CRYPT U_DISK CUSTOM_DOCROOT CUSTOM_PHPROOT
 


### PR DESCRIPTION
## What

`v-restore-web-domain-restic` set `IFS=','` globally to split the domain lists and never restored it, so the comma stayed as the field separator for the rest of the loop. The unquoted `echo $str >> web.conf` and the inner `parse_object_kv_list $(cat .../web.conf)` then word-split every comma-containing value, writing `PROXY_EXT` (and `ALIAS`) back with the commas replaced by spaces.

Because the stored `PROXY_EXT` no longer had commas, `${PROXY_EXT//,/|}` had nothing to convert and the rebuilt vhost got a space-separated regex alternation:

```nginx
location ~* ^.+\.(css htm html js ...)$ {
```

which nginx refuses to load — the web domain config is broken after every restic restore.

## Why

Scope `IFS=','` to the single `read` that splits `$WEB` (`IFS=',' read -a domains <<< "$WEB"`) so the global value is untouched and the later `echo`/parsing keep the commas intact, letting `${PROXY_EXT//,/|}` produce the correct `(css|htm|html|js|...)`.

While in the same lines, iterate the array with `"${domains[@]}"` instead of `$domains` — the latter only expanded the first element, so only the first of several web domains was ever restored (the web half of #4987). The membership check is rewritten as a plain comma-delimited glob match so it no longer depends on the global `IFS`, and the now-unused `domains_array` is dropped.

## How to test

1. Create a user with two web domains and a non-default proxy template (so `PROXY_EXT` is populated), take a restic snapshot.
2. Restore: `v-restore-web-domain-restic <user> <snapshot> '*'`.
   - Before: only the first domain is restored, and `grep 'location ~\*' /home/<user>/conf/web/<domain>/nginx.conf` shows a space-separated list; `nginx -t` fails.
   - After: both domains are restored, the list is pipe-separated (`(css|htm|html|...)`), and `nginx -t` passes.
3. Restoring a single domain (`... <user> <snapshot> domain.com`) and a comma list still selects the right domains — no regression.

`bash -n`, `shellcheck --severity=error`, and `prettier --check` all pass.

Note: the mail/dns/database restic restore scripts share the same `for domain in $domains` pattern; this PR is scoped to the web script (#4986). Happy to follow up on the rest of #4987 separately if wanted.

Fixes #4986
