### PR TITLE
fix: restore all domains/databases in restic mail, dns and db restores (#4987)

### DIFF
--- a/bin/v-restore-database-restic
+++ b/bin/v-restore-database-restic
@@ -57,12 +57,10 @@ fi
 
 parse_object_kv_list $(cat "$tmpdir/backup.conf")
 
-IFS=','
-read -a databases_array <<< "$database"
-read -a databases <<< "$DB"
+IFS=',' read -a databases <<< "$DB"
 
-for db in $DB; do
-	if [[ "${IFS}${databases_array[*]}${IFS}" =~ "${IFS}${db}${IFS}" || "$databases_array" = '*' ]]; then
+for db in "${databases[@]}"; do
+	if [[ ",$database," == *",$db,"* || "$database" = '*' ]]; then
 		check_config=$(grep "DB='$db'" $USER_DATA/db.conf)
 		if [ -z "$check_config" ]; then
 			restic --repo "${REPO%/}/$user" --password-file "$USER_DATA/restic.conf" --json dump "$snapshot" "/home/$user/backup/db/$db/hestia/db.conf" > "$tmpdir/db.conf"

--- a/bin/v-restore-dns-domain-restic
+++ b/bin/v-restore-dns-domain-restic
@@ -56,12 +56,10 @@ if [ ! -f "$tmpdir/backup.conf" ]; then
 fi
 
 parse_object_kv_list $(cat "$tmpdir/backup.conf")
-IFS=','
 domains=''
-read -a domains_array <<< "$dns"
-read -a domains <<< "$DNS"
-for domain in $domains; do
-	if [[ "${IFS}${domains_array[*]}${IFS}" =~ "${IFS}${domain}${IFS}" || "$dns" = '*' ]]; then
+IFS=',' read -a domains <<< "$DNS"
+for domain in "${domains[@]}"; do
+	if [[ ",$dns," == *",$domain,"* || "$dns" = '*' ]]; then
 		# Cleanup previous config keys
 		unset -v DOMAIN IP TPL TTL EXP SOA RECORDS DNSSEC KEY SLAVE MASTER
 		# Checking domain existence

--- a/bin/v-restore-mail-domain-restic
+++ b/bin/v-restore-mail-domain-restic
@@ -60,8 +60,7 @@ fi
 
 domains=""
 parse_object_kv_list $(cat "$tmpdir/backup.conf")
-read -a domains_array <<< "$mail"
-read -a domains <<< "$MAIL"
+IFS=',' read -a domains <<< "$MAIL"
 
 # Checking exim username for later chowning
 exim_user="exim"
@@ -70,8 +69,8 @@ if [ "$check_exim_username" -eq 1 ]; then
 	exim_user="Debian-exim"
 fi
 
-for domain in $domains; do
-	if [[ "${IFS}${domains_array[*]}${IFS}" =~ "${IFS}${domain}${IFS}" || "$mail" = '*' ]]; then
+for domain in "${domains[@]}"; do
+	if [[ ",$mail," == *",$domain,"* || "$mail" = '*' ]]; then
 		# Checking domain existance
 		check_config=$(grep "DOMAIN='$domain'" $USER_DATA/mail.conf)
 		if [ -z "$check_config" ]; then


### PR DESCRIPTION
## What

Follow-up to #5500, as offered there — this completes #4987 for the remaining restic restore scripts. #5500 fixed the web half; this PR applies the same three-part fix to `v-restore-mail-domain-restic`, `v-restore-dns-domain-restic` and `v-restore-database-restic`: scope `IFS=','` to the single `read` that splits the backup list, iterate the array with `"${arr[@]}"`, and rewrite the membership check as a plain comma-delimited glob match that doesn't depend on the global IFS.

## Why

Each script failed differently for users with multiple domains/databases:

- **mail**: never set `IFS=','` before the `read` (as noted in #4987), so `domains` was a single element holding the whole comma-joined list. Restoring a subset silently restored nothing, and restoring `'*'` attempted a domain literally named `dom1.com,dom2.com` — multi-domain mail restores never worked.
- **dns**: set `IFS=','` globally and looped `for domain in $domains`, which expands only the first array element — only the first zone was restored. The never-restored IFS also leaked into the rest of the script and the sourced rebuild functions, where unquoted expansions flatten commas to spaces (e.g. the TXT chunking in `update_domain_zone` would corrupt comma-containing values such as DMARC `rua` lists).
- **database**: set `IFS=','` globally too; its `for db in $DB` loop only iterated all databases *because* of that leak, and the membership test depended on it. The leaked IFS then persisted through `parse_object_kv_list` calls and the db.sh delete/rebuild/import helpers. Scoping the IFS and iterating the array removes the dependency on the leak without changing behavior for correct inputs.

## How to test

1. On a user with several mail domains, DNS zones, and databases, run `v-backup-user-restic user`.
2. `v-restore-mail-domain-restic user <snapshot> '*'` — before: no domain is restored (it looks for a domain literally named `dom1.com,dom2.com`); after: every domain is restored. Same with a single-domain argument, which previously was a silent no-op.
3. `v-restore-dns-domain-restic user <snapshot> '*'` — before: only the first zone comes back; after: all zones.
4. `v-restore-database-restic user <snapshot> '*'` and with a `db1,db2` list — behavior unchanged (all/selected databases restored), but the script no longer runs its restore/rebuild/import steps with a leaked global `IFS=','`.

`bash -n`, `shellcheck --severity=error`, and `prettier --check` all pass on the three scripts.

Fixes #4987 (together with the already-merged #5500 for web).
