### PR TITLE
fix: normalize renamed web domain name so www. targets stay manageable (#4958)

### DIFF
--- a/bin/v-change-web-domain-name
+++ b/bin/v-change-web-domain-name
@@ -34,6 +34,16 @@ format_domain
 format_domain_idn
 # TODO: $domain_idn not used in this script - maybe $domain should be converted to $doman_idn ?
 
+# Normalize the new domain name the same way domains are normalized on creation
+# (strip leading www., lowercase, drop trailing dots). Without this a www.-prefixed
+# rename target is stored verbatim, but every other command runs format_domain and
+# strips the www., so the renamed domain can no longer be managed (see #4958).
+orig_domain="$domain"
+domain="$new_domain"
+format_domain
+new_domain="$domain"
+domain="$orig_domain"
+
 #----------------------------------------------------------#
 #                    Verifications                         #
 #----------------------------------------------------------#


### PR DESCRIPTION
## What

`v-change-web-domain-name` now normalizes `NEW_DOMAIN` through `format_domain` before using it, matching how domain names are stored everywhere else.

## Why

Renaming a web domain to a `www.`-prefixed (or uppercase, or trailing-dot) name stored it verbatim, e.g. `DOMAIN='www.example.com'`. Every other Hestia command runs `format_domain` on its argument, which strips the leading `www.`, so it looked the domain up as `example.com` and never found it. The renamed domain could no longer be deleted, aliased, or renamed back — it was effectively orphaned (issue #4958). This mirrors `v-add-web-domain`, which already strips `www.` on creation, so `www.` is only ever valid as an alias, never as a primary domain name.

## How

Added a small normalization block that runs the existing `format_domain` routine on `NEW_DOMAIN` (saving/restoring `$domain` so the old-domain value used later is untouched). As a bonus, a no-op rename such as `example.com` → `www.example.com` now normalizes to `example.com` and correctly trips the existing "already exists" guard instead of `mv`-ing the docroot onto itself.

## How to test

1. `v-add-web-domain user example.com` — created and manageable.
2. `v-change-web-domain-name user example.com www.example2.com`.
3. Confirm `web.conf` stores `DOMAIN='example2.com'` (not `www.example2.com`).
4. Confirm the domain is fully manageable: `v-list-web-domain user example2.com`, add an alias, delete it — all succeed.
5. Before the fix, step 3 stored `www.example2.com` and every command in step 4 failed with "domain does not exist".

`bash -n`, `shellcheck --severity=error`, and `prettier --check` all pass.

Fixes #4958
