### PR TITLE
fix: convert SRV record targets to IDN so umlaut DNS zones load (#4951)

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -524,6 +524,16 @@ update_domain_zone() {
 		RECORD=$(idn2 --quiet "$RECORD")
 		if [ "$TYPE" = 'CNAME' ] || [ "$TYPE" = 'MX' ]; then
 			VALUE=$(idn2 --quiet "$VALUE")
+		elif [ "$TYPE" = 'SRV' ]; then
+			# SRV value is "weight port target" (the priority is stored separately
+			# in the PRIORITY field). Only the trailing target is a host name, so
+			# parse the fields and convert just that, leaving the numeric
+			# weight/port and a "." target (service unavailable) untouched.
+			read -r srv_weight srv_port srv_target <<< "$VALUE"
+			if [ "$srv_target" != "." ]; then
+				srv_target=$(idn2 --quiet "$srv_target")
+			fi
+			VALUE="$srv_weight $srv_port $srv_target"
 		fi
 
 		if [ "$TYPE" = 'TXT' ]; then


### PR DESCRIPTION
## What

`update_domain_zone()` now runs `idn2` on the target of SRV records, the same way it already does for CNAME and MX values.

## Why

The function converts CNAME and MX record values to their IDN/punycode form, but not SRV values. The default DNS template creates SRV records (`_submission._tcp`, `_imap._tcp`, `_imaps._tcp`, `_pop3._tcp`, `_pop3s._tcp`) whose targets are `mail.<domain>.`. For a domain that contains a non-ASCII character — e.g. a German umlaut — those targets keep the raw UTF-8 name in the generated zone file, while the zone itself is served under its punycode name.

BIND then rejects the zone:

```
zone xn--exmple-cua.com/IN: loading from master file …/exämple.com.db failed: bad name (check-names)
zone xn--exmple-cua.com/IN: not loaded due to errors.
```

Because `check-names` defaults to `fail` for master zones, the *entire* zone fails to load and every name under the domain returns SERVFAIL (#4951).

## How

For `TYPE = SRV`, the stored value is `weight port target`; only the trailing target is a host name, so convert just that field with `idn2` and leave the numeric weight/port untouched. CNAME/MX handling is unchanged, and ASCII SRV values are passed through unchanged (no regression for non-IDN zones).

## How to test

1. `v-add-dns-domain <user> exämple.com` (any domain with a non-ASCII char).
2. Inspect `/home/<user>/conf/dns/exämple.com.db`.
   - Before: SRV lines read `… mail.exämple.com.`
   - After:  SRV lines read `… mail.xn--exmple-cua.com.`
3. Reload BIND and check the log / query the zone.
   - Before: `bad name (check-names)`, zone not loaded, `drill xn--exmple-cua.com @ns1` → SERVFAIL.
   - After:  zone loads, queries resolve.

Verified by regenerating the exact zone `update_domain_zone` produces for a umlaut domain and validating with `named-checkzone -k fail`: it fails with `bad name (check-names)` before the change and loads `OK` after. `bash -n`, `shellcheck --severity=error` and `prettier --check` all pass.

Fixes #4951

---
*Disclosure: prepared with assistance from Claude (AI); the fix and the before/after `named-checkzone` verification were reviewed by me.*
