### PR TITLE
Approve NPM scripts for running will break in npm 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,11 @@
 	},
 	"browserslist": [
 		"defaults"
-	]
+	],
+	"allowScripts": {
+		"esbuild@0.28.1": true,
+		"esbuild@0.25.12": true,
+		"esbuild@0.21.5": true,
+		"fsevents@2.3.3": true
+	}
 }


### PR DESCRIPTION
Per the npm 12 breaking-changes discussion, npm 12 makes unreviewed install scripts a hard failure by default, not just a warning. 