### PR TITLE
feat(Installers): bump versions of apps

### DIFF
--- a/web/src/app/WebApp/Installers/Grav/GravSetup.php
+++ b/web/src/app/WebApp/Installers/Grav/GravSetup.php
@@ -11,7 +11,7 @@ class GravSetup extends BaseSetup {
     protected array $info = [
         "name" => "Grav",
         "group" => "cms",
-        "version" => "2.0.3",
+        "version" => "2.0.11",
         "thumbnail" => "grav-symbol.svg",
     ];
 
@@ -26,7 +26,7 @@ class GravSetup extends BaseSetup {
         "resources" => [
             "archive" => [
                 "src" =>
-                    "https://github.com/getgrav/grav/releases/download/2.0.3/grav-admin-v2.0.3.zip",
+                    "https://github.com/getgrav/grav/releases/download/2.0.11/grav-admin-v2.0.11.zip",
             ],
         ],
         "server" => [

--- a/web/src/app/WebApp/Installers/Joomla/JoomlaSetup.php
+++ b/web/src/app/WebApp/Installers/Joomla/JoomlaSetup.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Hestia\WebApp\Installers\Joomla;
 
-use Hestia\System\Util;
 use Hestia\WebApp\BaseSetup;
 use Hestia\WebApp\InstallationTarget\InstallationTarget;
 
@@ -12,7 +11,7 @@ class JoomlaSetup extends BaseSetup {
     protected array $info = [
         "name" => "Joomla",
         "group" => "cms",
-        "version" => "6.1.1",
+        "version" => "6.1.2",
         "thumbnail" => "joomla-logo.svg",
     ];
 
@@ -24,7 +23,7 @@ class JoomlaSetup extends BaseSetup {
             ],
             "admin_user" => [
                 "type" => "text",
-                "value" => "John",
+                "value" => "",
             ],
             "admin_username" => [
                 "type" => "text",
@@ -43,7 +42,7 @@ class JoomlaSetup extends BaseSetup {
         "resources" => [
             "archive" => [
                 "src" =>
-                    "https://downloads.joomla.org/cms/joomla6/6-1-1/Joomla_6-1-1-Stable-Full_Package.zip?format=zip",
+                    "https://downloads.joomla.org/cms/joomla6/6-1-2/Joomla_6-1-2-Stable-Full_Package.zip?format=zip",
             ],
         ],
         "server" => [

--- a/web/src/app/WebApp/Installers/MediaWiki/MediaWikiSetup.php
+++ b/web/src/app/WebApp/Installers/MediaWiki/MediaWikiSetup.php
@@ -11,7 +11,7 @@ class MediaWikiSetup extends BaseSetup {
     protected array $info = [
         "name" => "MediaWiki",
         "group" => "cms",
-        "version" => "1.45.3",
+        "version" => "1.46.0",
         "thumbnail" => "MediaWiki-2020-logo.svg", //Max size is 300px by 300px
     ];
 
@@ -25,7 +25,7 @@ class MediaWikiSetup extends BaseSetup {
         "database" => true,
         "resources" => [
             "archive" => [
-                "src" => "https://releases.wikimedia.org/mediawiki/1.45/mediawiki-1.45.3.zip",
+                "src" => "https://releases.wikimedia.org/mediawiki/1.46/mediawiki-1.46.0.zip",
             ],
         ],
         "server" => [
@@ -40,7 +40,7 @@ class MediaWikiSetup extends BaseSetup {
 
     protected function setupApplication(InstallationTarget $target, array $options): void {
         $this->appcontext->copyDirectory(
-            $target->getDocRoot("/mediawiki-1.45.3/."),
+            $target->getDocRoot("/mediawiki-1.46.0/."),
             $target->getDocRoot(),
         );
 
@@ -63,6 +63,6 @@ class MediaWikiSetup extends BaseSetup {
             ],
         );
 
-        $this->appcontext->deleteDirectory($target->getDocRoot("/mediawiki-1.45.3/"));
+        $this->appcontext->deleteDirectory($target->getDocRoot("/mediawiki-1.46.0/"));
     }
 }

--- a/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
+++ b/web/src/app/WebApp/Installers/Nextcloud/NextcloudSetup.php
@@ -30,7 +30,7 @@ class NextcloudSetup extends BaseSetup
                 'template' => 'owncloud',
             ],
             'php' => [
-                'supported' => ['8.0', '8.1', '8.2', '8.3'],
+                'supported' => ['8.2', '8.3', '8.4', '8.5'],
             ],
         ],
     ];

--- a/web/src/app/WebApp/Installers/ThirtyBees/ThirtyBeesSetup.php
+++ b/web/src/app/WebApp/Installers/ThirtyBees/ThirtyBeesSetup.php
@@ -11,7 +11,7 @@ class ThirtyBeesSetup extends BaseSetup {
     protected array $info = [
         "name" => "ThirtyBees",
         "group" => "ecommerce",
-        "version" => "1.6.0",
+        "version" => "1.7.0",
         "thumbnail" => "thirtybees-thumb.png",
     ];
 
@@ -27,7 +27,7 @@ class ThirtyBeesSetup extends BaseSetup {
         "resources" => [
             "archive" => [
                 "src" =>
-                    "https://github.com/thirtybees/thirtybees/releases/download/1.6.0/thirtybees-v1.6.0-php7.4.zip",
+                    "https://github.com/thirtybees/thirtybees/releases/download/1.7.0/thirtybees-v1.7.0-php7.4.zip",
             ],
         ],
         "server" => [


### PR DESCRIPTION
Update:
- Grav to 2.0.11
- Joomla to 6.1.2
- MediaWiki to 1.46.0
- ThirtyBees to 1.7.0
- supported PHP versions of Nextcloud