### PR TITLE
feat(Mail): add optional start/end date schedule for account auto-reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ It has no effect on the working. Both "hestia" package and "hestia-web-terminal"
 ### Features
 
 - Add: JSON files can now be edited directly in the File Manager (#5342)
+- Add: Optional start/end date schedule for mail account auto-reply messages, applied daily by the new v-update-mail-autoreplies job
 
 ### Bug fixes
 

--- a/bin/v-add-mail-account
+++ b/bin/v-add-mail-account
@@ -115,7 +115,7 @@ if [[ "$quota" -eq '0' ]]; then
 	quota='unlimited'
 fi
 
-str="ACCOUNT='$account' ALIAS='' AUTOREPLY='no' FWD='' FWD_ONLY=''"
+str="ACCOUNT='$account' ALIAS='' AUTOREPLY='no' AUTOREPLY_START='' AUTOREPLY_END='' FWD='' FWD_ONLY=''"
 str="$str MD5='$md5' QUOTA='$quota' U_DISK='0' SUSPENDED='no'"
 str="$str TIME='$time' DATE='$date'"
 echo "$str" >> $USER_DATA/mail/$domain.conf

--- a/bin/v-add-mail-account-autoreply
+++ b/bin/v-add-mail-account-autoreply
@@ -1,10 +1,14 @@
 #!/bin/bash
 # info: add mail account autoreply message
-# options: USER DOMAIN ACCOUNT MESSAGE
+# options: USER DOMAIN ACCOUNT MESSAGE [START_DATE] [END_DATE]
 #
 # example: v-add-mail-account-autoreply admin example.com user Hello from e-mail!
+# example: v-add-mail-account-autoreply admin example.com user 'On vacation' 2026-08-01 2026-08-15
 #
-# This function add new email account.
+# This function adds an autoreply message to a mail account. Optional
+# START_DATE/END_DATE (YYYY-MM-DD) limit the period the autoreply is active.
+# The message file used by Exim is only present while the schedule is active;
+# a daily job (v-update-mail-autoreplies) keeps it in sync.
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #
@@ -16,6 +20,8 @@ domain=$2
 domain_idn=$2
 account=$3
 autoreply=$4
+autoreply_start=$5
+autoreply_end=$6
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -27,13 +33,6 @@ source $HESTIA/func/domain.sh
 # load config file
 source_conf "$HESTIA/conf/hestia.conf"
 
-# Define mail user
-if [ "$MAIL_SYSTEM" = 'exim4' ]; then
-	MAIL_USER=Debian-exim
-else
-	MAIL_USER=exim
-fi
-
 # Additional argument formatting
 format_domain
 format_domain_idn
@@ -43,8 +42,8 @@ format_domain_idn
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-check_args '4' "$#" 'USER DOMAIN ACCOUNT MESSAGE'
-is_format_valid 'user' 'domain' 'account' 'autoreply'
+check_args '4' "$#" 'USER DOMAIN ACCOUNT MESSAGE [START_DATE] [END_DATE]'
+is_format_valid 'user' 'domain' 'account' 'autoreply' 'autoreply_start' 'autoreply_end'
 is_system_enabled "$MAIL_SYSTEM" 'MAIL_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -52,7 +51,11 @@ is_object_valid 'mail' 'DOMAIN' "$domain"
 is_object_unsuspended 'mail' 'DOMAIN' "$domain"
 is_object_valid "mail/$domain" 'ACCOUNT' "$account"
 is_object_unsuspended "mail/$domain" 'ACCOUNT' "$account"
-# is_object_value_empty "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY'
+if [ -n "$autoreply_start" ] && [ -n "$autoreply_end" ]; then
+	if [[ "$autoreply_end" < "$autoreply_start" ]]; then
+		check_result "$E_INVALID" "autoreply start date $autoreply_start is after end date $autoreply_end"
+	fi
+fi
 
 # Perform verification if read-only mode is enabled
 check_hestia_demo_mode
@@ -61,22 +64,35 @@ check_hestia_demo_mode
 #                       Action                             #
 #----------------------------------------------------------#
 
-# Adding exim autoreply
-if [[ "$MAIL_SYSTEM" =~ exim ]]; then
-	msg="$HOMEDIR/$user/conf/mail/$domain/autoreply.$account.msg"
-	echo -e "$autoreply" > $msg
-	chown $MAIL_USER:mail $msg
-	chmod 660 $msg
+# Saving autoreply message (source of truth for the Exim message file)
+echo -e "$autoreply" > $USER_DATA/mail/$account@$domain.msg
+chmod 660 $USER_DATA/mail/$account@$domain.msg
+
+# Saving autoreply flag and schedule
+update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY' 'yes'
+add_object_key "mail/$domain" 'ACCOUNT' "$account" 'AUTOREPLY_START' 'FWD'
+add_object_key "mail/$domain" 'ACCOUNT' "$account" 'AUTOREPLY_END' 'FWD'
+update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY_START' "$autoreply_start"
+update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY_END' "$autoreply_end"
+
+# Creating or removing the Exim message file according to the schedule.
+# The direct file write together with the "Define mail user" block
+# (Debian-exim for MAIL_SYSTEM=exim4, exim otherwise) formerly inlined here
+# moved unchanged into sync_mail_account_autoreply() in func/domain.sh,
+# because the same create-or-remove decision is now also made by
+# v-update-mail-autoreplies (daily) and rebuild_mail_domain_conf, and all
+# callers must apply identical ownership ($MAIL_USER:mail) and mode (660).
+sync_mail_account_autoreply "$user" "$domain" "$account"
+
+# Installing daily updater: applies schedule transitions and restores the
+# message file if it went missing, even if previous runs were skipped
+if ! grep --silent --no-messages "v-update-mail-autoreplies" $HESTIA/data/queue/daily.pipe; then
+	echo "$BIN/v-update-mail-autoreplies" >> $HESTIA/data/queue/daily.pipe
 fi
 
 #----------------------------------------------------------#
 #                       Hestia                             #
 #----------------------------------------------------------#
-
-# Adding autoreply message
-echo -e "$autoreply" > $USER_DATA/mail/$account@$domain.msg
-chmod 660 $USER_DATA/mail/$account@$domain.msg
-update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY' 'yes'
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Mail" "Added auto-reply message for mail account $account@$domain."

--- a/bin/v-delete-mail-account-autoreply
+++ b/bin/v-delete-mail-account-autoreply
@@ -60,11 +60,15 @@ fi
 #                       Hestia                             #
 #----------------------------------------------------------#
 
-# Deleting autoreply message
-rm -f $USER_DATA/mail/$domain/$account@$domain.msg
+# Deleting autoreply message. Path fix: v-add-mail-account-autoreply stores
+# the copy directly in $USER_DATA/mail/, the previously used
+# $USER_DATA/mail/$domain/ path never existed so the copy was never removed
+rm -f $USER_DATA/mail/$account@$domain.msg
 
 # Update config
 update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY' 'no'
+update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY_START' ''
+update_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY_END' ''
 
 # Logging
 $BIN/v-log-action "$user" "Info" "Mail" "Mail account auto-reply removed (User: $account@$domain)."

--- a/bin/v-list-mail-account-autoreply
+++ b/bin/v-list-mail-account-autoreply
@@ -30,7 +30,9 @@ json_list() {
 	msg=$(echo "$msg" | sed -e "s|${TO_ESCAPE}|${TO_ESCAPE}${TO_ESCAPE}|g" -e 's/"/\\"/g' -e "s/%quote%/'/g")
 	echo '{'
 	echo -e "\t\"$account\": {"
-	echo "            \"MSG\": \"$msg\""
+	echo "            \"MSG\": \"$msg\","
+	echo "            \"START\": \"$autoreply_start\","
+	echo "            \"END\": \"$autoreply_end\""
 	echo -e "\t}\n}"
 }
 
@@ -46,8 +48,8 @@ plain_list() {
 
 # CSV list function
 csv_list() {
-	echo "MSG"
-	echo "$msg"
+	echo "MSG,START,END"
+	echo "$msg,$autoreply_start,$autoreply_end"
 }
 
 #----------------------------------------------------------#
@@ -70,6 +72,10 @@ if [ -e "$USER_DATA/mail/$account@$domain.msg" ]; then
 	msg=$(cat $USER_DATA/mail/$account@$domain.msg \
 		| sed ':a;N;$!ba;s/\n/\\n/g')
 fi
+
+# Reading autoreply schedule
+autoreply_start=$(get_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY_START')
+autoreply_end=$(get_object_value "mail/$domain" 'ACCOUNT' "$account" '$AUTOREPLY_END')
 
 # Listing data
 case $format in

--- a/bin/v-update-mail-autoreplies
+++ b/bin/v-update-mail-autoreplies
@@ -1,0 +1,84 @@
+#!/bin/bash
+# info: update mail account autoreply message files according to schedule
+# options: [DATE]
+#
+# example: v-update-mail-autoreplies
+# example: v-update-mail-autoreplies 2026-08-05
+#
+# This function synchronizes the Exim autoreply message files of all mail
+# accounts with their AUTOREPLY_START/AUTOREPLY_END schedule. It is executed
+# daily from the system cron queue. The optional DATE argument (YYYY-MM-DD)
+# overrides "today" which allows testing schedule transitions.
+
+#----------------------------------------------------------#
+#                Variables & Functions                     #
+#----------------------------------------------------------#
+
+# Importing system environment  as we run this script
+#       mostly by cron wich not read it by itself
+source /etc/profile.d/hestia.sh
+
+# Argument definition
+check_date=$1
+
+# Includes
+# shellcheck source=/etc/hestiacp/hestia.conf
+source /etc/hestiacp/hestia.conf
+# shellcheck source=/usr/local/hestia/func/main.sh
+source $HESTIA/func/main.sh
+# shellcheck source=/usr/local/hestia/func/domain.sh
+source $HESTIA/func/domain.sh
+# load config file
+source_conf "$HESTIA/conf/hestia.conf"
+
+#----------------------------------------------------------#
+#                    Verifications                         #
+#----------------------------------------------------------#
+
+check_args '0' "$#" '[DATE]'
+if [ -n "$check_date" ]; then
+	is_date_format_valid "$check_date"
+fi
+
+#----------------------------------------------------------#
+#                       Action                             #
+#----------------------------------------------------------#
+
+if [[ ! "$MAIL_SYSTEM" =~ exim ]]; then
+	exit
+fi
+
+failed=''
+for user in $("$BIN/v-list-users" list); do
+	USER_DATA=$HESTIA/data/users/$user
+	if [ ! -f "$USER_DATA/mail.conf" ]; then
+		continue
+	fi
+	for domain in $(awk -F "DOMAIN='" '{print $2}' $USER_DATA/mail.conf | cut -f 1 -d "'"); do
+		if [ ! -f "$USER_DATA/mail/$domain.conf" ]; then
+			continue
+		fi
+		for account in $(search_objects "mail/$domain" 'AUTOREPLY' 'yes' 'ACCOUNT'); do
+			if ! sync_mail_account_autoreply "$user" "$domain" "$account" "$check_date"; then
+				failed="$failed $account@$domain"
+			fi
+		done
+	done
+done
+
+#----------------------------------------------------------#
+#                       Hestia                             #
+#----------------------------------------------------------#
+
+# Notifying panel administrator about failures
+if [ -n "$failed" ]; then
+	$BIN/v-add-user-notification "$ROOT_USER" 'Mail auto-reply schedule update failed' \
+		"<p>The auto-reply message file could not be updated for:$failed</p><p>Check <code>$HESTIA/log/error.log</code> for details.</p>" \
+		'alert'
+	log_event "$E_UPDATE" "$ARGUMENTS"
+	exit "$E_UPDATE"
+fi
+
+log_event "$OK" "$ARGUMENTS"
+
+exit

--- a/bin/v-update-sys-defaults
+++ b/bin/v-update-sys-defaults
@@ -32,6 +32,7 @@ if [ -n "$system" ]; then
 else
 	syshealth_update_web_config_format
 	syshealth_update_mail_config_format
+	syshealth_update_mail_account_config_format
 	syshealth_update_dns_config_format
 	syshealth_update_db_config_format
 	syshealth_update_user_config_format

--- a/func/domain.sh
+++ b/func/domain.sh
@@ -769,6 +769,74 @@ is_mail_new() {
 	fi
 }
 
+# Check if autoreply schedule is active on given date.
+# Args: START_DATE END_DATE [CHECK_DATE] (YYYY-MM-DD, empty date = no bound)
+is_autoreply_schedule_active() {
+	local start_date="$1"
+	local end_date="$2"
+	local check_date="${3:-$(date +%F)}"
+	if [ -n "$start_date" ] && [[ "$check_date" < "$start_date" ]]; then
+		return 1
+	fi
+	if [ -n "$end_date" ] && [[ "$check_date" > "$end_date" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# Materialize or remove the Exim autoreply message file based on the
+# account AUTOREPLY flag and AUTOREPLY_START/AUTOREPLY_END schedule.
+# The Hestia copy in $HESTIA/data/users/$user/mail is the source of truth.
+#
+# This consolidates the write logic formerly inlined in
+# v-add-mail-account-autoreply: the mail user selection (Debian-exim for
+# MAIL_SYSTEM=exim4, exim otherwise), the group (mail) and the mode (660)
+# are preserved 1:1. Shared by v-add-mail-account-autoreply,
+# v-update-mail-autoreplies and rebuild_mail_domain_conf so the file is
+# always created with the same ownership regardless of the caller.
+# Args: USER DOMAIN ACCOUNT [CHECK_DATE]
+sync_mail_account_autoreply() {
+	local user="$1"
+	local domain="$2"
+	local account="$3"
+	local check_date="${4:-$(date +%F)}"
+	local user_data="$HESTIA/data/users/$user"
+	local msg_src="$user_data/mail/$account@$domain.msg"
+	local msg_dst="$HOMEDIR/$user/conf/mail/$domain/autoreply.$account.msg"
+	local mail_user
+
+	if [[ ! "$MAIL_SYSTEM" =~ exim ]]; then
+		return 0
+	fi
+
+	# Define mail user
+	if [ "$MAIL_SYSTEM" = 'exim4' ]; then
+		mail_user="Debian-exim"
+	else
+		mail_user="exim"
+	fi
+
+	# Reset before parsing: schedule keys may be missing in older records
+	AUTOREPLY='no'
+	AUTOREPLY_START=''
+	AUTOREPLY_END=''
+	parse_object_kv_list "$(grep "ACCOUNT='$account'" "$user_data/mail/$domain.conf")"
+
+	if [ "$AUTOREPLY" = 'yes' ] && [ -e "$msg_src" ] \
+		&& is_autoreply_schedule_active "$AUTOREPLY_START" "$AUTOREPLY_END" "$check_date"; then
+		if ! cp -f "$msg_src" "$msg_dst" \
+			|| ! chown "$mail_user":mail "$msg_dst" \
+			|| ! chmod 660 "$msg_dst"; then
+			return 1
+		fi
+	else
+		if ! rm -f "$msg_dst"; then
+			return 1
+		fi
+	fi
+	return 0
+}
+
 # Add mail server SSL configuration
 add_mail_ssl_config() {
 	# Ensure that SSL certificate directories exists

--- a/func/main.sh
+++ b/func/main.sh
@@ -1437,6 +1437,8 @@ is_format_valid() {
 				antispam) is_boolean_format_valid "$arg" 'antispam' ;;
 				antivirus) is_boolean_format_valid "$arg" 'antivirus' ;;
 				autoreply) is_autoreply_format_valid "$arg" ;;
+				autoreply_end) is_date_format_valid "$arg" ;;
+				autoreply_start) is_date_format_valid "$arg" ;;
 				backup) is_object_format_valid "$arg" 'backup' ;;
 				charset) is_object_format_valid "$arg" "$arg_name" ;;
 				charsets) is_common_format_valid "$arg" 'charsets' ;;

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -740,6 +740,10 @@ rebuild_mail_domain_conf() {
 				sed -i "/^$account@$domain_idn:/ d" $HOMEDIR/$user/conf/mail/$domain/limits
 				echo "$account@$domain_idn:$system" >> $HOMEDIR/$user/conf/mail/$domain/limits
 			fi
+			# Restore autoreply message file according to schedule. Before the
+			# schedule feature rebuild never recreated autoreply.$account.msg;
+			# now it is derived from the $USER_DATA copy like on every daily run
+			sync_mail_account_autoreply "$user" "$domain" "$account"
 		fi
 	done
 

--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -92,7 +92,7 @@ function syshealth_update_mail_config_format() {
 function syshealth_update_mail_account_config_format() {
 	# MAIL ACCOUNTS
 	system="mail_accounts"
-	known_keys="ACCOUNT ALIAS AUTOREPLY FWD FWD_ONLY MD5 QUOTA RATE_LIMIT U_DISK SUSPENDED TIME DATE"
+	known_keys="ACCOUNT ALIAS AUTOREPLY AUTOREPLY_START AUTOREPLY_END FWD FWD_ONLY MD5 QUOTA RATE_LIMIT U_DISK SUSPENDED TIME DATE"
 	write_kv_config_file
 	unset system
 	unset known_keys

--- a/test/test.bats
+++ b/test/test.bats
@@ -1706,6 +1706,114 @@ function check_ip_not_banned(){
     assert_file_contains /etc/exim4/domains/$domain/limits "test@$domain:10"
 }
 
+@test "MAIL: Add account autoreply" {
+    run v-add-mail-account-autoreply $user $domain test "Test autoreply message"
+    assert_success
+    refute_output
+
+    assert_file_exist /etc/exim4/domains/$domain/autoreply.test.msg
+    assert_file_contains "${HESTIA}/data/users/${user}/mail/${domain}.conf" "AUTOREPLY='yes'"
+}
+
+@test "MAIL: Autoreply daily updater registered" {
+    run grep "v-update-mail-autoreplies" "${HESTIA}/data/queue/daily.pipe"
+    assert_success
+}
+
+@test "MAIL: Autoreply message file is restored if missing" {
+    rm -f /etc/exim4/domains/$domain/autoreply.test.msg
+    run v-update-mail-autoreplies
+    assert_success
+    refute_output
+
+    assert_file_exist /etc/exim4/domains/$domain/autoreply.test.msg
+}
+
+@test "MAIL: Add account autoreply with future schedule" {
+    run v-add-mail-account-autoreply $user $domain test "Vacation" 2044-01-10 2044-01-31
+    assert_success
+    refute_output
+
+    assert_file_not_exist /etc/exim4/domains/$domain/autoreply.test.msg
+    assert_file_contains "${HESTIA}/data/users/${user}/mail/${domain}.conf" "AUTOREPLY_START='2044-01-10'"
+    assert_file_contains "${HESTIA}/data/users/${user}/mail/${domain}.conf" "AUTOREPLY_END='2044-01-31'"
+}
+
+@test "MAIL: List account autoreply with schedule" {
+    run v-list-mail-account-autoreply $user $domain test json
+    assert_success
+    assert_output --partial '"START": "2044-01-10"'
+    assert_output --partial '"END": "2044-01-31"'
+}
+
+@test "MAIL: Autoreply schedule transitions" {
+    # inside the window: message file must be created
+    run v-update-mail-autoreplies 2044-01-15
+    assert_success
+    refute_output
+    assert_file_exist /etc/exim4/domains/$domain/autoreply.test.msg
+
+    # before the window: message file must be removed
+    run v-update-mail-autoreplies 2044-01-09
+    assert_success
+    refute_output
+    assert_file_not_exist /etc/exim4/domains/$domain/autoreply.test.msg
+
+    # after the window: message file must stay removed
+    run v-update-mail-autoreplies 2044-02-01
+    assert_success
+    refute_output
+    assert_file_not_exist /etc/exim4/domains/$domain/autoreply.test.msg
+}
+
+@test "MAIL: Autoreply schedule with end date only" {
+    run v-add-mail-account-autoreply $user $domain test "Vacation" '' 2044-01-31
+    assert_success
+    refute_output
+
+    # no start date: active immediately
+    assert_file_exist /etc/exim4/domains/$domain/autoreply.test.msg
+
+    # past the end date: no longer active
+    run v-update-mail-autoreplies 2044-02-01
+    assert_success
+    assert_file_not_exist /etc/exim4/domains/$domain/autoreply.test.msg
+}
+
+@test "MAIL: Autoreply schedule with start date only" {
+    run v-add-mail-account-autoreply $user $domain test "Vacation" 2044-01-10 ''
+    assert_success
+    refute_output
+
+    # before the start date: not active
+    assert_file_not_exist /etc/exim4/domains/$domain/autoreply.test.msg
+
+    # no end date: active indefinitely after the start date
+    run v-update-mail-autoreplies 2050-06-06
+    assert_success
+    assert_file_exist /etc/exim4/domains/$domain/autoreply.test.msg
+}
+
+@test "MAIL: Autoreply schedule invalid date format" {
+    run v-add-mail-account-autoreply $user $domain test "Vacation" 2044-1-1
+    assert_failure $E_INVALID
+}
+
+@test "MAIL: Autoreply start date after end date" {
+    run v-add-mail-account-autoreply $user $domain test "Vacation" 2044-02-01 2044-01-01
+    assert_failure $E_INVALID
+}
+
+@test "MAIL: Delete account autoreply" {
+    run v-delete-mail-account-autoreply $user $domain test
+    assert_success
+    refute_output
+
+    assert_file_not_exist /etc/exim4/domains/$domain/autoreply.test.msg
+    assert_file_not_exist "${HESTIA}/data/users/${user}/mail/test@${domain}.msg"
+    assert_file_contains "${HESTIA}/data/users/${user}/mail/${domain}.conf" "AUTOREPLY='no'"
+}
+
 @test "MAIL: Delete account" {
     run v-delete-mail-account $user $domain test
     assert_success

--- a/web/edit/mail/index.php
+++ b/web/edit/mail/index.php
@@ -161,8 +161,12 @@ if (!empty($_GET["domain"]) && !empty($_GET["account"])) {
 		unset($output);
 		$v_autoreply_message = $autoreply_str[$v_account]["MSG"];
 		$v_autoreply_message = str_replace("\\n", "\n", $v_autoreply_message);
+		$v_autoreply_start = $autoreply_str[$v_account]["START"] ?? "";
+		$v_autoreply_end = $autoreply_str[$v_account]["END"] ?? "";
 	} else {
 		$v_autoreply_message = "";
+		$v_autoreply_start = "";
+		$v_autoreply_end = "";
 	}
 }
 
@@ -1042,13 +1046,20 @@ if (!empty($_POST["save"]) && !empty($_GET["domain"]) && !empty($_GET["account"]
 		unset($output);
 		$v_autoreply = "no";
 		$v_autoreply_message = "";
+		$v_autoreply_start = "";
+		$v_autoreply_end = "";
 	}
 
 	// Add autoreply
 	if (!empty($_POST["v_autoreply"]) && empty($_SESSION["error_msg"])) {
-		if ($v_autoreply_message != str_replace("\r\n", "\n", $_POST["v_autoreply_message"])) {
-			$v_autoreply_message = str_replace("\r\n", "\n", $_POST["v_autoreply_message"]);
-			$v_autoreply_message = quoteshellarg($v_autoreply_message);
+		$new_autoreply_message = str_replace("\r\n", "\n", $_POST["v_autoreply_message"]);
+		$new_autoreply_start = trim($_POST["v_autoreply_start"] ?? "");
+		$new_autoreply_end = trim($_POST["v_autoreply_end"] ?? "");
+		if (
+			$v_autoreply_message != $new_autoreply_message ||
+			($v_autoreply_start ?? "") != $new_autoreply_start ||
+			($v_autoreply_end ?? "") != $new_autoreply_end
+		) {
 			exec(
 				HESTIA_CMD .
 					"v-add-mail-account-autoreply " .
@@ -1058,7 +1069,11 @@ if (!empty($_POST["save"]) && !empty($_GET["domain"]) && !empty($_GET["account"]
 					" " .
 					quoteshellarg($v_account) .
 					" " .
-					$v_autoreply_message,
+					quoteshellarg($new_autoreply_message) .
+					" " .
+					quoteshellarg($new_autoreply_start) .
+					" " .
+					quoteshellarg($new_autoreply_end),
 				$output,
 				$return_var,
 			);
@@ -1066,6 +1081,8 @@ if (!empty($_POST["save"]) && !empty($_GET["domain"]) && !empty($_GET["account"]
 			unset($output);
 			$v_autoreply = "yes";
 			$v_autoreply_message = $_POST["v_autoreply_message"];
+			$v_autoreply_start = $new_autoreply_start;
+			$v_autoreply_end = $new_autoreply_end;
 		}
 	}
 

--- a/web/templates/pages/edit_mail_acc.php
+++ b/web/templates/pages/edit_mail_acc.php
@@ -19,7 +19,15 @@
 
 	<form
 		x-data="{
-			hasAutoReply: <?= tohtml($v_autoreply == "yes" ? "true" : "false") ?>
+			hasAutoReply: <?= tohtml($v_autoreply == "yes" ? "true" : "false") ?>,
+			autoreplyStart: '<?= tohtml(trim($v_autoreply_start ?? "", "'")) ?>',
+			autoreplyEnd: '<?= tohtml(trim($v_autoreply_end ?? "", "'")) ?>',
+			autoreplyToday: '<?= date("Y-m-d") ?>',
+			autoreplyStatus() {
+				if (this.autoreplyStart && this.autoreplyToday < this.autoreplyStart) return 'scheduled';
+				if (this.autoreplyEnd && this.autoreplyToday > this.autoreplyEnd) return 'expired';
+				return 'active';
+			}
 		}"
 		id="main-form"
 		name="v_edit_mail_acc"
@@ -112,12 +120,35 @@
 							<label for="v_autoreply_message" class="form-label"><?= tohtml( _("Message")) ?></label>
 							<textarea class="form-control" name="v_autoreply_message" id="v_autoreply_message"><?= tohtml(trim($v_autoreply_message, "'")) ?></textarea>
 						</div>
+						<div class="u-mb10">
+							<label for="v_autoreply_start" class="form-label">
+								<?= tohtml( _("Start date")) ?> <span class="optional">(<?= tohtml( _("optional")) ?>)</span>
+							</label>
+							<input type="date" class="form-control" name="v_autoreply_start" id="v_autoreply_start" x-model="autoreplyStart" :max="autoreplyEnd || false">
+						</div>
+						<div class="u-mb10">
+							<label for="v_autoreply_end" class="form-label">
+								<?= tohtml( _("End date")) ?> <span class="optional">(<?= tohtml( _("optional")) ?>)</span>
+							</label>
+							<input type="date" class="form-control" name="v_autoreply_end" id="v_autoreply_end" x-model="autoreplyEnd" :min="autoreplyStart || false">
+						</div>
+						<div class="u-mb10">
+							<span x-show="autoreplyStatus() === 'active'">
+								<i class="fas fa-circle-check icon-green"></i> <?= tohtml( _("Active")) ?>
+							</span>
+							<span x-show="autoreplyStatus() === 'scheduled'">
+								<i class="fas fa-clock icon-orange"></i> <?= tohtml( _("Scheduled")) ?>
+							</span>
+							<span x-show="autoreplyStatus() === 'expired'">
+								<i class="fas fa-circle-xmark icon-red"></i> <?= tohtml( _("Expired")) ?>
+							</span>
+						</div>
 					</div>
 					<div class="u-mb20">
 						<label for="v_rate" class="form-label">
 							<?= tohtml( _("Rate Limit")) ?> <span class="optional">(<?= tohtml( _("email / hour")) ?>)</span>
 						</label>
-						<input type="text" class="form-control" name="v_rate" id="v_rate" value="<?= tohtml(trim($v_rate, "'")) ?>" <?php if ($_SESSION['userContext'] != "admin"){ echo "disabled"; }?>>
+						<input type="number" min="0" step="1" class="form-control" name="v_rate" id="v_rate" value="<?= tohtml(trim($v_rate, "'")) ?>" <?php if ($_SESSION['userContext'] != "admin"){ echo "disabled"; }?>>
 					</div>
 				</div>
 				<div class="sidebar-right-grid-sidebar">


### PR DESCRIPTION
- Store AUTOREPLY_START/AUTOREPLY_END (YYYY-MM-DD, empty = no bound) in the mail account record; validated (format, start <= end), keys added to syshealth known_keys and the account creation template
- New v-update-mail-autoreplies daily job (self-registered in daily.pipe): creates/removes the Exim message file according to the schedule, restores a lost file even after missed runs and notifies the panel administrator on failures
- sync_mail_account_autoreply() in func/domain.sh consolidates the Exim file write formerly inlined in v-add-mail-account-autoreply; the mail user selection (Debian-exim/exim), group and 660 mode are preserved 1:1 and reused by the daily job and rebuild_mail_domain_conf
- rebuild_mail_domain_conf now restores the autoreply message file from the USER_DATA copy according to the schedule
- Panel: date pickers with live Active/Scheduled/Expired status, mutual min/max limits on the date inputs, numeric Rate Limit input
- Fix: v-delete-mail-account-autoreply removed the message copy from a path that never existed; schedule keys are cleared on delete
- BATS tests covering all schedule combinations, transitions, self-heal, validation and cleanup