### PR TITLE
Fix invalid JSON output in v-list-mail-domain-ssl

### DIFF
--- a/bin/v-list-mail-domain-ssl
+++ b/bin/v-list-mail-domain-ssl
@@ -29,6 +29,7 @@ format_domain_idn
 
 # JSON list function
 json_list() {
+	issuer=$(echo "$issuer" | sed -e 's/"/\\"/g' -e "s/%quote%/'/g")
 	echo '{'
 	echo -e "\t\"$domain\": {"
 	echo "        \"CRT\": \"$crt\","


### PR DESCRIPTION
The `json_list()` function in `v-list-mail-domain-ssl` was missing the issuer sanitization step present in `v-list-web-domain-ssl`. Certificate issuer strings from openssl often contain literal double quotes (e.g. O = "CloudFlare, Inc."), which broke the JSON output when embedded unescaped in the ISSUER field, causing jq parse errors.

Added the same sed escaping used in `v-list-web-domain-ssl` to escape double quotes in `$issuer` before building the JSON output.

Fixes #5522