### PR TITLE
fix: phpMyAdmin SSO IP check uses different logic than token creation

### DIFF
--- a/install/deb/phpmyadmin/hestia-sso.php
+++ b/install/deb/phpmyadmin/hestia-sso.php
@@ -9,6 +9,13 @@ define("API_HOST_NAME", "%API_HOST_NAME%");
 define("API_HESTIA_PORT", "%API_HESTIA_PORT%");
 define("API_KEY", "%API_KEY%");
 
+/* Reuse Hestia's own get_real_user_ip() (see get_user_ip() below) instead of
+   re-implementing IP detection here -- this file is deployed standalone into
+   phpMyAdmin's directory, but Hestia's install path is fixed, so it's safe
+   to reach back into it. */
+require_once "/usr/local/hestia/web/inc/vendor/autoload.php";
+require_once "/usr/local/hestia/web/inc/helpers.php";
+
 class Hestia_API {
 	/** @var string */
 	public $hostname;
@@ -80,40 +87,14 @@ class Hestia_API {
 	}
 
 	public function get_user_ip() {
-		// Saving user IPs to the session for preventing session hijacking
-		$user_combined_ip = [];
-		if ($_SERVER["REMOTE_ADDR"] != $_SERVER["SERVER_ADDR"]) {
-			$user_combined_ip[] = $_SERVER["REMOTE_ADDR"];
-		}
-		if (isset($_SERVER["HTTP_CLIENT_IP"])) {
-			$user_combined_ip .= "|" . $_SERVER["HTTP_CLIENT_IP"];
-		}
-		if (isset($_SERVER["HTTP_X_FORWARDED_FOR"])) {
-			if ($_SERVER["REMOTE_ADDR"] != $_SERVER["HTTP_X_FORWARDED_FOR"]) {
-				$user_combined_ip[] = $_SERVER["HTTP_X_FORWARDED_FOR"];
-			}
-		}
-		if (isset($_SERVER["HTTP_FORWARDED_FOR"])) {
-			if ($_SERVER["REMOTE_ADDR"] != $_SERVER["HTTP_FORWARDED_FOR"]) {
-				$user_combined_ip[] = $_SERVER["HTTP_FORWARDED_FOR"];
-			}
-		}
-		if (isset($_SERVER["HTTP_X_FORWARDED"])) {
-			if ($_SERVER["REMOTE_ADDR"] != $_SERVER["HTTP_X_FORWARDED"]) {
-				$user_combined_ip[] = $_SERVER["HTTP_X_FORWARDED"];
-			}
-		}
-		if (isset($_SERVER["HTTP_FORWARDED"])) {
-			if ($_SERVER["REMOTE_ADDR"] != $_SERVER["HTTP_FORWARDED"]) {
-				$user_combined_ip[] = "|" . $_SERVER["HTTP_FORWARDED"];
-			}
-		}
-		if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
-			if (!empty($_SERVER["HTTP_CF_CONNECTING_IP"])) {
-				$user_combined_ip[] = $_SERVER["HTTP_CF_CONNECTING_IP"];
-			}
-		}
-		return implode("|", $user_combined_ip);
+		// Must compute the IP exactly the same way get_real_user_ip() does
+		// in web/inc/helpers.php -- that's what was used to build the
+		// token this value gets checked against in verify_token() below.
+		// This used to re-implement its own (inconsistent) IP detection,
+		// which silently disagreed with get_real_user_ip() as soon as a
+		// reverse proxy or Cloudflare was involved, breaking every SSO
+		// login behind one with "security token mismatch" (see #5068).
+		return get_real_user_ip();
 	}
 }
 


### PR DESCRIPTION
## Description

Closes #5068.

`hestia-sso.php`'s `get_user_ip()` (used to verify the SSO token when the callback is hit) computes the request's IP with completely different logic than `get_real_user_ip()` in `web/inc/helpers.php` (used to build the token in the first place, e.g. in `list_db.php`). The two silently disagree in common situations:

- Whenever `REMOTE_ADDR == SERVER_ADDR`, `get_user_ip()`'s inverted `!=` check leaves its IP list empty, while `get_real_user_ip()` still returns the real address.
- Any of `X-Forwarded-For`/`X-Forwarded`/`Forwarded`/`Client-IP` present causes `get_user_ip()` to append them (one branch even does `.=` string concatenation on what's declared as an array a few lines earlier), none of which `get_real_user_ip()` considers at all.
- Behind Cloudflare specifically (the case reported in #5068), `get_user_ip()` unconditionally trusts `CF-Connecting-IP` and combines it with `REMOTE_ADDR`, while `get_real_user_ip()` only substitutes it after validating `REMOTE_ADDR` is an actual Cloudflare edge IP -- and never combines the two.

Since the token's hash is `password_hash($database . $user . $ip . $time . KEY, ...)`, any of these mean `verify_token()`'s `password_verify()` call is comparing against a value that was never used to build the token, so it fails every time with "Access denied: There is a security token mismatch" -- not an edge case, just a broken login for any of these setups.

## Fix

`get_user_ip()` now simply returns `get_real_user_ip()` -- the exact function the panel side already uses -- instead of re-implementing IP detection with different (buggy) logic. Both sides of the comparison are now guaranteed to compute the same value.

`hestia-sso.php` is deployed standalone into phpMyAdmin's own directory (copied out of `install/deb/phpmyadmin/` by `v-add-sys-pma-sso`), so it doesn't normally have access to Hestia's own PHP includes. Since Hestia's install path is fixed, it now `require_once`s `web/inc/vendor/autoload.php` and `web/inc/helpers.php` directly from there (confirmed these are always present -- `bin/v-add-sys-dependencies`, which every install runs, is what installs that Composer dependency).

## How to test

The mismatch is easiest to reproduce without needing a real Cloudflare-fronted install:

```php
$_SERVER["REMOTE_ADDR"] = "192.168.1.109";
$_SERVER["SERVER_ADDR"] = "192.168.1.109"; // same as REMOTE_ADDR

// old get_user_ip() logic
function old_get_user_ip() {
    $user_combined_ip = [];
    if ($_SERVER["REMOTE_ADDR"] != $_SERVER["SERVER_ADDR"]) {
        $user_combined_ip[] = $_SERVER["REMOTE_ADDR"];
    }
    return implode("|", $user_combined_ip);
}

require_once "/usr/local/hestia/web/inc/vendor/autoload.php";
require_once "/usr/local/hestia/web/inc/helpers.php";

var_dump(old_get_user_ip());     // string(0) ""
var_dump(get_real_user_ip());    // string(13) "192.168.1.109"
```

Ran this on a real Hestia install: before the fix, `get_user_ip()` returns an empty string whenever `REMOTE_ADDR == SERVER_ADDR`, while `get_real_user_ip()` (what actually built the token) returns the real IP -- guaranteed `password_verify()` failure. After the fix, both return the identical value.

Also verified `hestia-sso.php` still loads and parses cleanly (`php -l`) with the new `require_once` calls, and confirmed `web/inc/vendor/autoload.php` / `web/inc/helpers.php` exist on a normally-installed server.
