### PR TITLE
Add posibility to build hestia package without any chroot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"jsdom": "^29.1.1",
 				"lightningcss": "^1.32.0",
 				"lint-staged": "^17.0.8",
-				"markdownlint-cli2": "^0.23.0",
+				"markdownlint-cli2": "^0.23.1",
 				"prettier": "^3.9.5",
 				"prettier-plugin-nginx": "^1.0.3",
 				"prettier-plugin-sh": "^0.19.0",
@@ -3486,9 +3486,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3692,9 +3692,9 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-			"integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+			"version": "16.2.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
+			"integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3896,9 +3896,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4368,9 +4368,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-			"integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+			"integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5158,9 +5158,9 @@
 			"license": "MIT"
 		},
 		"node_modules/markdown-it": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-			"integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+			"integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5175,8 +5175,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
-				"entities": "^4.4.0",
-				"linkify-it": "^5.0.1",
+				"entities": "^4.5.0",
+				"linkify-it": "^5.0.2",
 				"mdurl": "^2.0.0",
 				"punycode.js": "^2.3.1",
 				"uc.micro": "^2.1.0"
@@ -5186,9 +5186,9 @@
 			}
 		},
 		"node_modules/markdownlint": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.0.tgz",
-			"integrity": "sha512-xMUI3ChBuRuxuLF4ENvCZyS8z/+Jly1coUcZwErKLIB3sDj7ojpaTBa1e9YVPhSN4jGEIjYGQCldbTJS/hqS+A==",
+			"version": "0.41.1",
+			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+			"integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5210,18 +5210,18 @@
 			}
 		},
 		"node_modules/markdownlint-cli2": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.0.tgz",
-			"integrity": "sha512-1nmgQmU/ZTMRVwYCDs7i1HI3zfBISnT2NNRv+9V01oOLZbAtqL+a7tldpPhBWBVBten3FqhMCGV6EUh9McqutQ==",
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.1.tgz",
+			"integrity": "sha512-20JPI5W+HpV1OA+pUM712wgvL4GzYNUvbmhLU8KlEYJ1kCDx4soZ4/Xqd+WkLrPTOKMAn8SfO3zYFrK8GLlwQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"globby": "16.2.0",
-				"js-yaml": "5.2.0",
+				"globby": "16.2.1",
+				"js-yaml": "5.2.1",
 				"jsonc-parser": "3.3.1",
 				"jsonpointer": "5.0.1",
-				"markdown-it": "14.2.0",
-				"markdownlint": "0.41.0",
+				"markdown-it": "14.3.0",
+				"markdownlint": "0.41.1",
 				"markdownlint-cli2-formatter-default": "0.0.6",
 				"micromatch": "4.0.8",
 				"smol-toml": "1.7.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"jsdom": "^29.1.1",
 		"lightningcss": "^1.32.0",
 		"lint-staged": "^17.0.8",
-		"markdownlint-cli2": "^0.23.0",
+		"markdownlint-cli2": "^0.23.1",
 		"prettier": "^3.9.5",
 		"prettier-plugin-nginx": "^1.0.3",
 		"prettier-plugin-sh": "^0.19.0",

--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -145,8 +145,10 @@ get_distro_suffix() {
 
 apply_distro_version() {
 	local control_file="$1"
-	local distro_suffix
-	distro_suffix=$(get_distro_suffix)
+	local distro_suffix="$2"
+	if [ -z "$distro_suffix" ]; then
+		distro_suffix=$(get_distro_suffix)
+	fi
 
 	local current_version
 	current_version=$(grep "^Version:" "$control_file" | awk '{print $2}')
@@ -357,6 +359,8 @@ fi
 echo "Build version ${BUILD_VER}${_build_release}, with Nginx version $NGINX_V, PHP version $PHP_V and Web Terminal version $WEB_TERMINAL_V"
 
 HESTIA_V="${BUILD_VER}_${BUILD_ARCH}"
+# List of supported OS releases for Hestia used for crossbuilding.
+supported_os="debian11 debian12 debian13 ubuntu22.04 ubuntu24.04 ubuntu26.04"
 OPENSSL_V='3.5.7'
 PCRE_V='10.47'
 ZLIB_V='1.3.2'
@@ -803,75 +807,82 @@ arch="$BUILD_ARCH"
 if [ "$HESTIA_B" = true ]; then
 	if [ "$CROSS" = "true" ]; then
 		arch="amd64 arm64"
+	else
+		arch="$BUILD_ARCH"
+		supported_os=$(get_distro_suffix)
 	fi
-	for BUILD_ARCH in $arch; do
-		echo "Building Hestia Control Panel package..."
 
-		BUILD_DIR_HESTIA=$BUILD_DIR/hestia_$HESTIA_V
+	echo "Building Hestia Control Panel package..."
 
-		# Change to build directory
-		cd $BUILD_DIR
+	BUILD_DIR_HESTIA=$BUILD_DIR/hestia_$HESTIA_V
 
-		if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIA" ]; then
-			# Check if target directory exist
-			if [ -d $BUILD_DIR_HESTIA ]; then
-				rm -r $BUILD_DIR_HESTIA
-			fi
+	# Change to build directory
+	cd $BUILD_DIR
 
-			# Create directory
-			mkdir -p $BUILD_DIR_HESTIA
-		fi
-
-		cd $BUILD_DIR
-		rm -rf $BUILD_DIR/hestiacp-$branch_dash
-		# Download and unpack source files
-		if [ "$use_src_folder" == 'true' ]; then
-			[ "$HESTIA_DEBUG" ] && echo DEBUG: cp -rf "$SRC_DIR/" $BUILD_DIR/hestiacp-$branch_dash
-			cp -rf "$SRC_DIR/" $BUILD_DIR/hestiacp-$branch_dash
-		elif [ -d $SRC_DIR ]; then
-			download_file $HESTIA_ARCHIVE_LINK '-' 'fresh' | tar xz
-		fi
-
-		mkdir -p $BUILD_DIR_HESTIA/usr/local/hestia
-
-		# Build web and move needed directories
-		cd $BUILD_DIR/hestiacp-$branch_dash
-		npm ci --ignore-scripts
-		npm run build
-		cp -rf bin func install web $BUILD_DIR_HESTIA/usr/local/hestia/
-
-		# Set permissions
-		find $BUILD_DIR_HESTIA/usr/local/hestia/ -type f -exec chmod -x {} \;
-
-		# Allow send email via /usr/local/hestia/web/inc/mail-wrapper.php via cli
-		chmod +x $BUILD_DIR_HESTIA/usr/local/hestia/web/inc/mail-wrapper.php
-		# Allow the executable to be executed
-		chmod +x $BUILD_DIR_HESTIA/usr/local/hestia/bin/*
-		find $BUILD_DIR_HESTIA/usr/local/hestia/install/ \( -name '*.sh' \) -exec chmod +x {} \;
-		chmod -x $BUILD_DIR_HESTIA/usr/local/hestia/install/*.sh
-		chown -R root:root $BUILD_DIR_HESTIA
-		# Get Debian package files
-		mkdir -p $BUILD_DIR_HESTIA/DEBIAN
-		get_branch_file 'src/deb/hestia/control' "$BUILD_DIR_HESTIA/DEBIAN/control"
-		if [ "$BUILD_ARCH" != "amd64" ]; then
-			sed -i "s/amd64/${BUILD_ARCH}/g" "$BUILD_DIR_HESTIA/DEBIAN/control"
-		fi
-		apply_distro_version "$BUILD_DIR_HESTIA/DEBIAN/control"
-		get_branch_file 'src/deb/hestia/copyright' "$BUILD_DIR_HESTIA/DEBIAN/copyright"
-		get_branch_file 'src/deb/hestia/preinst' "$BUILD_DIR_HESTIA/DEBIAN/preinst"
-		get_branch_file 'src/deb/hestia/postinst' "$BUILD_DIR_HESTIA/DEBIAN/postinst"
-		chmod +x $BUILD_DIR_HESTIA/DEBIAN/postinst
-		chmod +x $BUILD_DIR_HESTIA/DEBIAN/preinst
-
-		echo Building Hestia DEB
-		dpkg-deb -Zxz --build $BUILD_DIR_HESTIA $DEB_DIR
-
-		# clear up the source folder
-		if [ "$KEEPBUILD" != 'true' ]; then
+	if [ "$KEEPBUILD" != 'true' ] || [ ! -d "$BUILD_DIR_HESTIA" ]; then
+		# Check if target directory exist
+		if [ -d $BUILD_DIR_HESTIA ]; then
 			rm -r $BUILD_DIR_HESTIA
-			rm -rf hestiacp-$branch_dash
 		fi
-		cd $BUILD_DIR/hestiacp-$branch_dash
+
+		# Create directory
+		mkdir -p $BUILD_DIR_HESTIA
+	fi
+
+	cd $BUILD_DIR
+	rm -rf $BUILD_DIR/hestiacp-$branch_dash
+	# Download and unpack source files
+	if [ "$use_src_folder" == 'true' ]; then
+		[ "$HESTIA_DEBUG" ] && echo DEBUG: cp -rf "$SRC_DIR/" $BUILD_DIR/hestiacp-$branch_dash
+		cp -rf "$SRC_DIR/" $BUILD_DIR/hestiacp-$branch_dash
+	elif [ -d $SRC_DIR ]; then
+		download_file $HESTIA_ARCHIVE_LINK '-' 'fresh' | tar xz
+	fi
+
+	mkdir -p $BUILD_DIR_HESTIA/usr/local/hestia
+
+	# Build web and move needed directories
+	cd $BUILD_DIR/hestiacp-$branch_dash
+	npm ci --ignore-scripts
+	npm run build
+	for BUILD_ARCH in $arch; do
+		for os in $supported_os; do
+			mkdir -p $BUILD_DIR_HESTIA/usr/local/hestia
+			cp -rf bin func install web $BUILD_DIR_HESTIA/usr/local/hestia/
+
+			# Set permissions
+			find $BUILD_DIR_HESTIA/usr/local/hestia/ -type f -exec chmod -x {} \;
+
+			# Allow send email via /usr/local/hestia/web/inc/mail-wrapper.php via cli
+			chmod +x $BUILD_DIR_HESTIA/usr/local/hestia/web/inc/mail-wrapper.php
+			# Allow the executable to be executed
+			chmod +x $BUILD_DIR_HESTIA/usr/local/hestia/bin/*
+			find $BUILD_DIR_HESTIA/usr/local/hestia/install/ \( -name '*.sh' \) -exec chmod +x {} \;
+			chmod -x $BUILD_DIR_HESTIA/usr/local/hestia/install/*.sh
+			chown -R root:root $BUILD_DIR_HESTIA
+			# Get Debian package files
+			mkdir -p $BUILD_DIR_HESTIA/DEBIAN
+			get_branch_file 'src/deb/hestia/control' "$BUILD_DIR_HESTIA/DEBIAN/control"
+			if [ "$BUILD_ARCH" != "amd64" ]; then
+				sed -i "s/amd64/${BUILD_ARCH}/g" "$BUILD_DIR_HESTIA/DEBIAN/control"
+			fi
+			apply_distro_version "$BUILD_DIR_HESTIA/DEBIAN/control" "$os"
+			get_branch_file 'src/deb/hestia/copyright' "$BUILD_DIR_HESTIA/DEBIAN/copyright"
+			get_branch_file 'src/deb/hestia/preinst' "$BUILD_DIR_HESTIA/DEBIAN/preinst"
+			get_branch_file 'src/deb/hestia/postinst' "$BUILD_DIR_HESTIA/DEBIAN/postinst"
+			chmod +x $BUILD_DIR_HESTIA/DEBIAN/postinst
+			chmod +x $BUILD_DIR_HESTIA/DEBIAN/preinst
+
+			echo Building Hestia DEB
+			dpkg-deb -Zxz --build $BUILD_DIR_HESTIA $DEB_DIR
+
+			# clear up the source folder
+			if [ "$KEEPBUILD" != 'true' ]; then
+				rm -r $BUILD_DIR_HESTIA
+				rm -rf hestiacp-$branch_dash
+			fi
+			cd $BUILD_DIR/hestiacp-$branch_dash
+		done
 	done
 fi
 


### PR DESCRIPTION
Since the hestia package doesn't depend on any specific compilation, we can build it without chroot.

However, the version naming broke things, since a unique name is required for each build. This PR makes the build script loop through all currently supported operating systems.
