### PR TITLE
Fix SCRIPT_FILENAME in phpmyadmin/phppgadmin templates

### DIFF
--- a/install/deb/nginx/phpmyadmin.inc
+++ b/install/deb/nginx/phpmyadmin.inc
@@ -16,7 +16,7 @@ location /%pma_alias% {
 		include       /etc/nginx/fastcgi_params;
 		fastcgi_index index.php;
 		fastcgi_param HTTP_EARLY_DATA $rfc_early_data if_not_empty;
-		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param SCRIPT_FILENAME $request_filename;
 		fastcgi_pass  unix:/run/php/www.sock;
 	}
 

--- a/install/deb/nginx/phppgadmin.inc
+++ b/install/deb/nginx/phppgadmin.inc
@@ -6,7 +6,7 @@ location /%pga_alias% {
 		include       /etc/nginx/fastcgi_params;
 		fastcgi_index index.php;
 		fastcgi_param HTTP_EARLY_DATA $rfc_early_data if_not_empty;
-		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param SCRIPT_FILENAME $request_filename;
 		fastcgi_pass  unix:/run/php/www.sock;
 	}
 }

--- a/install/upgrade/versions/1.9.8.sh
+++ b/install/upgrade/versions/1.9.8.sh
@@ -45,3 +45,23 @@ for huser in $("$HESTIA/bin/v-list-users" list); do
 		"$HESTIA/bin/v-add-user-composer" "$huser" 2 yes &> /dev/null
 	fi
 done
+
+# Fix SCRIPT_FILENAME in phpmyadmin.inc/phppgadmin.inc templates for Nginx
+# on current installations
+config="$("$BIN/v-list-sys-config" json 2> /dev/null)"
+
+if [[ -n $config ]]; then
+	if dba_pma="$(jq -r '.[].DB_PMA_ALIAS // empty' <<< "$config" 2> /dev/null)"; then
+		if [[ -n $dba_pma ]]; then
+			echo "[ + ] Fixing phpmyadmin.inc for Nginx"
+			"$BIN/v-change-sys-db-alias" pma "$dba_pma"
+		fi
+	fi
+
+	if dba_pga="$(jq -r '.[].DB_PGA_ALIAS // empty' <<< "$config" 2> /dev/null)"; then
+		if [[ -n $dba_pga ]]; then
+			echo "[ + ] Fixing phppgadmin.inc for Nginx"
+			"$BIN/v-change-sys-db-alias" pga "$dba_pga"
+		fi
+	fi
+fi


### PR DESCRIPTION
alias + regex capture makes `$document_root` resolve to the full script path, so `$document_root$fastcgi_script_name` produces a duplicated, nonexistent path `/usr/share/phpmyadmin/index.php/phpmyadmin/index.php`.

This breaks with `"No input file specified"` when `cgi.fix_pathinfo` is set to `0`, and is silently masked otherwise (this is the current case because by default, `cgi.fixpathinfo` is set to `1`).

Fixes #5534