### PR TITLE
Adds DNS serial rollover test

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -1510,6 +1510,28 @@ function check_ip_not_banned(){
     refute_output
 }
 
+@test "DNS: Check serial rollover from max 32-bit value to 1 (RFC 1982)" {
+	[ -z "$DNS_SYSTEM" ] && skip
+
+	USER_DATA=$HESTIA/data/users/$user
+	local zn_conf="$HOMEDIR/$user/conf/dns/${domain}.db"
+
+	# Seed the zone's current serial to the max unsigned 32-bit value so the
+	# next update has to wrap around per RFC 1982 (serial 0 is skipped, so it
+	# wraps to 1, not 0).
+	sed -i -E "0,/^[[:space:]]*[0-9]+[[:space:]]*\$/s//                                            4294967295/" "$zn_conf"
+	assert_file_contains "$zn_conf" "4294967295"
+
+	# Any DNS-mutating command runs update_domain_serial() as a side effect.
+	run v-change-dns-domain-ttl $user $domain 3600
+	assert_success
+	refute_output
+
+	run get_object_value 'dns' 'DOMAIN' "$domain" '$SERIAL'
+	assert_success
+	assert_output "0000000001"
+}
+
 @test "DNS: Change domain ip" {
     run v-change-dns-domain-ip $user $domain 127.0.0.1
     assert_success


### PR DESCRIPTION
Adds a new test to verify the DNS SOA serial number rollover mechanism.

This test simulates a scenario where the SOA serial reaches its maximum 32-bit value. It then confirms that subsequent updates correctly wrap the serial around to `1`, adhering to RFC 1982 guidelines which state that `0` is skipped. This ensures the reliability and correctness of DNS serial number management.