### PR TITLE
Restrict ROOT_USER account modifications to the ROOT_USER session

### DIFF
--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -22,15 +22,14 @@ if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 	$v_username = $_SESSION["user"];
 }
 
-// Prevent other users with admin privileges from editing properties of default 'admin' user
+// Prevent other users with admin privileges from editing properties of the ROOT_USER account.
+// Only a session whose real logged-in user IS the ROOT_USER may edit it,
+// regardless of impersonation state ($_SESSION["look"] is always set by main.php).
 if (
-	($_SESSION["userContext"] === "admin" &&
-		$_SESSION["look"] != "" &&
-		$user == $_SESSION["ROOT_USER"]) ||
-	($_SESSION["userContext"] === "admin" &&
-		!isset($_SESSION["look"]) &&
-		$user == "admin" &&
-		$_SESSION["user"] != $_SESSION["ROOT_USER"])
+	$_SESSION["userContext"] === "admin" &&
+	!empty($_SESSION["ROOT_USER"]) &&
+	$user === $_SESSION["ROOT_USER"] &&
+	$_SESSION["user"] !== $_SESSION["ROOT_USER"]
 ) {
 	header("Location: /list/user/");
 	exit();
@@ -152,6 +151,17 @@ unset($output);
 if (!empty($_POST["save"])) {
 	// Check token
 	verify_csrf($_POST);
+
+	// A non-ROOT_USER admin must never modify the ROOT_USER account
+	if (
+		$_SESSION["userContext"] === "admin" &&
+		!empty($_SESSION["ROOT_USER"]) &&
+		$v_username === $_SESSION["ROOT_USER"] &&
+		$_SESSION["user"] !== $_SESSION["ROOT_USER"]
+	) {
+		header("Location: /list/user/");
+		exit();
+	}
 
 	// Change password
 	if (!empty($_POST["v_password"]) && empty($_SESSION["error_msg"])) {
@@ -350,7 +360,7 @@ if (!empty($_POST["save"])) {
 		if (
 			$v_role != $_POST["v_role"] &&
 			$_SESSION["userContext"] === "admin" &&
-			$v_username != "admin" &&
+			$v_username != $_SESSION["ROOT_USER"] &&
 			empty($_SESSION["error_msg"])
 		) {
 			if (!empty($_POST["v_role"])) {


### PR DESCRIPTION
Ensure that only the actual ROOT_USER session can modify the ROOT_USER account, regardless of impersonation state.

Also replace hardcoded references to the "admin" user with the configured ROOT_USER during role validation to keep authorization checks consistent.