### PR TITLE
Fix: Sanitize debug panel variable output

### DIFF
--- a/web/templates/pages/debug_panel.php
+++ b/web/templates/pages/debug_panel.php
@@ -16,7 +16,7 @@ if( !defined("HESTIA_DIR_BIN") ){
 			echo "<h3 class=\"u-mb10\">Server Variables</h3>";
 			foreach ($_SERVER as $key => $val) {
 				if(is_string($val)){
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . $val . " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . tohtml($val) . " ";
 				}
 			}
   	?>
@@ -24,12 +24,12 @@ if( !defined("HESTIA_DIR_BIN") ){
 			echo "<h3 class=\"u-mb10 u-mt10\">Session Variables</h3>";
 			foreach ($_SESSION as $key => $val) {
 				if(is_string($val)){
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . $val . " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . tohtml($val) . " ";
 				}else if(is_array($val)){
 					array_walk_recursive($val, function (&$value) {
 							$value = htmlentities($value);
 					});
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> "  .var_dump($val). " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> "  .tohtml(var_export($val, true)). " ";
 				}
 			}
   	?>
@@ -37,12 +37,12 @@ if( !defined("HESTIA_DIR_BIN") ){
 			echo "<h3 class=\"u-mb10 u-mt10\">POST Variables</h3>";
 			foreach ($_POST as $key => $val) {
 				if(is_string($val)){
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . $val . " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . tohtml($val) . " ";
 				}else if(is_array($val)){
 					array_walk_recursive($val, function (&$value) {
 							$value = htmlentities($value);
 					});
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> "  .var_dump($val). " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> "  .tohtml(var_export($val, true)). " ";
 				}
 			}
   	?>
@@ -50,12 +50,12 @@ if( !defined("HESTIA_DIR_BIN") ){
 			echo "<h3 class=\"u-mb10 u-mt10\">GET Variables</h3>";
 			foreach ($_GET as $key => $val) {
 				if(is_string($val)){
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . $val . " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> " . tohtml($val) . " ";
 				}else if(is_array($val)){
 					array_walk_recursive($val, function (&$value) {
 							$value = htmlentities($value);
 					});
-					echo "<span class=\"u-text-bold\">" . $key . "= </span> "  .var_dump($val). " ";
+					echo "<span class=\"u-text-bold\">" . $key . "= </span> "  .tohtml(var_export($val, true)). " ";
 				}
 			}
   	?>

--- a/web/templates/pages/list_key.php
+++ b/web/templates/pages/list_key.php
@@ -62,7 +62,7 @@
 								<?php } ?>
 								title="<?= tohtml( _("Delete")) ?>"
 								data-confirm-title="<?= tohtml( _("Delete")) ?>"
-								data-confirm-message="<?= tohtml(sprintf(_("Are you sure you want to delete SSH key %s?"), $key)) ?>"
+								data-confirm-message="<?= tohtml(sprintf(_("Are you sure you want to delete SSH key %s?"), tohtml($key))) ?>"
 							>
 								<i class="fas fa-trash icon-red"></i>
 								<span class="u-hide-desktop"><?= tohtml( _("Delete")) ?></span>


### PR DESCRIPTION
Uses `tohtml()` to escape HTML entities for all `$_SERVER`, `$_SESSION`, `$_POST`, and `$_GET` string variables. This prevents potential XSS vulnerabilities when displaying user-controlled or untrusted data in the debug panel.

For array variables, `var_export($val, true)` is now used instead of `var_dump($val)` to return a string representation, which is then also passed through `tohtml()` for proper HTML escaping and improved readability.
