### PR TITLE
Fix v-add-user-composer update

### DIFF
--- a/bin/v-add-user-composer
+++ b/bin/v-add-user-composer
@@ -51,8 +51,8 @@ COMPOSER_DIR="$HOMEDIR/$user/.composer"
 COMPOSER_BIN="$COMPOSER_DIR/composer"
 
 if [ -f "$COMPOSER_BIN" ]; then
-	if [ -f "$update" ]; then
-		user_exec $COMPOSER_BIN self-update
+	if [[ "${update,,}" = "yes" ]]; then
+		COMPOSER_HOME="$HOMEDIR/$user/.config/composer" user_exec "$COMPOSER_BIN" --quiet self-update
 		exit
 	fi
 	echo "Composer already available"

--- a/bin/v-add-user-composer
+++ b/bin/v-add-user-composer
@@ -52,7 +52,7 @@ COMPOSER_BIN="$COMPOSER_DIR/composer"
 
 if [ -f "$COMPOSER_BIN" ]; then
 	if [ -f "$update" ]; then
-		user_exec $COMPOSER_BIN selfupdate
+		user_exec $COMPOSER_BIN self-update
 		exit
 	fi
 	echo "Composer already available"


### PR DESCRIPTION
Fix typo in `v-add-user-composer` (`selfupdate` with `self-update`)

Update the `composer` self-update condition to explicitly check for yes, set the correct `COMPOSER_HOME` path, and run the update in quiet mode.