### PR TITLE
skip useradd unless needed

### DIFF
--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -69,7 +69,7 @@ rebuild_user_conf() {
 
 	# Rebuild user
 	shell=$(grep -w "$SHELL" /etc/shells | head -n1)
-	/usr/sbin/useradd "$user" -s "$shell" -c "$CONTACT" \
+	id "$user" &>/dev/null || /usr/sbin/useradd "$user" -s "$shell" -c "$CONTACT" \
 		-m -d "$HOMEDIR/$user" > /dev/null 2>&1
 
 	# Add a general group for normal users created by Hestia


### PR DESCRIPTION
During upgrades (e.g. 1.9.7 → 1.9.8), rebuild_user_conf() is called for every HestiaCP user account.

The function calls /usr/sbin/useradd unconditionally, even when the system user already exists. useradd correctly rejects the duplicate creation and logs failed adding user '', data deleted to syslog for every account.

On servers with many users this generates a burst of syslog entries that are indistinguishable from a real account-manipulation attack, triggering false-positive alerts in security monitoring systems (SIEM/SOC).

Suggested fix: Guard the useradd call with an existence check: id "$user" &>/dev/null || /usr/sbin/useradd ...
This is a one-line change with no behavioural difference for new users, and complete silence for existing users.

Fixes #5558