### PR TITLE
Fix issues with web-terminal  / On Nodejs 24

### DIFF
--- a/bin/v-add-sys-web-terminal
+++ b/bin/v-add-sys-web-terminal
@@ -38,7 +38,7 @@ $BIN/v-change-sys-config-value "WEB_TERMINAL" "true"
 
 # Detect and install Node.js if necessary
 apt="/etc/apt/sources.list.d"
-node_v="20"
+node_v="24"
 
 if [ $(uname -m) = "x86_64" ]; then
 	ARCH=amd64

--- a/build.js
+++ b/build.js
@@ -10,9 +10,9 @@ const externalPackages = [
 	'chart.js/auto',
 	'alpinejs/dist/cdn.min.js',
 	'@alpinejs/collapse/dist/cdn.min.js',
-	'xterm',
-	'xterm-addon-webgl',
-	'xterm-addon-canvas',
+	'@xterm/xterm',
+	'@xterm/addon-webgl',
+	'@xterm/addon-canvas',
 ];
 
 // Build main bundle
@@ -63,6 +63,10 @@ function getOutputPath(pkg) {
 		pkgName = 'alpinejs';
 	} else if (pkg.startsWith('@alpinejs/collapse')) {
 		pkgName = 'alpinejs-collapse';
+	} else if (pkg === '@xterm/xterm') {
+		pkgName = 'xterm';
+	} else if (pkg.startsWith('@xterm/')) {
+		pkgName = pkg.replace('@xterm/', 'xterm-');
 	} else {
 		pkgName = pkg.replace(/\//g, '-');
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,15 +12,15 @@
 			"dependencies": {
 				"@alpinejs/collapse": "^3.15.12",
 				"@fortawesome/fontawesome-free": "^7.3.1",
+				"@xterm/addon-canvas": "^0.7.0",
+				"@xterm/addon-webgl": "^0.19.0",
+				"@xterm/xterm": "^5.5.0",
 				"alpinejs": "^3.15.12",
 				"chart.js": "^4.5.1",
 				"check-password-strength": "^3.0.0",
 				"floating-vue": "^5.2.2",
 				"nanoid": "^5.1.16",
-				"normalize.css": "^8.0.1",
-				"xterm": "^5.3.0",
-				"xterm-addon-canvas": "^0.5.0",
-				"xterm-addon-webgl": "^0.16.0"
+				"normalize.css": "^8.0.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.6",
@@ -2437,6 +2437,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
+		},
+		"node_modules/@xterm/addon-canvas": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@xterm/addon-canvas/-/addon-canvas-0.7.0.tgz",
+			"integrity": "sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@xterm/xterm": "^5.0.0"
+			}
+		},
+		"node_modules/@xterm/addon-webgl": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+			"integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
+			"license": "MIT"
+		},
+		"node_modules/@xterm/xterm": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+			"integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+			"license": "MIT"
 		},
 		"node_modules/abbrev": {
 			"version": "2.0.0",
@@ -8769,33 +8790,6 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/xterm": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-			"integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-			"deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-			"license": "MIT"
-		},
-		"node_modules/xterm-addon-canvas": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xterm-addon-canvas/-/xterm-addon-canvas-0.5.0.tgz",
-			"integrity": "sha512-QOo/eZCMrCleAgMimfdbaZCgmQRWOml63Ued6RwQ+UTPvQj3Av9QKx3xksmyYrDGRO/AVRXa9oNuzlYvLdmoLQ==",
-			"deprecated": "This package is now deprecated. Move to @xterm/addon-canvas instead.",
-			"license": "MIT",
-			"peerDependencies": {
-				"xterm": "^5.0.0"
-			}
-		},
-		"node_modules/xterm-addon-webgl": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.16.0.tgz",
-			"integrity": "sha512-E8cq1AiqNOv0M/FghPT+zPAEnvIQRDbAbkb04rRYSxUym69elPWVJ4sv22FCLBqM/3LcrmBLl/pELnBebVFKgA==",
-			"deprecated": "This package is now deprecated. Move to @xterm/addon-webgl instead.",
-			"license": "MIT",
-			"peerDependencies": {
-				"xterm": "^5.0.0"
-			}
 		},
 		"node_modules/yaml": {
 			"version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
 		"floating-vue": "^5.2.2",
 		"nanoid": "^5.1.16",
 		"normalize.css": "^8.0.1",
-		"xterm": "^5.3.0",
-		"xterm-addon-canvas": "^0.5.0",
-		"xterm-addon-webgl": "^0.16.0"
+		"@xterm/addon-canvas": "^0.7.0",
+		"@xterm/addon-webgl": "^0.19.0",
+		"@xterm/xterm": "^5.5.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.6",
@@ -54,5 +54,11 @@
 	},
 	"browserslist": [
 		"defaults"
-	]
+	],
+	"allowScripts": {
+		"esbuild@0.28.1": true,
+		"esbuild@0.25.12": true,
+		"esbuild@0.21.5": true,
+		"fsevents@2.3.3": true
+	}
 }

--- a/src/deb/web-terminal/control
+++ b/src/deb/web-terminal/control
@@ -1,7 +1,7 @@
 Source: hestia-web-terminal
 Package: hestia-web-terminal
 Priority: optional
-Version: 1.0.4
+Version: 1.0.5
 Section: admin
 Maintainer: HestiaCP <info@hestiacp.com>
 Homepage: https://www.hestiacp.com

--- a/src/deb/web-terminal/package.json
+++ b/src/deb/web-terminal/package.json
@@ -13,5 +13,8 @@
 	"devDependencies": {
 		"@types/ws": "^8.18.1",
 		"@types/node": "^24.13.3"
+	},
+	"allowScripts": {
+		"node-pty@1.1.0": true
 	}
 }

--- a/web/css/src/themes/default.css
+++ b/web/css/src/themes/default.css
@@ -1,4 +1,4 @@
-@import url("node:xterm/css/xterm.css");
+@import url("node:@xterm/xterm/css/xterm.css");
 @import url("node:normalize.css/normalize.css");
 @import url("node:@fortawesome/fontawesome-free/css/fontawesome");
 @import url("node:@fortawesome/fontawesome-free/css/solid");

--- a/web/js/src/webTerminal.js
+++ b/web/js/src/webTerminal.js
@@ -32,7 +32,7 @@ export default async function initWebTerminal() {
 	});
 }
 
-/** @returns {Promise<typeof import("xterm").Terminal>} */
+/** @returns {Promise<typeof import("@xterm/xterm").Terminal>} */
 async function loadXterm() {
 	// NOTE: String expression used to prevent ESBuild from resolving
 	// the import on build (xterm is a separate bundle)
@@ -41,7 +41,7 @@ async function loadXterm() {
 	return xtermModule.default.Terminal;
 }
 
-/** @returns {Promise<typeof import("xterm-addon-webgl").WebglAddon>} */
+/** @returns {Promise<typeof import("@xterm/addon-webgl").WebglAddon>} */
 async function loadWebGLAddon() {
 	// NOTE: String expression used to prevent ESBuild from resolving
 	// the import on build (xterm-addon-webgl is a separate bundle)
@@ -50,7 +50,7 @@ async function loadWebGLAddon() {
 	return xtermModule.default.WebglAddon;
 }
 
-/** @returns {Promise<typeof import("xterm-addon-canvas").CanvasAddon>} */
+/** @returns {Promise<typeof import("@xterm/addon-canvas").CanvasAddon>} */
 async function loadCanvasAddon() {
 	// NOTE: String expression used to prevent ESBuild from resolving
 	// the import on build (xterm-addon-canvas is a separate bundle)


### PR DESCRIPTION
Replace: 
-xterm-addon-canvas 
-xterm-addon-webgl 
-xterm 

to 

@xterm/xterm
@xterm/addon-canvas
@xterm/addonwebgl

Add node-pty to allowed scripts in package.json web-terminal

Als updated version to 1.0.5 to force update on next release