### PR TITLE
Enhance add_object_key against invalid sed execution

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -628,13 +628,19 @@ update_object_value() {
 
 # Add object key
 add_object_key() {
-	row=$(grep -n "$2='$3'" $USER_DATA/$1.conf)
-	lnr=$(echo $row | cut -f 1 -d ':')
-	object=$(echo $row | sed "s/^$lnr://")
-	if [ -z "$(echo $object | grep $4=)" ]; then
+	row=$(grep -n "$2='$3'" "$USER_DATA/$1.conf")
+	lnr=$(echo "$row" | cut -f 1 -d ':')
+	object=$(echo "$row" | sed "s/^$lnr://")
+
+	# If lnr or $5 is empty, do not run sed
+	if [[ -z "$lnr" || -z "$5" ]]; then
+		return 1
+	fi
+
+	if [[ -z "$(echo "$object" | grep "$4=")" ]]; then
 		local varname="${4#\$}"
 		old="${!varname}"
-		sed -i "$lnr s/$5='/$4='' $5='/" $USER_DATA/$1.conf
+		sed -i "$lnr s/$5='/$4='' $5='/" "$USER_DATA/$1.conf"
 	fi
 }
 

--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -186,6 +186,7 @@ function syshealth_repair_mail_account_config() {
 	system="mail_accounts"
 	sanitize_config_file "$system"
 	get_object_values "mail/$domain" 'ACCOUNT' "$account"
+	prev="ACCOUNT"
 	for key in $known_keys; do
 		if [ -z "${!key}" ]; then
 			add_object_key "mail/$domain" 'ACCOUNT' "$account" "$key" "$prev"


### PR DESCRIPTION
Add a guard to return early when the line number or previous key is empty, avoiding invalid sed commands.
Initialize the `prev` key in `syshealth_repair_mail_account_config()` before calling `add_object_key()`.

Fixes #5561