### PR TITLE
Fix syshealth wrongly re-adding deleted config keys

### DIFF
--- a/func/syshealth.sh
+++ b/func/syshealth.sh
@@ -549,14 +549,14 @@ function syshealth_repair_system_config() {
 		$BIN/v-change-sys-config-value "DOMAINDIR_WRITABLE" "no"
 	fi
 
-	touch $HESTIA/conf/hestia.conf.new
+	: > "$HESTIA/conf/hestia.conf.new"
+
 	while IFS='= ' read -r lhs rhs; do
 		if [[ ! $lhs =~ ^\ *# && -n $lhs ]]; then
-			rhs="${rhs%%^\#*}" # Del in line right comments
-			rhs="${rhs%%*( )}" # Del trailing spaces
-			rhs="${rhs%\'*}"   # Del opening string quotes
-			rhs="${rhs#\'*}"   # Del closing string quotes
-
+			rhs="${rhs%%#*}"             # Del inline right comments
+			rhs="${rhs%"${rhs##*[! ]}"}" # Del trailing spaces
+			rhs="${rhs%\'}"              # Del closing string quote
+			rhs="${rhs#\'}"              # Del opening string quote
 		fi
 		check_ckey=$(grep "^$lhs='" "$HESTIA/conf/hestia.conf.new")
 		if [ -z "$check_ckey" ]; then
@@ -564,15 +564,13 @@ function syshealth_repair_system_config() {
 		else
 			sed -i "s|^$lhs=.*|$lhs='$rhs'|g" "$HESTIA/conf/hestia.conf.new"
 		fi
-	done < $HESTIA/conf/hestia.conf
+	done < "$HESTIA/conf/hestia.conf"
 
-	cmp --silent $HESTIA/conf/hestia.conf $HESTIA/conf/hestia.conf.new
-	if [ $? -ne 0 ]; then
+	if ! cmp --silent "$HESTIA/conf/hestia.conf" "$HESTIA/conf/hestia.conf.new"; then
 		echo "[ ! ] Duplicated keys found repair config"
-		rm $HESTIA/conf/hestia.conf
-		cp $HESTIA/conf/hestia.conf.new $HESTIA/conf/hestia.conf
-		rm $HESTIA/conf/hestia.conf.new
+		cp "$HESTIA/conf/hestia.conf.new" "$HESTIA/conf/hestia.conf"
 	fi
+	rm -f "$HESTIA/conf/hestia.conf.new"
 
 	source_conf "$HESTIA/conf/hestia.conf"
 }


### PR DESCRIPTION
Prevent `syshealth_repair_system_config()` from reusing an existing hestia.conf.new file that could overwrite hestia.conf during upgrades, restoring obsolete configuration variables. Also improve parsing and always remove the temporary file.

Fixes #5577