### PR TITLE
Fix SSL panel breaking on certs with commas in Subject/Issuer DN

### DIFF
--- a/bin/v-list-mail-domain-ssl
+++ b/bin/v-list-mail-domain-ssl
@@ -29,19 +29,21 @@ format_domain_idn
 
 # JSON list function
 json_list() {
-	issuer=$(echo "$issuer" | sed -e 's/"/\\"/g' -e "s/%quote%/'/g")
+	json_escape() {
+		echo -n "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+	}
 	echo '{'
 	echo -e "\t\"$domain\": {"
 	echo "        \"CRT\": \"$crt\","
 	echo "        \"KEY\": \"$key\","
 	echo "        \"CA\": \"$ca\","
-	echo "        \"SUBJECT\": \"$subj\","
-	echo "        \"ALIASES\": \"$alt_dns\","
-	echo "        \"NOT_BEFORE\": \"$before\","
-	echo "        \"NOT_AFTER\": \"$after\","
-	echo "        \"SIGNATURE\": \"$signature\","
-	echo "        \"PUB_KEY\": \"$pub_key\","
-	echo "        \"ISSUER\": \"$issuer\""
+	echo "        \"SUBJECT\": \"$(json_escape "$subj")\","
+	echo "        \"ALIASES\": \"$(json_escape "$alt_dns")\","
+	echo "        \"NOT_BEFORE\": \"$(json_escape "$before")\","
+	echo "        \"NOT_AFTER\": \"$(json_escape "$after")\","
+	echo "        \"SIGNATURE\": \"$(json_escape "$signature")\","
+	echo "        \"PUB_KEY\": \"$(json_escape "$pub_key")\","
+	echo "        \"ISSUER\": \"$(json_escape "$issuer")\""
 	echo -e "\t}\n}"
 }
 
@@ -120,7 +122,7 @@ if [ -e "$USER_DATA/ssl/mail.$domain.crt" ]; then
 	crt=$(cat $USER_DATA/ssl/mail.$domain.crt | sed ':a;N;$!ba;s/\n/\\n/g')
 
 	info=$(openssl x509 -text -in $USER_DATA/ssl/mail.$domain.crt)
-	subj=$(echo "$info" | grep Subject: | sed -e "s/\"//g" -e "s/.*= //")
+	subj=$(openssl x509 -noout -nameopt multiline -subject -in $USER_DATA/ssl/mail.$domain.crt | sed -n 's/^ *commonName *= //p')
 	before=$(echo "$info" | grep Before: | sed -e "s/.*Before: //")
 	after=$(echo "$info" | grep "After :" | sed -e "s/.*After : //")
 	signature=$(echo "$info" | grep "Algorithm:" | head -n1)

--- a/bin/v-list-sys-hestia-ssl
+++ b/bin/v-list-sys-hestia-ssl
@@ -23,18 +23,21 @@ source_conf "$HESTIA/conf/hestia.conf"
 
 # JSON list function
 json_list() {
+	json_escape() {
+		echo -n "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+	}
 	echo '{'
 	echo -e "\t\"HESTIA\": {"
 	echo "        \"CRT\": \"$crt\","
 	echo "        \"KEY\": \"$key\","
-	echo "        \"CA\": \"$ca\","
-	echo "        \"SUBJECT\": \"$subj\","
-	echo "        \"ALIASES\": \"$alt_dns\","
-	echo "        \"NOT_BEFORE\": \"$before\","
-	echo "        \"NOT_AFTER\": \"$after\","
-	echo "        \"SIGNATURE\": \"$signature\","
-	echo "        \"PUB_KEY\": \"$pub_key\","
-	echo "        \"ISSUER\": \"$issuer\""
+	echo "        \"CA\": \"$(json_escape "$ca")\","
+	echo "        \"SUBJECT\": \"$(json_escape "$subj")\","
+	echo "        \"ALIASES\": \"$(json_escape "$alt_dns")\","
+	echo "        \"NOT_BEFORE\": \"$(json_escape "$before")\","
+	echo "        \"NOT_AFTER\": \"$(json_escape "$after")\","
+	echo "        \"SIGNATURE\": \"$(json_escape "$signature")\","
+	echo "        \"PUB_KEY\": \"$(json_escape "$pub_key")\","
+	echo "        \"ISSUER\": \"$(json_escape "$issuer")\""
 	echo -e "\t}\n}"
 }
 
@@ -102,7 +105,7 @@ key=$(cat $HESTIA/ssl/certificate.key | sed ':a;N;$!ba;s/\n/\\n/g')
 
 # Parsing SSL certificate details without CA
 info=$(openssl x509 -text -in $HESTIA/ssl/certificate.crt)
-subj=$(echo "$info" | grep Subject: | cut -f 2 -d =)
+subj=$(openssl x509 -noout -nameopt multiline -subject -in $HESTIA/ssl/certificate.crt | sed -n 's/^ *commonName *= //p')
 before=$(echo "$info" | grep Before: | sed -e "s/.*Before: //")
 after=$(echo "$info" | grep "After :" | sed -e "s/.*After : //")
 signature=$(echo "$info" | grep "Algorithm:" | head -n1)

--- a/bin/v-list-sys-hestia-ssl
+++ b/bin/v-list-sys-hestia-ssl
@@ -30,7 +30,7 @@ json_list() {
 	echo -e "\t\"HESTIA\": {"
 	echo "        \"CRT\": \"$crt\","
 	echo "        \"KEY\": \"$key\","
-	echo "        \"CA\": \"$(json_escape "$ca")\","
+	echo "        \"CA\": \"$ca\","
 	echo "        \"SUBJECT\": \"$(json_escape "$subj")\","
 	echo "        \"ALIASES\": \"$(json_escape "$alt_dns")\","
 	echo "        \"NOT_BEFORE\": \"$(json_escape "$before")\","
@@ -102,6 +102,9 @@ csv_list() {
 # Parsing SSL certificate
 crt=$(cat $HESTIA/ssl/certificate.crt | sed ':a;N;$!ba;s/\n/\\n/g')
 key=$(cat $HESTIA/ssl/certificate.key | sed ':a;N;$!ba;s/\n/\\n/g')
+if [ -e "$HESTIA/ssl/certificate.ca" ]; then
+	ca=$(cat $HESTIA/ssl/certificate.ca | sed ':a;N;$!ba;s/\n/\\n/g')
+fi
 
 # Parsing SSL certificate details without CA
 info=$(openssl x509 -text -in $HESTIA/ssl/certificate.crt)

--- a/bin/v-list-web-domain-ssl
+++ b/bin/v-list-web-domain-ssl
@@ -25,20 +25,21 @@ source_conf "$HESTIA/conf/hestia.conf"
 
 # JSON list function
 json_list() {
-	issuer=$(echo "$issuer" | sed -e 's/"/\\"/g' -e "s/%quote%/'/g")
+	json_escape() {
+		echo -n "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+	}
 	echo '{'
 	echo -e "\t\"$domain\": {"
 	echo "        \"CRT\": \"$crt\","
 	echo "        \"KEY\": \"$key\","
 	echo "        \"CA\": \"$ca\","
-	echo "        \"SUBJECT\": \"$subj\","
-	echo "        \"ALIASES\": \"$alt_dns\","
-	echo "        \"NOT_BEFORE\": \"$before\","
-	echo "        \"NOT_AFTER\": \"$after\","
-	echo "        \"SIGNATURE\": \"$signature\","
-	echo "        \"PUB_KEY\": \"$pub_key\","
-	echo "        \"ISSUER\": \"$issuer\","
-	echo "        \"SSL_FORCE\": \"$SSL_FORCE\""
+	echo "        \"SUBJECT\": \"$(json_escape "$subj")\","
+	echo "        \"ALIASES\": \"$(json_escape "$alt_dns")\","
+	echo "        \"NOT_BEFORE\": \"$(json_escape "$before")\","
+	echo "        \"NOT_AFTER\": \"$(json_escape "$after")\","
+	echo "        \"SIGNATURE\": \"$(json_escape "$signature")\","
+	echo "        \"PUB_KEY\": \"$(json_escape "$pub_key")\","
+	echo "        \"ISSUER\": \"$(json_escape "$issuer")\""
 	echo -e "\t}\n}"
 }
 
@@ -122,7 +123,7 @@ if [ -e "$USER_DATA/ssl/$domain.crt" ]; then
 	crt=$(cat $USER_DATA/ssl/$domain.crt | sed ':a;N;$!ba;s/\n/\\n/g')
 
 	info=$(openssl x509 -text -in $USER_DATA/ssl/$domain.crt)
-	subj=$(echo "$info" | grep Subject: | sed -e "s/\"//g" -e "s/.*= //")
+	subj=$(openssl x509 -noout -nameopt multiline -subject -in $USER_DATA/ssl/$domain.crt | sed -n 's/^ *commonName *= //p')
 	before=$(echo "$info" | grep Before: | sed -e "s/.*Before: //")
 	after=$(echo "$info" | grep "After :" | sed -e "s/.*After : //")
 	signature=$(echo "$info" | grep "Algorithm:" | head -n1)

--- a/web/templates/pages/edit_web.php
+++ b/web/templates/pages/edit_web.php
@@ -248,7 +248,7 @@
 								type="button"
 								class="form-link"
 								x-on:click="showCertificates = !showCertificates"
-								x-text="showCertificates ? <?= json_encode(_("Hide Certificate"), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR) ?> : <?= json_encode(_("Show Certificate"), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR) ?>">
+								x-text='showCertificates ? <?= json_encode(_("Hide Certificate"), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR) ?> : <?= json_encode(_("Show Certificate"), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR) ?>'>
 								<?= tohtml( _("Show Certificate")) ?>
 							</button>
 						</p>


### PR DESCRIPTION
openssl x509 -text output embeds unescaped double quotes when an RDN value contains a comma (e.g. O = "Company, Inc."), which breaks the hand-built JSON in json_list() and makes json_decode() return null, blanking every field in Server > SSL.

Also fixes CN extraction (cut -f2 -d= breaks with OpenSSL 3.x's spaced "CN = value" format).

Tested on Ubuntu 24.04 / OpenSSL 3.x with a self-signed cert whose Issuer CN contains a comma (`CN = "My Company, Inc. CA"`). Before the fix, `v-list-sys-hestia-ssl json` produced invalid JSON and every field in Server > SSL showed blank. After the fix, JSON parses correctly and all fields display as expected, including a clean CN in "Issued To" instead of a garbled fragment.
