### PR TITLE
Changed file manager date format to DD/MM/YYYY HH:mm:ss

### DIFF
--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -39,7 +39,7 @@ $dist_config["frontend_config"]["editable"] = [
 	".tpl",
 	".yaml",
 ];
-$dist_config["frontend_config"]["date_format"] = "YY/MM/DD H:mm:ss";
+$dist_config["frontend_config"]["date_format"] = "DD/MM/YYYY H:mm:ss";
 $dist_config["frontend_config"]["guest_redirection"] = "/login/";
 $dist_config["frontend_config"]["upload_max_size"] = 1024 * 1024 * 1024;
 $dist_config["frontend_config"]["pagination"] = [100, 50, 25];


### PR DESCRIPTION
Changed the frontend date format to display the date before the time using the European format (DD/MM/YYYY HH:mm:ss).