### PR TITLE
fix(nginx): name the trusted header in the cloudflare.inc fallback

### DIFF
--- a/install/deb/nginx/cloudflare.inc
+++ b/install/deb/nginx/cloudflare.inc
@@ -23,3 +23,5 @@ set_real_ip_from 2606:4700::/32;
 set_real_ip_from 2803:f800::/32;
 set_real_ip_from 2a06:98c0::/29;
 set_real_ip_from 2c0f:f248::/32;
+
+real_ip_header CF-Connecting-IP;

--- a/install/deb/nginx/cloudflare.inc
+++ b/install/deb/nginx/cloudflare.inc
@@ -23,5 +23,5 @@ set_real_ip_from 2606:4700::/32;
 set_real_ip_from 2803:f800::/32;
 set_real_ip_from 2a06:98c0::/29;
 set_real_ip_from 2c0f:f248::/32;
-
+# Header
 real_ip_header CF-Connecting-IP;


### PR DESCRIPTION
### What

`install/deb/nginx/cloudflare.inc` gains the one directive it was missing:

```nginx
real_ip_header CF-Connecting-IP;
```

### Why

That file is the fallback copied into place *before* the Cloudflare API is queried, so a failed
fetch cannot leave the `include` dangling and stop nginx from starting (#3876, fixing #3875).
It declares `set_real_ip_from` for every Cloudflare range but never says **which header** to
read, so nginx falls back to its own default: `X-Real-IP`.

That inverts the intent rather than merely weakening it:

* `CF-Connecting-IP` is written by Cloudflare on every request and cannot be forged through it.
* `X-Real-IP` is not a header Cloudflare manages; it is forwarded from the client verbatim.

So on any box where the API call failed at install time (5s timeout, restrictive egress, or a CF
outage - the `if` has no `else` and logs nothing), the result is:

* `CF-Connecting-IP` is **ignored outright**, so every visitor behind Cloudflare is attributed to
  the edge address. Log noise at best; with fail2ban in front of the panel it eventually bans the
  edge and locks out everyone behind it. No attacker involved.
* a client-supplied **`X-Real-IP` becomes `$remote_addr`**, and from there it flows into
  `proxy_set_header X-Real-IP $remote_addr` in `nginx.conf`, i.e. on to whatever sits behind.

### Measured

Isolated nginx instance, loopback only, `set_real_ip_from` covering the source in both cases.
The only variable is the presence of the directive:

```
without real_ip_header:  X-Real-IP: 1.2.3.4        -> remote_addr=1.2.3.4
                         CF-Connecting-IP: 9.9.9.9 -> remote_addr=<peer>

with    real_ip_header:  X-Real-IP: 1.2.3.4        -> remote_addr=<peer>
                         CF-Connecting-IP: 9.9.9.9 -> remote_addr=9.9.9.9
```

Identical on **nginx 1.22.1 (bookworm), 1.24.0 (noble), 1.26.3 (trixie), 1.28.3 (resolute)**.

### Scope

One line plus a blank. The ranges are untouched (still an exact match for the published
`ips-v4`/`ips-v6` sets). No behaviour change on any install where the API call succeeded - this
only affects the fallback.

Both installers and `func/upgrade.sh` already append this exact line when they regenerate the
file (`hst-install-debian.sh:1628`, `hst-install-ubuntu.sh:1672`, `upgrade.sh:586`); only the
static fallback lacked it, so this brings it in line with the three places that get it right.

### Related

Complements GHSA-73p3-rqpv-59wx and #5273, which hardened the **PHP** side by only honouring
`CF-Connecting-IP` when `REMOTE_ADDR` is a verified Cloudflare address. The advisory's own
suggested fix mentions handling this at the nginx layer with `set_real_ip_from` + `real_ip_header`;
this patch closes the case where that layer was configured with only the first of the two.
