### PR TITLE
Fixed issue with webterminal

### DIFF
--- a/build.js
+++ b/build.js
@@ -45,6 +45,7 @@ async function buildExternalJS() {
 				bundle: true,
 				minify: true,
 				format: 'esm',
+				mainFields: ['main'],
 			});
 			console.log(`✅ Dependency build completed for ${pkg}`);
 		});


### PR DESCRIPTION
@xterm/addon-webgl's package.json declares a "module" field pointing to an ESM build (lib/addon-webgl.mjs) with only a named WebglAddon export —
no default. @xterm/xterm and @xterm/addon-canvas only declare "main" (UMD/CJS), so esbuild wraps those in a synthetic default export. Since esbuild prefers "module" over "main" by default, only the webgl bundle came out shaped differently, so (await import(...)).default.WebglAddon in webTerminal.js was undefined.
