### PR TITLE
Fix: gracefully handle non-root execution in configure-server-smtp

### DIFF
--- a/install/upgrade/manual/configure-server-smtp.sh
+++ b/install/upgrade/manual/configure-server-smtp.sh
@@ -12,6 +12,12 @@
 #                    Variable&Function                     #
 #----------------------------------------------------------#
 
+# Check root
+[[ $EUID -eq 0 ]] || {
+	echo "Error: this script must be run as root."
+	exit 1
+}
+
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
 source /etc/hestiacp/hestia.conf


### PR DESCRIPTION
## Description
When running `configure-server-smtp.sh` as a standard user without `sudo`, the script currently fails with cascading "Permission denied" errors. This happens because it attempts to source restricted system configuration files (like `/etc/hestiacp/hestia.conf`) before verifying whether the user has the appropriate privileges to do so.

This PR introduces a standard `$EUID` check at the beginning of the script. This ensures the script gracefully halts execution and outputs a clean, helpful error message if it is not run as root.

## Steps to Reproduce (Before)
1. Log in as a standard user.
2. Run `bash /usr/local/hestia/install/upgrade/manual/configure-server-smtp.sh`
3. Observe permission denied errors on lines 36 and 21.

## Expected Behavior (After)
The script immediately outputs `Error: this script must be run as root.` and exits cleanly with code `1`.