### PR TITLE
fix: intermittent iptables service stopped status by waiting for xtables lock

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -318,7 +318,7 @@ fi
 # Checking FIREWALL system
 if [ -n "$FIREWALL_SYSTEM" ] && [ "$FIREWALL_SYSTEM" != 'remote' ]; then
 	state="stopped"
-	if $(iptables -S INPUT | grep -qx '\-P INPUT DROP'); then
+	if $(iptables -w -S INPUT | grep -qx '\-P INPUT DROP'); then
 		state="running"
 	fi
 	data="$data\nNAME='$FIREWALL_SYSTEM' SYSTEM='firewall'"

--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -318,7 +318,7 @@ fi
 # Checking FIREWALL system
 if [ -n "$FIREWALL_SYSTEM" ] && [ "$FIREWALL_SYSTEM" != 'remote' ]; then
 	state="stopped"
-	if $(iptables -S INPUT | grep -qx '\-P INPUT DROP'); then
+	if iptables -w -S INPUT | grep -qx '\-P INPUT DROP'; then
 		state="running"
 	fi
 	data="$data\nNAME='$FIREWALL_SYSTEM' SYSTEM='firewall'"


### PR DESCRIPTION
## Description
This PR fixes an issue where the `iptables` firewall service status in the HestiaCP dashboard would intermittently show as "stopped" when it was actually running. 

The `v-list-sys-services` script relies on `iptables -S INPUT` to verify if the default policy is `DROP`. However, if another service like `fail2ban` holds the `xtables` lock concurrently (e.g., when aggressively banning/unbanning IPs), the command fails with a "Resource temporarily unavailable" error. Since this failure produces no output, the script falsely interprets it as the firewall being stopped.

By passing the `-w` (wait) flag to `iptables`, we ensure the command waits for the `xtables` lock to become available instead of instantly failing, producing a reliable reading.

**Related Issues:**
None

**Verification:**
- Verified that `v-list-sys-services` correctly reports the firewall as `running`.
- Verified that concurrent `fail2ban` locking no longer causes false negatives.