### PR TITLE
Bump file manager to version 7.15.1

### DIFF
--- a/install/upgrade/upgrade.conf
+++ b/install/upgrade/upgrade.conf
@@ -60,7 +60,7 @@ sm_v='2.38.2'
 # UPGRADE_UPDATE_FILEMANAGER_CONFIG: Updates only the configuration file if changes are made but now new issue has been issued!
 UPGRADE_UPDATE_FILEMANAGER_CONFIG='false'
 # Set version of File manager to update during upgrade if not already installed
-fm_v='7.14.4'
+fm_v='7.15.1'
 
 # Backblaze
 b2_v='3.6.0'


### PR DESCRIPTION
- Security fix: batch download archives are now bound to the session that created them, reported by Yulio Valdes (https://github.com/Yunnn-Yulio).
- Security fix: uploads can no longer reach another user's temporary files via the chunk filename, reported by Yulio Valdes (https://github.com/Yunnn-Yulio).
- Fix unreadable .box text in dark theme, thanks @TowyTowy (see #589)
- Add Danish translation (see #590)
- Open the folder itself when selecting a folder search result (see #591 by @TowyTowy)