### PR TITLE
Fix accidently overwrite VERSION

### DIFF
--- a/install/upgrade/versions/1.10.0.sh
+++ b/install/upgrade/versions/1.10.0.sh
@@ -21,7 +21,7 @@ upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'true'
-upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'true'
 
 # fix/file manager ignores user language
 echo "[ * ] Fix File Manager ignoring user language"

--- a/install/upgrade/versions/1.10.0.sh
+++ b/install/upgrade/versions/1.10.0.sh
@@ -28,7 +28,12 @@ echo "[ * ] Fix File Manager ignoring user language"
 cp -f "$HESTIA"/install/deb/filemanager/filegator/configuration.php "$HESTIA"/web/fm/configuration.php
 
 if [ -f /etc/os-release ]; then
+	# /etc/os-release defines its own $VERSION, which would otherwise
+	# clobber Hestia's $VERSION since this script is sourced by the caller
+	_HESTIA_VERSION="$VERSION"
 	source /etc/os-release
+	VERSION="$_HESTIA_VERSION"
+	unset _HESTIA_VERSION
 fi
 
 # Set running OS


### PR DESCRIPTION
We source /etc/os-release to lookup the release_id but also contain "VERSION" causing it to be overwritten
