### PR TITLE
Adjust text wrapping behavior in `u-text-break` utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
 		}
 	},
 	"allowScripts": {
-		"esbuild@0.28.1": true,
+		"fsevents@2.3.3": true,
 		"esbuild@0.25.12": true,
-		"fsevents@2.3.3": true
+		"esbuild@0.28.2": true
 	}
 }

--- a/web/css/src/utilities.css
+++ b/web/css/src/utilities.css
@@ -58,7 +58,7 @@
 }
 
 .u-text-break {
-	overflow-wrap: break-word !important;
+	overflow-wrap: anywhere !important;
 }
 
 .u-text-no-wrap {


### PR DESCRIPTION
Changes how word breaks happen.

Currently
<img width="1690" height="70" alt="Screenshot 2026-08-15 at 23 01 49" src="https://github.com/user-attachments/assets/ac7c091f-0f99-4531-88bf-e841d56bacbe" />

New
<img width="1122" height="185" alt="Screenshot 2026-08-15 at 23 01 42" src="https://github.com/user-attachments/assets/db7a666e-2c02-4baf-9b55-60e1b9913e16" />
