### PR TITLE
docs: correct spelling

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -7,7 +7,7 @@
 # This function adds virtual host to a server. In cases when ip is
 # undefined in the script, "default" template will be used. The alias of
 # `www.domain.tld` type will be automatically assigned to the domain unless
-# "none" is transmited as argument. If ip have associated dns name, this
+# "none" is transmitted as argument. If ip have associated dns name, this
 # domain will also get the alias domain-tpl.$ipname. An alias with the ip
 # name is useful during the site testing while dns isn't moved to server yet.
 

--- a/bin/v-add-web-domain-proxy
+++ b/bin/v-add-web-domain-proxy
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: add webdomain proxy support
-# options: USER DOMAIN [TEMPLATE] [EXTENTIONS] [RESTART]
+# options: USER DOMAIN [TEMPLATE] [EXTENSIONS] [RESTART]
 #
 # example: v-add-web-domain-proxy admin example.com
 #
@@ -15,9 +15,9 @@
 user=$1
 domain=$2
 template=$3
-default_extentions="jpg,jpeg,gif,png,webp,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,\
+default_extensions="jpg,jpeg,gif,png,webp,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,\
 exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,html,htm"
-extentions=${4-$default_extentions}
+extensions=${4-$default_extensions}
 restart="$5"
 
 # Includes
@@ -37,7 +37,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 check_args '2' "$#" 'USER DOMAIN [TEMPLATE] [EXTENTIONS] [RESTART]'
-is_format_valid 'user' 'domain' 'extentions' 'restart'
+is_format_valid 'user' 'domain' 'extensions' 'restart'
 is_system_enabled "$PROXY_SYSTEM" 'PROXY_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -62,7 +62,7 @@ prepare_web_domain_values
 local_ip=$(get_real_ip "$IP")
 
 # Preparing domain values for the template substitution
-PROXY_EXT="$extentions"
+PROXY_EXT="$extensions"
 add_web_config "$PROXY_SYSTEM" "$template.tpl"
 
 # Adding proxy for ssl
@@ -76,7 +76,7 @@ fi
 
 # Update config
 update_object_value 'web' 'DOMAIN' "$domain" '$PROXY' "$template"
-update_object_value 'web' 'DOMAIN' "$domain" '$PROXY_EXT' "$extentions"
+update_object_value 'web' 'DOMAIN' "$domain" '$PROXY_EXT' "$extensions"
 
 # Restarting web server
 $BIN/v-restart-proxy "$restart"

--- a/bin/v-change-sys-release
+++ b/bin/v-change-sys-release
@@ -4,7 +4,7 @@
 #
 # This function for changing the release branch for the
 # Hestia Control Panel. This allows the user to switch between
-# stable and pre-release builds which will automaticlly update
+# stable and pre-release builds which will automatically update
 # based on the appropriate release schedule if auto-update is
 # turned on.
 

--- a/bin/v-change-sys-service-config
+++ b/bin/v-change-sys-service-config
@@ -4,7 +4,7 @@
 #
 # example: v-change-sys-service-config /home/admin/dovecot.conf dovecot yes
 #
-# This function for changing service confguration.
+# This function for changing service configuration.
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #

--- a/bin/v-change-user-rkey
+++ b/bin/v-change-user-rkey
@@ -2,7 +2,7 @@
 # info: change user random key
 # options: USER [HASH]
 #
-# This function changes user's RKEY value thats has been used for security value to be used forgot password function only.
+# This function changes user's RKEY value that has been used for security value to be used forgot password function only.
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #

--- a/bin/v-change-web-domain-proxy-tpl
+++ b/bin/v-change-web-domain-proxy-tpl
@@ -1,6 +1,6 @@
 #!/bin/bash
 # info: change web domain proxy template
-# options: USER DOMAIN TEMPLATE [EXTENTIONS] [RESTART]
+# options: USER DOMAIN TEMPLATE [EXTENSIONS] [RESTART]
 #
 # example: v-change-web-domain-proxy-tpl admin domain.tld hosting
 #
@@ -15,9 +15,9 @@ user=$1
 domain=$2
 domain_idn=$2
 template=$3
-default_extentions="jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,\
+default_extensions="jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,\
 exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,html,htm"
-extentions=${4-$default_extentions}
+extensions=${4-$default_extensions}
 restart="$5"
 
 # Includes
@@ -42,7 +42,7 @@ format_domain_idn
 #----------------------------------------------------------#
 
 check_args '3' "$#" 'USER DOMAIN TEMPLATE [EXTENTIONS] [RESTART]'
-is_format_valid 'user' 'domain' 'template' 'extentions' 'restart'
+is_format_valid 'user' 'domain' 'template' 'extensions' 'restart'
 is_system_enabled "$PROXY_SYSTEM" 'PROXY_SYSTEM'
 is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
@@ -70,7 +70,7 @@ fi
 
 # Add new vhost
 PROXY="$template"
-PROXY_EXT="$extentions"
+PROXY_EXT="$extensions"
 
 prepare_web_domain_values
 add_web_config "$PROXY_SYSTEM" "$PROXY.tpl"
@@ -84,7 +84,7 @@ fi
 
 # Updating config
 update_object_value 'web' 'DOMAIN' "$domain" '$PROXY' "$PROXY"
-update_object_value 'web' 'DOMAIN' "$domain" '$PROXY_EXT' "$extentions"
+update_object_value 'web' 'DOMAIN' "$domain" '$PROXY_EXT' "$extensions"
 
 # Restarting proxy
 $BIN/v-restart-proxy "$restart"

--- a/bin/v-delete-letsencrypt-domain
+++ b/bin/v-delete-letsencrypt-domain
@@ -1,5 +1,5 @@
 #!/bin/bash
-# info: deleting letsencrypt ssl cetificate for domain
+# info: deleting letsencrypt ssl certificate for domain
 # options: USER DOMAIN [RESTART] [MAIL]
 #
 # example: v-delete-letsencrypt-domain admin acme.com yes

--- a/bin/v-delete-sys-api-ip
+++ b/bin/v-delete-sys-api-ip
@@ -1,5 +1,5 @@
 #!/bin/bash
-# info: delete ip adresss from allowed ip list api
+# info: delete ip address from allowed ip list api
 # options: IP
 #
 # example: v-delete-sys-api-ip 1.1.1.1

--- a/bin/v-delete-web-domain-alias
+++ b/bin/v-delete-web-domain-alias
@@ -5,7 +5,7 @@
 # example: v-delete-web-domain-alias admin example.com www.example.com
 #
 # This function of deleting the alias domain (parked domain). By this call
-# default www aliase can be removed as well.
+# default www alias can be removed as well.
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #

--- a/bin/v-list-dnssec-public-key
+++ b/bin/v-list-dnssec-public-key
@@ -1,8 +1,8 @@
 #!/bin/bash
 # info: list public dnssec key
-# options: USER DOMAIN [FROMAT]
+# options: USER DOMAIN [FORMAT]
 #
-# example: v-list-dns-public-key admin acme.com
+# example: v-list-dnssec-public-key admin acme.com
 #
 # This function list the public key to be used with DNSSEC and needs to be added to the domain register.
 

--- a/bin/v-schedule-letsencrypt-domain
+++ b/bin/v-schedule-letsencrypt-domain
@@ -1,5 +1,5 @@
 #!/bin/bash
-# info: adding cronjob for letsencrypt cetificate installation
+# info: adding cronjob for letsencrypt certificate installation
 # options: USER DOMAIN [ALIASES]
 #
 # example: v-schedule-letsencrypt-domain admin example.com www.example.com

--- a/bin/v-update-user-cgroup
+++ b/bin/v-update-user-cgroup
@@ -4,7 +4,7 @@
 #
 # example: v-update-user-cgroup admin
 #
-# The functions upates cgroup, cpu, ram ,... for specific user
+# The functions updates cgroup, cpu, ram ,... for specific user
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #

--- a/bin/v-update-user-quota
+++ b/bin/v-update-user-quota
@@ -4,7 +4,7 @@
 #
 # example: v-update-user-quota alice
 #
-# The functions upates disk quota for specific user
+# The functions updates disk quota for specific user
 
 #----------------------------------------------------------#
 #                Variables & Functions                     #

--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -113,7 +113,7 @@ To choose what software gets installed, you can provide flags to the installatio
 ```
 
 :::tip
-Option --multiphp (Multi PHP) also accepts a comma seperated list of PHP versions. For example: --multiphp 8.3,8.4 will install PHP8.3 and PHP8.4
+Option --multiphp (Multi PHP) also accepts a comma separated list of PHP versions. For example: --multiphp 8.3,8.4 will install PHP8.3 and PHP8.4
 :::
 
 #### Example

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -1068,7 +1068,7 @@ v-add-web-domain admin wonderland.com 192.18.22.43 yes www.wonderland.com
 This function adds virtual host to a server. In cases when ip is
 undefined in the script, "default" template will be used. The alias of
 `www.domain.tld` type will be automatically assigned to the domain unless
-"none" is transmited as argument. If ip have associated dns name, this
+"none" is transmitted as argument. If ip have associated dns name, this
 domain will also get the alias domain-tpl.$ipname. An alias with the ip
 name is useful during the site testing while dns isn't moved to server yet.
 
@@ -1162,7 +1162,7 @@ This function is used for securing web domain with http auth
 
 add webdomain proxy support
 
-**Options**: `USER` `DOMAIN` `[TEMPLATE]` `[EXTENTIONS]` `[RESTART]`
+**Options**: `USER` `DOMAIN` `[TEMPLATE]` `[EXTENSIONS]` `[RESTART]`
 
 **Examples**:
 
@@ -1995,7 +1995,7 @@ update web templates
 
 This function for changing the release branch for the
 Hestia Control Panel. This allows the user to switch between
-stable and pre-release builds which will automaticlly update
+stable and pre-release builds which will automatically update
 based on the appropriate release schedule if auto-update is
 turned on.
 
@@ -2013,7 +2013,7 @@ change service config
 v-change-sys-service-config /home/admin/dovecot.conf dovecot yes
 ```
 
-This function for changing service confguration.
+This function for changing service configuration.
 
 ## v-change-sys-timezone
 
@@ -2200,7 +2200,7 @@ change user random key
 
 **Options**: `USER` `[HASH]`
 
-This function changes user's RKEY value thats has been used for security value to be used forgot password function only.
+This function changes user's RKEY value that has been used for security value to be used forgot password function only.
 
 ## v-change-user-role
 
@@ -2423,7 +2423,7 @@ This function is used for changing the domain name.
 
 change web domain proxy template
 
-**Options**: `USER` `DOMAIN` `TEMPLATE` `[EXTENTIONS]` `[RESTART]`
+**Options**: `USER` `DOMAIN` `TEMPLATE` `[EXTENSIONS]` `[RESTART]`
 
 **Examples**:
 
@@ -3046,7 +3046,7 @@ This function deletes file on the file system
 
 [Source](https://github.com/hestiacp/hestiacp/blob/release/bin/v-delete-letsencrypt-domain)
 
-deleting letsencrypt ssl cetificate for domain
+deleting letsencrypt ssl certificate for domain
 
 **Options**: `USER` `DOMAIN` `[RESTART]` `[MAIL]`
 
@@ -3362,7 +3362,7 @@ This function synchronise dns with the remote server.
 
 [Source](https://github.com/hestiacp/hestiacp/blob/release/bin/v-delete-sys-api-ip)
 
-delete ip adresss from allowed ip list api
+delete ip address from allowed ip list api
 
 **Options**: `IP`
 
@@ -3777,7 +3777,7 @@ v-delete-web-domain-alias admin example.com www.example.com
 ```
 
 This function of deleting the alias domain (parked domain). By this call
-default www aliase can be removed as well.
+default www alias can be removed as well.
 
 ## v-delete-web-domain-allow-users
 
@@ -4618,7 +4618,7 @@ This function for obtaining the list of all DNS templates available.
 
 list public dnssec key
 
-**Options**: `USER` `DOMAIN` `[FROMAT]`
+**Options**: `USER` `DOMAIN` `[FORMAT]`
 
 **Examples**:
 
@@ -6349,7 +6349,7 @@ This function runs a limited list of cli commands with dropped privileges as the
 
 [Source](https://github.com/hestiacp/hestiacp/blob/release/bin/v-schedule-letsencrypt-domain)
 
-adding cronjob for letsencrypt cetificate installation
+adding cronjob for letsencrypt certificate installation
 
 **Options**: `USER` `DOMAIN` `[ALIASES]`
 
@@ -7555,7 +7555,7 @@ update user disk quota
 v-update-user-cgroup admin
 ```
 
-The functions upates cgroup, cpu, ram ,... for specific user
+The functions updates cgroup, cpu, ram ,... for specific user
 
 ## v-update-user-counters
 
@@ -7619,7 +7619,7 @@ update user disk quota
 v-update-user-quota alice
 ```
 
-The functions upates disk quota for specific user
+The functions updates disk quota for specific user
 
 ## v-update-user-stats
 

--- a/docs/docs/server-administration/backup-restore.md
+++ b/docs/docs/server-administration/backup-restore.md
@@ -36,7 +36,7 @@ Currently HestiaCP only support restoring backups made using:
 
 To edit the number of backups, please read the [Packages](../user-guide/packages) and [Users](../user-guide/users) documentation. You will need to create or edit a package, and assign it to the desired user.
 
-## Not enough disk space available to preform the backup
+## Not enough disk space available to perform the backup
 
 For safety reasons, Hestia takes into account 2x the user’s disk usage when creating a backup. Therefore, before starting a backup, we check how much disk usage a user has left. If you encounter this error, you can do one of the following to solve the issue:
 
@@ -54,7 +54,7 @@ For more information see [the zstd repo](https://github.com/facebook/zstd).
 
 ## What is the optimal compression ratio
 
-The higher the number how better the compression ratio. During our testing, we discoverd that zstd level 3 is similar to level 9 for disk space, however it is much faster. zstd level 11 took about the same time, but gave us a smaller size. Levels higher than 19 should never be used, as zstd then becomes terribly slow.
+The higher the number how better the compression ratio. During our testing, we discovered that zstd level 3 is similar to level 9 for disk space, however it is much faster. zstd level 11 took about the same time, but gave us a smaller size. Levels higher than 19 should never be used, as zstd then becomes terribly slow.
 
 ## What kind of protocols are currently supported
 
@@ -183,7 +183,7 @@ v-backup-user-restic username
 ```
 
 :::warning
-A new restic repository is initiated on the first time you run this command. An encryption key is generated at the same time in /usr/local/hestia/data/users/{users}/restic.conf. Please make sure to backup this file somewhere incase the server gets comprimised or the user gets deleted. Without this "secret" key we don't provide any method to restore the user data. This is the reason why we alway advice to keep the orignal backup still working.
+A new restic repository is initiated on the first time you run this command. An encryption key is generated at the same time in /usr/local/hestia/data/users/{users}/restic.conf. Please make sure to backup this file somewhere in case the server gets compromised or the user gets deleted. Without this "secret" key we don't provide any method to restore the user data. This is the reason why we always advice to keep the original backup still working.
 :::
 
 ### Other methods

--- a/docs/docs/server-administration/configuration.md
+++ b/docs/docs/server-administration/configuration.md
@@ -48,7 +48,7 @@ systemctl restart hestia
 
 ## What does the “Enforce subdomain ownership” policy mean?
 
-In Hestia <=1.3.5 and Vesta, it was possible for users to create subdomains from domains that were owned by other users. For example, user Bob could create `bob.alice.com`, even if `alice.com` is owned by Alice. This could cause security issues and therefor we have decided to add a policy to control this behaviour. By default, the policy is enabled.
+In Hestia <=1.3.5 and Vesta, it was possible for users to create subdomains from domains that were owned by other users. For example, user Bob could create `bob.alice.com`, even if `alice.com` is owned by Alice. This could cause security issues and therefore we have decided to add a policy to control this behaviour. By default, the policy is enabled.
 
 You can tweak the policy for a specific domain and user, for example for a domain that has been used for testing:
 

--- a/docs/docs/server-administration/databases.md
+++ b/docs/docs/server-administration/databases.md
@@ -132,6 +132,6 @@ $cfg["Servers"][$i]["controlpass"] = "random password";
 $cfg["Servers"][$i]["bookmarktable"] = "pma__bookmark";
 ```
 
-Please make sure to create aswell the phpmyadmin user and database.
+Please make sure to create as well the phpmyadmin user and database.
 
 See `/usr/local/hestia/install/deb/phpmyadmin/pma.sh`

--- a/docs/docs/server-administration/dns.md
+++ b/docs/docs/server-administration/dns.md
@@ -29,7 +29,7 @@ If you have just set up your slave, check that the host name resolves and that y
 
 ## DNS Cluster setup
 
-A Master server is where DNS zones are created, and a Slave server recieves the zone via the API. Hestia can be configured as Master <-> Master or Master -> Slave. With a Master <-> Master configuration, each Master is also a Slave, so it could be considered as Master/Slave <-> Master/Slave.
+A Master server is where DNS zones are created, and a Slave server receives the zone via the API. Hestia can be configured as Master <-> Master or Master -> Slave. With a Master <-> Master configuration, each Master is also a Slave, so it could be considered as Master/Slave <-> Master/Slave.
 
 On each Slave server, a unique user is required who will be assigned the zones, and must be assigned the "Sync DNS User" or "dns-cluster" role.
 
@@ -162,7 +162,7 @@ To view the public key. Got to the list DNS domains and click the <i class="fas 
 Depending on your registrar, you will either be able to create a new record based on the DNSKEY or based on DS key. After the DNSSEC public key has been added to the registrar, DNSSEC is enabled and live.
 
 ::: danger
-Removing or disabling the private key in Hestia will make the domain inaccessble.
+Removing or disabling the private key in Hestia will make the domain inaccessible.
 :::
 
 ## FAQ & troubleshooting

--- a/docs/docs/server-administration/email.md
+++ b/docs/docs/server-administration/email.md
@@ -158,7 +158,7 @@ Then add a root cron job, for example to run daily at 03:30:
 ## Rejected because [ip] is in black list at zen.spamhaus.org. Error open resolver: `https://www.spamhaus.org/returnc/pub/65.1.174.102`
 
 1. Go to [Spamhaus free data query account](https://www.spamhaus.com/free-trial/sign-up-for-a-free-data-query-service-account/)
-1. Fill in the form and verify your email address by via the link in the email you recive.
+1. Fill in the form and verify your email address by via the link in the email you receive.
 1. Once logged, go to Products → DQS and you will see your Query Key and below you will see the exactly fqdn that you will need to use Zen Spamhaus black list. Something like: `HereYourQueryKey.zen.dq.spamhaus.net`
 1. Run `v-delete-sys-mail-dnsbl zen.spamhaus.org` to remove the default Spamhaus entry.
 1. Run `v-add-sys-mail-dnsbl HereYourQueryKey.zen.dq.spamhaus.net` to add your custom DQS key. (Note: HestiaCP automatically prevents your Spamhaus Query key from leaking in bounce messages).

--- a/docs/docs/server-administration/rest-api.md
+++ b/docs/docs/server-administration/rest-api.md
@@ -48,7 +48,7 @@ Method has been Deprecated
 To create an access key, follow [the guide in our documentation](../user-guide/account#api-access-keys).
 
 :::tip
-Or create it with the following commad. To create a acccess that requires administrator permissions create the api key via the initial admin user!
+Or create it with the following command. To create a access that requires administrator permissions create the api key via the initial admin user!
 :::
 
 ```bash
@@ -71,7 +71,7 @@ COMMANDS='v-list-web-domains,v-add-web-domain,v-list-web-domain'
 ```
 
 - Role: user or admin.
-- Commands: Comma seperated list with all the command you require.
+- Commands: Comma separated list with all the command you require.
 
 If the software you are using already supports the hash format, use `ACCESS_KEY:SECRET_KEY` instead of your old API key.
 

--- a/docs/docs/server-administration/ssl-certificates.md
+++ b/docs/docs/server-administration/ssl-certificates.md
@@ -87,7 +87,7 @@ Yes, you are able to use Let’s Encrypt certificates with Cloudflare’s proxy,
 1. Disable Cloudflare’s proxy for the desired domain.
 2. Wait at least 5 minutes, for DNS caches to expire.
 3. Request the certificate via the control panel or use the CLI command.
-4. Reenable the proxy.
+4. Re-enable the proxy.
 5. In the **SSL/TLS** tab, switch over to **Full (strict)**.
 
 ## Can I use a Cloudflare Origin CA SSL Certificate?

--- a/docs/docs/server-administration/troubleshooting.md
+++ b/docs/docs/server-administration/troubleshooting.md
@@ -56,7 +56,7 @@ xxxxxx is the date/time the backup is made during the last update of HestiaCP
 
 If you don't have have a backup made you can also copy the config in /usr/local/hestia/install/deb/apache2/apache2.conf to /etc/apache2.conf and also empty /etc/apache2/ports.conf
 
-## Unable to bind adress
+## Unable to bind address
 
 In rare cases the network service might be slower than Apache2 and or Nginx. In that case Nginx or Apache2 will refuse to start up successfully start.
 
@@ -117,7 +117,7 @@ worker_rlimit_nofile 16384
 
 And then restart nginx with systemctl restart nginx
 
-To verifiy run:
+To verify run:
 
 ```bash
 cat /proc/ < nginx-pid > /limits

--- a/docs/docs/user-guide/account.md
+++ b/docs/docs/user-guide/account.md
@@ -85,7 +85,7 @@ You can also use an app to manage them:
 This option is disabled by default for standard users. An administrator needs to enable it in the server settings.
 :::
 
-Click the **<i class="fas fa-fw fa-key"></i> Access Keys** button to view the access keys. Access keys are used for the API to autenticate instead of using the username and password.
+Click the **<i class="fas fa-fw fa-key"></i> Access Keys** button to view the access keys. Access keys are used for the API to authenticate instead of using the username and password.
 
 ### Creating an access key
 


### PR DESCRIPTION
Corrects 50 misspellings across 11 documentation files, found with codespell 2.4.3 and reviewed by hand: seperated, transmited, automaticlly, cetificate, recieves, preform, aswell, autenticate, comprimised, EXTENTIONS, FROMAT, and similar.