### PR TITLE
Fix typo in serial

### DIFF
--- a/bin/v-add-dns-domain
+++ b/bin/v-add-dns-domain
@@ -135,7 +135,7 @@ if [ -z $ns2 ]; then
 fi
 soa="$ns1"
 exp=$(date +%F -d "+ 1 year")
-serial=30000000
+serial=3000000000
 ttl=14400
 
 # Reading template


### PR DESCRIPTION
Variable `serial` is using `30000000` instead of `3000000000`. It doesn't break anything but we need to be consistent with the default serial used in function script `domain.sh`