### PR TITLE
Fix File Manager showing session-timeout redirect as file content

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
+++ b/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
@@ -27,9 +27,7 @@ class HestiaAuth implements Service, AuthInterface {
 	protected $hestia_user = "";
 
 	public function init(array $config = []) {
-		if (isset($_SESSION["user"])) {
-			$v_user = $_SESSION["user"];
-		}
+		$v_user = $_SESSION["user"] ?? "";
 		if (!empty($_SESSION["look"])) {
 			if (isset($_SESSION["look"]) && $_SESSION["userContext"] === "admin") {
 				$v_user = $_SESSION["look"];
@@ -51,6 +49,9 @@ class HestiaAuth implements Service, AuthInterface {
 	}
 
 	public function user(): ?User {
+		if (empty($this->hestia_user)) {
+			return $this->getGuest();
+		}
 		$cmd = "/usr/bin/sudo /usr/local/hestia/bin/v-list-user";
 		exec($cmd . " " . quoteshellarg($this->hestia_user) . " json", $output, $return_var);
 

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -1,6 +1,26 @@
 <?php
 use function Hestiacp\quoteshellarg\quoteshellarg;
 
+// The frontend's AJAX calls (e.g. loading a file into the editor) expect a
+// JSON body with a non-2xx status on error, wrapped the same way as
+// FileGator's own Kernel\Response::json() does (see AuthController /
+// ErrorController: response->json('Not Allowed', 401) becomes
+// {"data": "Not Allowed"}) - otherwise the raw response gets rendered as if
+// it were the requested content. Full page navigations (e.g. a direct
+// /download link) instead need a real redirect, since there is no caller
+// left to interpret a JSON error body.
+function fm_session_expired_response() {
+	$accept = $_SERVER["HTTP_ACCEPT"] ?? "";
+	if (str_contains($accept, "application/json")) {
+		http_response_code(401);
+		header("Content-Type: application/json");
+		echo json_encode(["data" => "Session expired. Please log in again."]);
+	} else {
+		header("Location: /");
+	}
+	exit();
+}
+
 if (session_status() === PHP_SESSION_NONE) {
 	session_start();
 }
@@ -144,9 +164,21 @@ switch ($lang) {
 $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 	"adapter"
 ] = function () {
+	// Filesystem::init() calls this adapter factory for every single request,
+	// not just file operations, because FileGator eagerly initializes all
+	// configured services up front. Routes that FileGator's own routes.php
+	// marks accessible to the "guest" role (no session required) must keep
+	// working without a valid Hestia session - e.g. /getuser is how the
+	// frontend detects "not logged in" and must not itself fail with an
+	// error. Give those a no-op adapter instead of enforcing the session
+	// check meant for actual file access.
+	$guest_routes = ["/getuser", "/getconfig"];
+	if (in_array($_GET["r"] ?? "", $guest_routes, true)) {
+		return new \League\Flysystem\Adapter\NullAdapter();
+	}
+
 	if (empty($_SESSION["user"])) {
-		echo '<meta http-equiv="refresh" content="0; url=/">';
-		exit();
+		fm_session_expired_response();
 	}
 	if (!empty($_SESSION["INACTIVE_SESSION_TIMEOUT"])) {
 		if ($_SESSION["INACTIVE_SESSION_TIMEOUT"] * 60 + $_SESSION["LAST_ACTIVITY"] < time()) {
@@ -161,13 +193,12 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 			session_unset();
 			session_destroy();
 			session_start();
-			echo '<meta http-equiv="refresh" content="0; url=/">';
-			exit();
+			fm_session_expired_response();
 		} else {
 			$_SESSION["LAST_ACTIVITY"] = time();
 		}
 	} else {
-		echo '<meta http-equiv="refresh" content="0; url=/">';
+		fm_session_expired_response();
 	}
 	if (isset($_SESSION["user"])) {
 		$v_user = $_SESSION["user"];


### PR DESCRIPTION
Fixes #5292

When the Hestia session expires, the File Manager's storage adapter echoed a raw `<meta http-equiv="refresh" content="0; url=/">` tag and exited. AJAX calls (e.g. loading a file into the editor) then rendered that string as if it were the requested file's content - misleading and, on a site being investigated for compromise, easy to mistake for tampered data. Full page navigations (e.g. a direct /download link) landed on a dead page instead of being redirected.

This PR:
- Returns a JSON error (matching FileGator's own `{"data": ...}` response envelope) for AJAX requests, and a real redirect for page navigations, so the frontend recognizes the failure instead of displaying it as content.
- Stops the session check from blocking `/getuser` and `/getconfig`, which FileGator's own `routes.php` marks accessible to the `guest` role - the frontend uses `/getuser` to detect "not logged in" and it must not itself fail.
- Fixes a crash in `HestiaAuth` (`user()`/`init()`) that surfaces once `/getuser` is reachable again: it left a session-derived variable undefined and passed it straight into `quoteshellarg()`, which declares `strict_types` and rejects `null` with an uncaught TypeError.

## Test plan

Tested manually end to end on a HestiaCP 1.10.3 instance:
- [x] Open a file in the File Manager editor, let the session expire, reopen it - shows a proper error / redirects to login instead of the fake `<meta refresh>` content
- [x] Hit a direct download link with an expired session - redirects cleanly to the login page instead of a dead page
- [x] `/getuser` and `/getconfig` work normally (no longer blocked/crashing) with an expired session
- [x] `php -l` clean on both changed files
- [x] `prettier --check` clean on both changed files