### PR TITLE
Fix migration scripts not adding the imap_sieve plugin to the IMAP conf

### DIFF
--- a/install/upgrade/manual/migrate_conf_to_debian_13.sh
+++ b/install/upgrade/manual/migrate_conf_to_debian_13.sh
@@ -74,7 +74,7 @@ if [[ "$dovecot_version" = "2.4" ]]; then
 				|| sed -i -E -z 's/    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\n  unix_listener auth-master {\n    group = mail\n    mode = 0660\n    user = dovecot\n  }\n\}/' /etc/dovecot/conf.d/10-master.conf
 			grep -q 'mail_plugins.*sieve' /etc/dovecot/conf.d/15-lda.conf \
 				|| sed -i '/^protocol lda {$/a\  mail_plugins = mail_compress quota sieve' /etc/dovecot/conf.d/15-lda.conf
-			grep -q 'imap_sieve' /etc/dovecot/conf.d/20-imap.conf \
+			grep -q 'imap_quota imap_sieve' /etc/dovecot/conf.d/20-imap.conf \
 				|| sed -i "s/quota imap_quota/quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
 			cp -f "$HESTIA_COMMON_DIR"/dovecot/2.4/sieve/* /etc/dovecot/conf.d
 		fi

--- a/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
+++ b/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
@@ -89,7 +89,7 @@ if [[ "$dovecot_version" = "2.4" ]]; then
 				|| sed -i -E -z 's/    user = dovecot\n  \}\n\}/    user = dovecot\n  \}\n\n  unix_listener auth-master {\n    group = mail\n    mode = 0660\n    user = dovecot\n  }\n\}/' /etc/dovecot/conf.d/10-master.conf
 			grep -q 'mail_plugins.*sieve' /etc/dovecot/conf.d/15-lda.conf \
 				|| sed -i '/^protocol lda {$/a\  mail_plugins = mail_compress quota sieve' /etc/dovecot/conf.d/15-lda.conf
-			grep -q 'imap_sieve' /etc/dovecot/conf.d/20-imap.conf \
+			grep -q 'imap_quota imap_sieve' /etc/dovecot/conf.d/20-imap.conf \
 				|| sed -i "s/quota imap_quota/quota imap_quota imap_sieve/g" /etc/dovecot/conf.d/20-imap.conf
 			cp -f "$HESTIA_COMMON_DIR"/dovecot/2.4/sieve/* /etc/dovecot/conf.d
 		fi


### PR DESCRIPTION
The migration scripts detect whether the `imap_sieve` plugin has been added to the IMAP config `20-imap.conf` using:

```bash
grep -q 'imap_sieve' /etc/dovecot/conf.d/20-imap.conf
```

If it finds `imap_sieve`, the script assumes the plugin is already configured and doesn't add it.

The problem is that, since we keep the original config below our conf, it matches this example line:

```
# imap_sieve = yes
```

As a result, the plugin is not actually added.

This PR fixes the detection in both migration scripts.