### PR TITLE
fix: back link and Access Keys button pointing to wrong user (#5635)

### DIFF
--- a/web/templates/pages/edit_user.php
+++ b/web/templates/pages/edit_user.php
@@ -26,7 +26,7 @@
 			<?php } ?>
 			<?php
 				$api_status = (!empty($_SESSION['API_SYSTEM']) && is_numeric($_SESSION['API_SYSTEM'])) ? $_SESSION['API_SYSTEM'] : 0;
-				if (($user_plain == $_SESSION['ROOT_USER'] && $api_status > 0) || ($user_plain != $_SESSION['ROOT_USER'] && $api_status > 1)) { ?>
+				if (($v_username == $_SESSION['ROOT_USER'] && $api_status > 0) || ($v_username != $_SESSION['ROOT_USER'] && $api_status > 1)) { ?>
 				<a href="<?= tohtml($keys_url) ?>" class="button button-secondary js-button-create" title="<?= tohtml( _("Access Keys")) ?>">
 					<i class="fas fa-key icon-purple"></i><?= tohtml( _("Access Keys")) ?>
 				</a>

--- a/web/templates/pages/list_access_keys.php
+++ b/web/templates/pages/list_access_keys.php
@@ -6,6 +6,10 @@
 				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
+			<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) { ?>
+				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
+					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
+				</a>
 			<?php } else { ?>
 				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>

--- a/web/templates/pages/list_key.php
+++ b/web/templates/pages/list_key.php
@@ -6,6 +6,10 @@
 				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
+			<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) { ?>
+				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
+					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
+				</a>
 			<?php } else { ?>
 				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>

--- a/web/templates/pages/list_log.php
+++ b/web/templates/pages/list_log.php
@@ -15,6 +15,10 @@
 					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 					</a>
+				<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) { ?>
+					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
+						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
+					</a>
 				<?php } else { ?>
 					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>


### PR DESCRIPTION
Closes #5635.

### Problem

When an administrator navigates directly to another user's sub-page (SSH
Keys, Access Keys, or Logs) via the pencil "Edit User" icon in the user
list — without using "Log in as" impersonation — the "Back" button on
that sub-page incorrectly links back to the administrator's own profile
instead of the user actually being managed.

Root cause: the fallback branch of the back-link condition used
`$_SESSION["user"]` (the logged-in admin's own identity) instead of
`$_GET["user"]` (the user whose page is actually being viewed). This
only reproduces via the pencil icon, not via "Log in as" — that path
already worked correctly because it goes through a different branch of
the same condition.

While verifying the fix, the same class of bug was found in the "Access
Keys" button on the user edit page: its visibility check used
`$user_plain` (the acting session identity, which is the admin when
navigating via the pencil icon) instead of `$v_username` (the user
actually being edited), so the button could be shown or hidden based on
the wrong account's `API_SYSTEM` policy eligibility.

### Changes

- `web/templates/pages/list_key.php`
- `web/templates/pages/list_access_keys.php`
- `web/templates/pages/list_log.php`

  Added a branch that uses `$_GET["user"]` for the back link when an
  admin is viewing another user's page directly (not impersonating).

- `web/templates/pages/edit_user.php`

  Changed the "Access Keys" button visibility check to use
  `$v_username` (the user being edited) instead of `$user_plain` (the
  acting session identity).

### Testing

Manually verified on a live Hestia install with an admin account and two
non-admin users:

- Back button on SSH Keys / Access Keys / Logs now points to the
  correct user when navigated to via the pencil "Edit User" icon.
- "Log in as" impersonation path unaffected (was already correct).
- Access Keys button visibility now matches between the pencil-icon
  path and the "Log in as" path, consistent with the `API_SYSTEM`
  policy level.