### PR TITLE
Update HestiaApp.php

### DIFF
--- a/web/src/app/System/HestiaApp.php
+++ b/web/src/app/System/HestiaApp.php
@@ -261,17 +261,15 @@ class HestiaApp
     {
         try {
             $result = $this->runUser('v-list-user', ['json']);
-    
             $userInfo = $result->getOutputJson()[$this->user()];
-    
-            // true = можно создать БД
+
             if ($userInfo['DATABASES'] === 'unlimited') {
                 return true;
             }
-    
+
             $limit = (int) $userInfo['DATABASES'];
             $used  = (int) $userInfo['U_DATABASES'];
-    
+
             return ($limit - $used) > 0;
         } catch (ProcessFailedException) {
             throw new RuntimeException('Unable to check database limit');

--- a/web/src/app/System/HestiaApp.php
+++ b/web/src/app/System/HestiaApp.php
@@ -261,11 +261,18 @@ class HestiaApp
     {
         try {
             $result = $this->runUser('v-list-user', ['json']);
-
+    
             $userInfo = $result->getOutputJson()[$this->user()];
-
-            return $userInfo['DATABASES'] === 'unlimited' ||
-                $userInfo['DATABASES'] - $userInfo['U_DATABASES'] < 1;
+    
+            // true = можно создать БД
+            if ($userInfo['DATABASES'] === 'unlimited') {
+                return true;
+            }
+    
+            $limit = (int) $userInfo['DATABASES'];
+            $used  = (int) $userInfo['U_DATABASES'];
+    
+            return ($limit - $used) > 0;
         } catch (ProcessFailedException) {
             throw new RuntimeException('Unable to check database limit');
         }


### PR DESCRIPTION
The condition `< 1` implies "limit reached," yet the method must return `true` when a database can still be created. Consequently:

when slots are available → `false` → `!checkDatabaseLimit()` triggers in `BaseSetup` → "Limit reached" error; when the limit is reached → `true` → creation is not blocked.