### PR TITLE
Disable imap and smtp debug in Roundcube

### DIFF
--- a/install/common/roundcube/main.inc.php
+++ b/install/common/roundcube/main.inc.php
@@ -8,10 +8,10 @@ $config["db_dsnw"] = "mysql://roundcube:%password%@localhost/roundcube";
 $config["smtp_log"] = false;
 
 // Log IMAP conversation to <log_dir>/imap or to syslog
-$config["imap_debug"] = true;
+$config["imap_debug"] = false;
 
 // Log SMTP conversation to <log_dir>/smtp.log or to syslog
-$config["smtp_debug"] = true;
+$config["smtp_debug"] = false;
 
 // ----------------------------------
 // IMAP


### PR DESCRIPTION
Disable imap_debug and smtp_debug by default. Currently, these options are set to true, which could cause disk space issues.

Fixes #5641