### PR TITLE
Fix bug in SFTP rotation caused #4918

### DIFF
--- a/func/backup.sh
+++ b/func/backup.sh
@@ -401,11 +401,15 @@ sftp_backup() {
 
 	# Checking retention (Only include .tar files)
 	if [ -z $BPATH ]; then
-		backup_list=$(sftpc "ls -l" | awk '{print $9}' | grep -E "^${user}\.[0-9]{4}-.+\.tar$" | sort)
+		backup_list=$(sftpc "ls -l" | tr -d '\r' | awk '{print $9}' | grep -E "^${user}\.[0-9]{4}-.+\.tar$" | sort)
 	else
-		backup_list=$(sftpc "cd $BPATH" "ls -l" | awk '{print $9}' | grep -E "^${user}\.[0-9]{4}-.+\.tar$" | sort)
+		backup_list=$(sftpc "cd $BPATH" "ls -l" | tr -d '\r' | awk '{print $9}' | grep -E "^${user}\.[0-9]{4}-.+\.tar$" | sort)
 	fi
-	backups_count=$(echo "$backup_list" | wc -l)
+	if [ -z "$backup_list" ]; then
+		backups_count=0
+	else
+		backups_count=$(echo "$backup_list" | wc -l)
+	fi
 	if [ "$backups_count" -ge "$BACKUPS" ]; then
 		backups_rm_number=$((backups_count - BACKUPS + 1))
 		for backup in $(echo "$backup_list" | head -n $backups_rm_number); do


### PR DESCRIPTION
Issue caused the server backup storage not properly  rotate the backups on my backup storage causing issue with free backup space. 

Added tr -d '\r' right after sftpc in both the $BPATH and no-$BPATH branches, stripping the pty-injected CR before awk/grep see it.
Replaced the wc -l-on-possibly-empty-string count with an explicit empty check, so a real zero-backup case reports 0 instead of 1.