### PR TITLE
Use release instead of main branch

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -65,15 +65,15 @@ function nav() {
 			items: [
 				{
 					text: 'Changelog',
-					link: 'https://github.com/hestiacp/hestiacp/blob/main/CHANGELOG.md',
+					link: 'https://github.com/hestiacp/hestiacp/blob/release/CHANGELOG.md',
 				},
 				{
 					text: 'Contributing',
-					link: 'https://github.com/hestiacp/hestiacp/blob/main/CONTRIBUTING.md',
+					link: 'https://github.com/hestiacp/hestiacp/blob/release/CONTRIBUTING.md',
 				},
 				{
 					text: 'Security policy',
-					link: 'https://github.com/hestiacp/hestiacp/blob/main/SECURITY.md',
+					link: 'https://github.com/hestiacp/hestiacp/blob/release/SECURITY.md',
 				},
 			],
 		},


### PR DESCRIPTION
Use https://github.com/hestiacp/hestiacp/blob/release/CHANGELOG.md
instead of https://github.com/hestiacp/hestiacp/blob/main/CHANGELOG.md

for the main website