### PR TITLE
Rename phpMyAdmin tempdir configuration to load it last

### DIFF
--- a/install/deb/phpmyadmin/pma.sh
+++ b/install/deb/phpmyadmin/pma.sh
@@ -44,7 +44,7 @@ echo "\$cfg['Servers'][\$i]['designer_coords'] = 'pma__designer_coords';" >> $pm
 echo "\$cfg['Servers'][\$i]['hide_db'] = 'information_schema';" >> $pmapath
 
 # Create temporal dir in /var/lib/
-phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"
+phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/99-tempdir.php"
 phpmyadmin_tmp="/var/lib/phpmyadmin/tmp"
 
 mkdir -p "$phpmyadmin_tmp"

--- a/install/upgrade/manual/migrate_phpmyadmin.sh
+++ b/install/upgrade/manual/migrate_phpmyadmin.sh
@@ -132,7 +132,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	echo "\$cfg['Servers'][\$i]['designer_coords'] = 'pma__designer_coords';" >> $pmapath
 
 	# Create temporal dir in /var/lib/
-	phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"
+	phpmyadmin_tempdir_conf="/etc/phpmyadmin/conf.d/99-tempdir.php"
 	phpmyadmin_tmp="/var/lib/phpmyadmin/tmp"
 
 	mkdir -p "$phpmyadmin_tmp"

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Hestia Control Panel upgrade script for target version 1.10.5
+
+#######################################################################################
+#######                      Place additional commands below.                   #######
+#######################################################################################
+####### upgrade_config_set_value only accepts true or false.                    #######
+#######                                                                         #######
+####### Pass through information to the end user in case of a issue or problem  #######
+#######                                                                         #######
+####### Use add_upgrade_message "My message here" to include a message          #######
+####### in the upgrade notification email. Example:                             #######
+#######                                                                         #######
+####### add_upgrade_message "My message here"                                   #######
+#######                                                                         #######
+####### You can use \n within the string to create new lines.                   #######
+#######################################################################################
+
+upgrade_config_set_value 'UPGRADE_UPDATE_WEB_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_DNS_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
+upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
+upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
+
+# Load the phpMyAdmin tempdir configuration last, leaving lower-numbered
+# prefixes available for additional phpMyAdmin configuration files.
+pma_old_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"
+pma_new_tempdir_conf="/etc/phpmyadmin/conf.d/99-tempdir.php"
+
+if [[ -f "$pma_old_tempdir_conf" ]]; then
+	mv "$pma_old_tempdir_conf" "$pma_new_tempdir_conf"
+fi


### PR DESCRIPTION
Load the phpMyAdmin tempdir configuration last, leaving lower-numbered prefixes available for additional phpMyAdmin configuration files.