### PR TITLE
Bump OpenSSL to 3.5.8

### DIFF
--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -361,7 +361,7 @@ echo "Build version ${BUILD_VER}${_build_release}, with Nginx version $NGINX_V, 
 HESTIA_V="${BUILD_VER}_${BUILD_ARCH}"
 # List of supported OS releases for Hestia used for crossbuilding.
 supported_os="debian11 debian12 debian13 ubuntu22.04 ubuntu24.04 ubuntu26.04"
-OPENSSL_V='3.5.7'
+OPENSSL_V='3.5.8'
 PCRE_V='10.47'
 ZLIB_V='1.3.2'
 


### PR DESCRIPTION
OpenSSL 3.5.8 is a security patch release. The most severe CVE fixed in this release is Moderate.

This release incorporates the following bug fixes and mitigations:

    Fixed QUIC server being able to trigger double free when processing
    INITIAL packet.
    (CVE-2026-18798)

    Fixed heap buffer overflow in CMS key unwrapping.
    (CVE-2026-63072)

    Fixed invalid pointer dereference in CMP server via crafted protectionAlg.
    (CVE-2026-63076)

    Fixed unbounded memory growth in QUIC server incoming channel queue.
    (CVE-2026-14456)

    Fixed RPK server signature algorithm selection being able to dereference
    a missing certificate.
    (CVE-2026-14457)

    Fixed excessive memory use buffering DTLS records for a future epoch.
    (CVE-2026-54874)

    Fixed untrusted Sender DN being used as a format string in CMP response
    validation.
    (CVE-2026-63073)

    Fixed CMP indefinite cache growth of extraCerts.
    (CVE-2026-63074)

    Fixed QUIC ACK-only packet retention being able to cause memory exhaustion.
    (CVE-2026-63075)

    Fixed possibility of AEAD forgeries with empty ciphertext when using
    EVP_Cipher().
    (CVE-2026-75803)

    Fixed checking of authentication tags for empty ciphertexts for AEAD ciphers
    in CCM cipher mode.