### PR TITLE
Fix Global SMTP relay password validation

### DIFF
--- a/bin/v-add-mail-domain-smtp-relay
+++ b/bin/v-add-mail-domain-smtp-relay
@@ -38,7 +38,7 @@ is_object_valid 'user' 'USER' "$user"
 is_object_unsuspended 'user' 'USER' "$user"
 is_object_valid 'mail' 'DOMAIN' "$domain"
 is_object_unsuspended 'mail' 'DOMAIN' "$domain"
-is_password_valid "$password" "Password"
+is_password_valid
 is_username_format_valid "$username" "Username"
 format_no_quotes "$password" "Password"
 

--- a/bin/v-add-sys-smtp-relay
+++ b/bin/v-add-sys-smtp-relay
@@ -32,6 +32,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 check_args '1' "$#" 'HOST [USERNAME] [PASSWORD] [PORT]'
 is_format_valid 'port' 'host' 'password'
 is_username_format_valid "$username" 'username'
+is_password_valid
 format_no_quotes "$password" 'passowrd'
 is_system_enabled "$MAIL_SYSTEM" 'MAIL_SYSTEM'
 


### PR DESCRIPTION
The `v-add-sys-smtp-relay` script was not using the `is_password_valid` function, causing the password to be added as a temporary file instead of the actual password.

Also removed the extra arguments passed to the function in `v-add-mail-domain-smtp-relay`, as the function does not require any arguments.

Fixes #5664