### PR TITLE
Fix system SMTP relay password file handling

### DIFF
--- a/bin/v-add-sys-smtp-relay
+++ b/bin/v-add-sys-smtp-relay
@@ -30,6 +30,7 @@ source_conf "$HESTIA/conf/hestia.conf"
 #----------------------------------------------------------#
 
 check_args '1' "$#" 'HOST [USERNAME] [PASSWORD] [PORT]'
+is_password_valid
 is_format_valid 'port' 'host' 'password'
 is_username_format_valid "$username" 'username'
 format_no_quotes "$password" 'passowrd'


### PR DESCRIPTION
The server-wide SMTP relay settings page passes the relay password to `v-add-sys-smtp-relay` through a temporary file to avoid exposing the password in the process list.

`v-add-sys-smtp-relay` currently does not call `is_password_valid`, so the temporary file path is treated as the password and written to `/etc/exim4/smtp_relay.conf`.

This causes SMTP authentication to fail when the global relay is configured through the web interface.

This change calls the existing `is_password_valid` helper before validating and writing the password, matching Hestia's existing temporary-file password handling.

Tested with the Global SMTP Relay UI using Amazon SES:

- Before the change, the temporary file path was stored as the password and SMTP authentication failed with `535 Authentication Credentials Invalid`.
- After the change, the actual password was stored and SMTP authentication succeeded.