### PR TITLE
Update PCRE to 10.48

### DIFF
--- a/src/hst_autocompile.sh
+++ b/src/hst_autocompile.sh
@@ -362,7 +362,7 @@ HESTIA_V="${BUILD_VER}_${BUILD_ARCH}"
 # List of supported OS releases for Hestia used for crossbuilding.
 supported_os="debian11 debian12 debian13 ubuntu22.04 ubuntu24.04 ubuntu26.04"
 OPENSSL_V='3.5.8'
-PCRE_V='10.47'
+PCRE_V='10.48'
 ZLIB_V='1.3.2'
 
 # Create build directories


### PR DESCRIPTION
This is a regular release, incorporating security fixes along with fixes and small improvements to library behaviour.

This release is available as before as a (signed) Git tag, or alternatively as a (signed) tarball of the Git tag (attestation).

NEWS

Only changes to behaviour, changes to the API, and other significant changes are described here. Please see the ChangeLog and Git log for further details.

(Git change) Renamed the default development branch from master to main.

(Maintenance change) Added a five-year support lifecycle policy and publication of backport patches for security and high-severity fixes in older releases.

(Security fix for specific API usage, GHSA-2p8c-ff85-vh9x) If pcre2_jit_compile() is called with options for some match modes, and then pcre2_match() is used to perform a match for a different match mode, an out-of-bounds read can occur if the match is attempted against invalid UTF input.

(Security fix for pattern conversion, GHSA-q8g2-wprr-34m9) If pcre2_convert() is called on untrusted input on platforms with 32-bit size_t, an out-of-bounds heap write can occur.

(Security fix, GHSA-3r4p-g7gg-ppmf) Fixed an out-of-bounds write in DFA matching when using a heap limit; also fixed possible integer overflows which could cause under-allocation of the workspace.

(Security fix, GHSA-fmgr-6ggq-9859) Added bounds checks for several integer overflows while compiling patterns on 32-bit CPUs, which could cause under-allocation followed by out-of-bounds writes.

(Security fix, GHSA-9qww-pwc4-77qq) Applied lower buffer bound to prevent two out-of-bounds reads while scanning backwards through invalid UTF data with PCRE2_MATCH_INVALID_UTF.

(Matching correctness) Fixed several matching issues:

A JIT-specific matching bug affecting prefix scanning on patterns with repeats (#875).
A JIT-specific matching bug in variable-length lookbehinds (#912).
Miscompiled Unicode character classes combining characters at or below U+00FF with characters at U+0100 and U+8000 or above (#841).
Incorrect JIT character advancement with PCRE2_MATCH_INVALID_UTF in UTF-8 and UTF-16 modes, which could skip adjacent characters (#945).
(Behaviour change) Updated Unicode support to Unicode 17.0.

(Small behaviour changes) Many small fixes, including pcre2_substitute() improvements, optimisation of possessive backreference matching, and pcre2_compile() fixes.

(Small build changes) Many small adjustments to the CMake and Zig builds.

(Security fix for specific API usage, #937) Fixed a leak and later invalid free when calling the fast-path pcre2_jit_match() function with a match data object previously used with pcre2_match() and PCRE2_COPY_MATCHED_SUBJECT.

(Low-severity security fix, GHSA-q7rw-r7qq-2hx6) Fixed exposure of two uninitialised bytes from malloc() via pcre2_serialize_encode().