### PR TITLE
Omit CN for domains longer than 64 characters

### DIFF
--- a/bin/v-generate-ssl-cert
+++ b/bin/v-generate-ssl-cert
@@ -111,7 +111,14 @@ if [ -n "$email" ]; then
 fi
 
 subj="$subj/C=$country/ST=$state/L=$city/O=$org"
-subj="$subj/OU=$org_unit/CN=$domain_idn"
+subj="$subj/OU=$org_unit"
+
+# The CN (CommonName) has an ASN.1 limit of 64 characters in OpenSSL.
+# If the domain exceeds this limit, the CN is omitted and only the SAN
+# (subjectAltName) is trusted, which is what modern browsers validate.
+if [ ${#domain_idn} -le 64 ]; then
+	subj="$subj/CN=$domain_idn"
+fi
 
 if [ -e "/etc/ssl/openssl.cnf" ]; then
 	ssl_conf='/etc/ssl/openssl.cnf'


### PR DESCRIPTION
Avoid setting the certificate Common Name (CN) when the domain name exceeds OpenSSL's 64-character ASN.1 limit.

For longer domains, rely on the Subject Alternative Name (SAN), which is used by modern browsers for hostname validation. This prevents certificate generation failures caused by oversized CN values.

Fixes #5675