### PR TITLE
Fix ProFTPd in Debian 13 and Ubuntu 26.04

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -77,7 +77,7 @@ software="acl apache2 apache2-suexec-custom apache2-utils at awstats bc bind9 bs
   php$fpm_v php$fpm_v-apcu php$fpm_v-bz2 php$fpm_v-cgi php$fpm_v-cli php$fpm_v-common php$fpm_v-curl php$fpm_v-gd
   php$fpm_v-imagick php$fpm_v-imap php$fpm_v-intl php$fpm_v-ldap php$fpm_v-mbstring php$fpm_v-mysql
   php$fpm_v-pgsql php$fpm_v-pspell php$fpm_v-readline php$fpm_v-xml php$fpm_v-zip postgresql postgresql-contrib
-  proftpd-basic quota rrdtool rsyslog spamd sysstat unrar-free unzip util-linux vim-common vsftpd xxd whois zip zstd bubblewrap restic"
+  proftpd-core proftpd-mod-crypto quota rrdtool rsyslog spamd sysstat unrar-free unzip util-linux vim-common vsftpd xxd whois zip zstd bubblewrap restic"
 
 installer_dependencies="apt-transport-https ca-certificates curl dirmngr gnupg openssl wget sudo"
 
@@ -1049,8 +1049,8 @@ if [ "$vsftpd" = 'no' ]; then
 	software=$(echo "$software" | sed -e "s/vsftpd//")
 fi
 if [ "$proftpd" = 'no' ]; then
-	software=$(echo "$software" | sed -e "s/proftpd-basic//")
-	software=$(echo "$software" | sed -e "s/proftpd-mod-vroot//")
+	software=$(echo "$software" | sed -e "s/proftpd-core//")
+	software=$(echo "$software" | sed -e "s/proftpd-mod-crypto//")
 fi
 if [ "$named" = 'no' ]; then
 	software=$(echo "$software" | sed -e "s/bind9//")
@@ -1759,7 +1759,14 @@ if [ "$proftpd" = 'yes' ]; then
 	echo "127.0.0.1 $servername" >> /etc/hosts
 	cp -f $HESTIA_INSTALL_DIR/proftpd/proftpd.conf /etc/proftpd/
 	cp -f $HESTIA_INSTALL_DIR/proftpd/tls.conf /etc/proftpd/
-
+	# In Debian 13 we need to add modules.conf to proftpd.conf so tls mod is loaded
+	if [[ $release -ge 13 ]]; then
+		if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
+			if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+				sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+			fi
+		fi
+	fi
 	update-rc.d proftpd defaults > /dev/null 2>&1
 	systemctl start proftpd >> $LOG
 	check_result $? "proftpd start failed"

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1027,7 +1027,6 @@ if [ "$vsftpd" = 'no' ]; then
 fi
 if [ "$proftpd" = 'no' ]; then
 	software=$(echo "$software" | sed -e "s/proftpd-core//")
-	software=$(echo "$software" | sed -e "s/proftpd-mod-vroot//")
 	software=$(echo "$software" | sed -e "s/proftpd-mod-crypto//")
 fi
 if [ "$named" = 'no' ]; then
@@ -1811,6 +1810,37 @@ if [ "$proftpd" = 'yes' ]; then
 	echo "127.0.0.1 $servername" >> /etc/hosts
 	cp -f $HESTIA_INSTALL_DIR/proftpd/proftpd.conf /etc/proftpd/
 	cp -f $HESTIA_INSTALL_DIR/proftpd/tls.conf /etc/proftpd/
+
+	# In Ubuntu 26.04 we need to:
+	#   1.- Add modules.conf to proftpd.conf so tls mod is loaded.
+	#   2.- Add rules to AppArmor to allow ProFTPD to read the certificates and create the socket.
+	ubuntu_major="${release%%.*}"
+	if [[ "$ubuntu_major" -ge 26 ]]; then
+		# Add modules.conf
+		if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
+			if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+				sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+			fi
+		fi
+
+		# Add ruleset for AppArmor
+		mkdir -p /etc/apparmor.d/local
+		if [[ ! -f /etc/apparmor.d/local/proftpd ]]; then
+			cat > /etc/apparmor.d/local/proftpd << 'EOF'
+# Configuration added by Hestia
+/usr/local/hestia/ssl/certificate.crt r,
+/usr/local/hestia/ssl/certificate.key r,
+/run/proftpd.sock rw,
+EOF
+		elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
+			cat >> /etc/apparmor.d/local/proftpd << 'EOF'
+# Configuration added by Hestia
+/usr/local/hestia/ssl/certificate.crt r,
+/usr/local/hestia/ssl/certificate.key r,
+/run/proftpd.sock rw,
+EOF
+		fi
+	fi
 
 	update-rc.d proftpd defaults > /dev/null 2>&1
 	systemctl start proftpd >> $LOG

--- a/install/hst-install-ubuntu.sh
+++ b/install/hst-install-ubuntu.sh
@@ -1832,6 +1832,7 @@ if [ "$proftpd" = 'yes' ]; then
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
+			apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
 		elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
 			cat >> /etc/apparmor.d/local/proftpd << 'EOF'
 # Configuration added by Hestia
@@ -1839,6 +1840,7 @@ EOF
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
+			apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
 		fi
 	fi
 

--- a/install/upgrade/manual/migrate_conf_to_debian_13.sh
+++ b/install/upgrade/manual/migrate_conf_to_debian_13.sh
@@ -161,6 +161,7 @@ s#  quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/d
 			systemctl status exim4 --no-pager -l >&2
 			echo "[ + ] Recovering configuration backup"
 			cp -f /etc/exim4/exim4.conf.template.bak /etc/exim4/exim4.conf.template
+
 			if systemctl restart exim4 &> /dev/null; then
 				echo "[ + ] Exim successfully restarted after recovery"
 			else
@@ -172,6 +173,39 @@ s#  quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/d
 		echo "[ * ] Exim configuration already up to date"
 	fi
 
+fi
+
+#----------------------------------------------------------#
+#                   ProFTPd configuration                    #
+#----------------------------------------------------------#
+
+if [[ "$FTP_SYSTEM" =~ proftpd ]]; then
+	echo "[ * ] Checking ProFTPd:"
+	if ! dpkg -s proftpd-mod-crypto &> /dev/null; then
+		echo "[ + ] Installing proftpd-mod-crypto:"
+		if apt-get install -y proftpd-mod-crypto &> /dev/null; then
+			echo "[ + ] proftpd-mod-crypto successfully installed"
+		else
+			echo "[ ! ] Error installing proftpd-mod-crypto" >&2
+		fi
+	else
+		echo "[ - ] proftpd-mod-crypto already installed, nothing to do"
+	fi
+	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
+		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+			echo "[ + ] Updating ProFTPd configuration:"
+			sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+
+			if systemctl restart proftpd &> /dev/null; then
+				echo "[ + ] ProFTPd successfully restarted"
+			else
+				echo "[ ! ] Error restarting ProFTPd" >&2
+				systemctl status proftpd --no-pager -l >&2
+			fi
+		else
+			echo "[ - ] ProFTPd already configured, nothing to do"
+		fi
+	fi
 fi
 
 echo

--- a/install/upgrade/manual/migrate_conf_to_debian_13.sh
+++ b/install/upgrade/manual/migrate_conf_to_debian_13.sh
@@ -181,6 +181,7 @@ echo
 #----------------------------------------------------------#
 
 if [[ "$FTP_SYSTEM" =~ proftpd ]]; then
+	restart_proftpd=false
 	echo "[ * ] Checking ProFTPd:"
 	if ! dpkg -s proftpd-mod-crypto &> /dev/null; then
 		echo "[ + ] Installing proftpd-mod-crypto:"
@@ -192,21 +193,37 @@ if [[ "$FTP_SYSTEM" =~ proftpd ]]; then
 	else
 		echo "[ - ] proftpd-mod-crypto already installed, nothing to do"
 	fi
+
+	if [[ -f /etc/proftpd/modules.conf.proftpd-new ]] && [[ -f /etc/proftpd/modules.conf ]] && ! grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf; then
+		echo "[ + ] Ensuring xfer module is enabled"
+		if grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf.proftpd-new; then
+			cp /etc/proftpd/modules.conf "/etc/proftpd/modules.conf.hestia-backup-$(date +%Y-%m-%d)"
+			cp /etc/proftpd/modules.conf.proftpd-new /etc/proftpd/modules.conf
+			restart_proftpd=true
+		else
+			echo "[ ! ] Error: mod_xfer.c is not enabled in modules.conf.proftpd-new either"
+		fi
+	fi
+
 	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
 		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
 			echo "[ + ] Updating ProFTPd configuration:"
 			sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
-
-			if systemctl restart proftpd &> /dev/null; then
-				echo "[ + ] ProFTPd successfully restarted"
-			else
-				echo "[ ! ] Error restarting ProFTPd" >&2
-				systemctl status proftpd --no-pager -l >&2
-			fi
+			restart_proftpd=true
 		else
 			echo "[ - ] ProFTPd already configured, nothing to do"
 		fi
 	fi
+
+	if $restart_proftpd; then
+		if systemctl restart proftpd &> /dev/null; then
+			echo "[ + ] ProFTPd successfully restarted"
+		else
+			echo "[ ! ] Error restarting ProFTPd" >&2
+			systemctl status proftpd --no-pager -l >&2
+		fi
+	fi
+
 fi
 
 echo

--- a/install/upgrade/manual/migrate_conf_to_debian_13.sh
+++ b/install/upgrade/manual/migrate_conf_to_debian_13.sh
@@ -174,6 +174,7 @@ s#  quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/d
 	fi
 
 fi
+echo
 
 #----------------------------------------------------------#
 #                   ProFTPd configuration                    #

--- a/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
+++ b/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
@@ -189,5 +189,54 @@ s#  quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/d
 
 fi
 
+#----------------------------------------------------------#
+#                   ProFTPd configuration                    #
+#----------------------------------------------------------#
+
+if [[ "$FTP_SYSTEM" =~ proftpd ]]; then
+	restart_proftpd=false
+	echo "[ * ] Checking ProFTPd:"
+	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
+		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+			echo "[ + ] Updating ProFTPd configuration:"
+			sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+			restart_proftpd=true
+
+		else
+			echo "[ - ] ProFTPd already configured, nothing to do"
+		fi
+	fi
+	mkdir -p /etc/apparmor.d/local
+	if [[ ! -f /etc/apparmor.d/local/proftpd ]]; then
+		echo "[ + ] Updating AppArmor rules for ProFTPd"
+		cat > /etc/apparmor.d/local/proftpd << 'EOF'
+# Configuration added by Hestia
+/usr/local/hestia/ssl/certificate.crt r,
+/usr/local/hestia/ssl/certificate.key r,
+/run/proftpd.sock rw,
+EOF
+		apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
+		restart_proftpd=true
+	elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
+		echo "[ + ] Updating AppArmor rules for ProFTPd"
+		cat >> /etc/apparmor.d/local/proftpd << 'EOF'
+# Configuration added by Hestia
+/usr/local/hestia/ssl/certificate.crt r,
+/usr/local/hestia/ssl/certificate.key r,
+/run/proftpd.sock rw,
+EOF
+		apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
+		restart_proftpd=true
+	fi
+	if $restart_proftpd; then
+		if systemctl restart proftpd &> /dev/null; then
+			echo "[ + ] ProFTPd successfully restarted"
+		else
+			echo "[ ! ] Error restarting ProFTPd" >&2
+			systemctl status proftpd --no-pager -l >&2
+		fi
+	fi
+fi
+
 echo
 echo "[ * ] Configuration finished!"

--- a/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
+++ b/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
@@ -197,6 +197,17 @@ echo
 if [[ "$FTP_SYSTEM" =~ proftpd ]]; then
 	restart_proftpd=false
 	echo "[ * ] Checking ProFTPd:"
+	if [[ -f /etc/proftpd/modules.conf.proftpd-new ]] && [[ -f /etc/proftpd/modules.conf ]] && ! grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf; then
+		echo "[ + ] Ensuring xfer module is enabled"
+		if grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf.proftpd-new; then
+			cp /etc/proftpd/modules.conf "/etc/proftpd/modules.conf.hestia-backup-$(date +%Y-%m-%d)"
+			cp /etc/proftpd/modules.conf.proftpd-new /etc/proftpd/modules.conf
+			restart_proftpd=true
+		else
+			echo "[ ! ] Error: mod_xfer.c is not enabled in modules.conf.proftpd-new either"
+		fi
+	fi
+
 	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
 		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
 			echo "[ + ] Updating ProFTPd configuration:"

--- a/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
+++ b/install/upgrade/manual/migrate_conf_to_ubuntu_26.04.sh
@@ -188,6 +188,7 @@ s#  quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/d
 	fi
 
 fi
+echo
 
 #----------------------------------------------------------#
 #                   ProFTPd configuration                    #

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -114,7 +114,7 @@ if $restart_proftpd; then
 		systemctl status proftpd --no-pager -l >&2
 	fi
 else
-	echo "[ + ] ProFTPd doens't need to be fixed"
+	echo "[ + ] ProFTPd doesn't need to be fixed"
 fi
 
 # End fix ProFTPD

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -50,75 +50,77 @@ if $IS_DEBIAN13 || $IS_UBUNTU2604; then
 fi
 
 # Start fix ProFTPD
-# In Debiand 13 and Ubuntu 26.04 we need to:
-#   Add modules.conf to proftpd.conf so tls mod is loaded.
-#   Ensure the xfer module is loaded so the UseSendfile directive doesn't produce an error.
-restart_proftpd=false
-if $IS_DEBIAN13_OR_UBUNTU2604; then
-	echo "[ + ] Checking whether ProFTPd needs to be fixed..."
+ftp_system="$(/usr/local/hestia/bin/v-list-sys-config json | jq -r '.[].FTP_SYSTEM')"
+if [[ "$ftp_system" =~ proftpd ]]; then
+	# In Debiand 13 and Ubuntu 26.04 we need to:
+	#   Add modules.conf to proftpd.conf so tls mod is loaded.
+	#   Ensure the xfer module is loaded so the UseSendfile directive doesn't produce an error.
+	restart_proftpd=false
+	if $IS_DEBIAN13_OR_UBUNTU2604; then
+		echo "[ + ] Checking whether ProFTPd needs to be fixed..."
 
-	if [[ -f /etc/proftpd/modules.conf.proftpd-new ]] && [[ -f /etc/proftpd/modules.conf ]] && ! grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf; then
-		echo "[ + ] Fixing ProFTPd not loading module xfer"
-		if grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf.proftpd-new; then
-			cp /etc/proftpd/modules.conf "/etc/proftpd/modules.conf.hestia-backup-$(date +%Y-%m-%d)"
-			cp /etc/proftpd/modules.conf.proftpd-new /etc/proftpd/modules.conf
-			restart_proftpd=true
-		else
-			echo "[ ! ] Error: mod_xfer.c is not enabled in either modules.conf or modules.conf.proftpd-new"
+		if [[ -f /etc/proftpd/modules.conf.proftpd-new ]] && [[ -f /etc/proftpd/modules.conf ]] && ! grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf; then
+			echo "[ + ] Fixing ProFTPd not loading module xfer"
+			if grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf.proftpd-new; then
+				cp /etc/proftpd/modules.conf "/etc/proftpd/modules.conf.hestia-backup-$(date +%Y-%m-%d)"
+				cp /etc/proftpd/modules.conf.proftpd-new /etc/proftpd/modules.conf
+				restart_proftpd=true
+			else
+				echo "[ ! ] Error: mod_xfer.c is not enabled in either modules.conf or modules.conf.proftpd-new"
+			fi
+		fi
+
+		if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
+			if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+				echo "[ + ] Fixing ProFTPd not loading modules.conf"
+				sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+				restart_proftpd=true
+			fi
 		fi
 	fi
 
-	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
-		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
-			echo "[ + ] Fixing ProFTPd not loading modules.conf"
-			sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
-			restart_proftpd=true
-		fi
-	fi
-fi
-
-# In Ubuntu 26.04 we also need to:
-#   Add rules to AppArmor to allow ProFTPD to read the certificates and create the socket.
-if $IS_UBUNTU2604; then
-	# Add ruleset for AppArmor
-	mkdir -p /etc/apparmor.d/local
-	if [[ ! -f /etc/apparmor.d/local/proftpd ]]; then
-		echo "[ + ] Fixing ProFTPd rules for AppArmor"
-		cat > /etc/apparmor.d/local/proftpd << 'EOF'
+	# In Ubuntu 26.04 we also need to:
+	#   Add rules to AppArmor to allow ProFTPD to read the certificates and create the socket.
+	if $IS_UBUNTU2604; then
+		# Add ruleset for AppArmor
+		mkdir -p /etc/apparmor.d/local
+		if [[ ! -f /etc/apparmor.d/local/proftpd ]]; then
+			echo "[ + ] Fixing ProFTPd rules for AppArmor"
+			cat > /etc/apparmor.d/local/proftpd << 'EOF'
 # Configuration added by Hestia
 /usr/local/hestia/ssl/certificate.crt r,
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
-		apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
-		restart_proftpd=true
-	elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
-		echo "[ + ] Fixing ProFTPd rules for AppArmor"
-		cat >> /etc/apparmor.d/local/proftpd << 'EOF'
+			apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
+			restart_proftpd=true
+		elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
+			echo "[ + ] Fixing ProFTPd rules for AppArmor"
+			cat >> /etc/apparmor.d/local/proftpd << 'EOF'
 # Configuration added by Hestia
 /usr/local/hestia/ssl/certificate.crt r,
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
-		apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
-		restart_proftpd=true
-	fi
-fi
-
-if $IS_DEBIAN13_OR_UBUNTU2604; then
-	if $restart_proftpd; then
-		echo "[ + ] Restarting ProFTPd service"
-		if systemctl restart proftpd &> /dev/null; then
-			echo "[ + ] ProFTPd successfully restarted"
-		else
-			echo "[ ! ] Error restarting ProFTPd" >&2
-			systemctl status proftpd --no-pager -l >&2
+			apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
+			restart_proftpd=true
 		fi
-	else
-		echo "[ + ] ProFTPd doesn't need to be fixed"
+	fi
+
+	if $IS_DEBIAN13_OR_UBUNTU2604; then
+		if $restart_proftpd; then
+			echo "[ + ] Restarting ProFTPd service"
+			if systemctl restart proftpd &> /dev/null; then
+				echo "[ + ] ProFTPd successfully restarted"
+			else
+				echo "[ ! ] Error restarting ProFTPd" >&2
+				systemctl status proftpd --no-pager -l >&2
+			fi
+		else
+			echo "[ + ] ProFTPd doesn't need to be fixed"
+		fi
 	fi
 fi
-
 # End fix ProFTPD
 
 # Load the phpMyAdmin tempdir configuration last, leaving lower-numbered

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -105,16 +105,18 @@ EOF
 	fi
 fi
 
-if $restart_proftpd; then
-	echo "[ + ] Restarting ProFTPd service"
-	if systemctl restart proftpd &> /dev/null; then
-		echo "[ + ] ProFTPd successfully restarted"
+if $IS_DEBIAN13_OR_UBUNTU2604; then
+	if $restart_proftpd; then
+		echo "[ + ] Restarting ProFTPd service"
+		if systemctl restart proftpd &> /dev/null; then
+			echo "[ + ] ProFTPd successfully restarted"
+		else
+			echo "[ ! ] Error restarting ProFTPd" >&2
+			systemctl status proftpd --no-pager -l >&2
+		fi
 	else
-		echo "[ ! ] Error restarting ProFTPd" >&2
-		systemctl status proftpd --no-pager -l >&2
+		echo "[ + ] ProFTPd doesn't need to be fixed"
 	fi
-else
-	echo "[ + ] ProFTPd doesn't need to be fixed"
 fi
 
 # End fix ProFTPD

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -52,10 +52,27 @@ fi
 # Start fix ProFTPD
 # In Debiand 13 and Ubuntu 26.04 we need to:
 #   Add modules.conf to proftpd.conf so tls mod is loaded.
+#   Ensure the xfer module is loaded so the UseSendfile directive doesn't produce an error.
+restart_proftpd=false
 if $IS_DEBIAN13_OR_UBUNTU2604; then
+	echo "[ + ] Checking whether ProFTPd needs to be fixed..."
+
+	if [[ -f /etc/proftpd/modules.conf.proftpd-new ]] && [[ -f /etc/proftpd/modules.conf ]] && ! grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf; then
+		echo "[ + ] Fixing ProFTPd not loading module xfer"
+		if grep -qE "^[[:space:]]*LoadModule[[:space:]]+mod_xfer\.c" /etc/proftpd/modules.conf.proftpd-new; then
+			cp /etc/proftpd/modules.conf "/etc/proftpd/modules.conf.hestia-backup-$(date +%Y-%m-%d)"
+			cp /etc/proftpd/modules.conf.proftpd-new /etc/proftpd/modules.conf
+			restart_proftpd=true
+		else
+			echo "[ ! ] Error: mod_xfer.c is not enabled in either modules.conf or modules.conf.proftpd-new"
+		fi
+	fi
+
 	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
 		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+			echo "[ + ] Fixing ProFTPd not loading modules.conf"
 			sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+			restart_proftpd=true
 		fi
 	fi
 fi
@@ -66,21 +83,38 @@ if $IS_UBUNTU2604; then
 	# Add ruleset for AppArmor
 	mkdir -p /etc/apparmor.d/local
 	if [[ ! -f /etc/apparmor.d/local/proftpd ]]; then
+		echo "[ + ] Fixing ProFTPd rules for AppArmor"
 		cat > /etc/apparmor.d/local/proftpd << 'EOF'
 # Configuration added by Hestia
 /usr/local/hestia/ssl/certificate.crt r,
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
+		restart_proftpd=true
 	elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
+		echo "[ + ] Fixing ProFTPd rules for AppArmor"
 		cat >> /etc/apparmor.d/local/proftpd << 'EOF'
 # Configuration added by Hestia
 /usr/local/hestia/ssl/certificate.crt r,
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
+		restart_proftpd=true
 	fi
 fi
+
+if $restart_proftpd; then
+	echo "[ + ] Restarting ProFTPd service"
+	if systemctl restart proftpd &> /dev/null; then
+		echo "[ + ] ProFTPd successfully restarted"
+	else
+		echo "[ ! ] Error restarting ProFTPd" >&2
+		systemctl status proftpd --no-pager -l >&2
+	fi
+else
+	echo "[ + ] ProFTPd doens't need to be fixed"
+fi
+
 # End fix ProFTPD
 
 # Load the phpMyAdmin tempdir configuration last, leaving lower-numbered

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -23,6 +23,66 @@ upgrade_config_set_value 'UPGRADE_UPDATE_FILEMANAGER_CONFIG' 'false'
 upgrade_config_set_value 'UPGRADE_UPDATE_MAIL_TEMPLATES' 'false'
 upgrade_config_set_value 'UPGRADE_REBUILD_USERS' 'false'
 
+if [ -f /etc/os-release ]; then
+	# /etc/os-release defines its own $VERSION, which would otherwise
+	# clobber Hestia's $VERSION since this script is sourced by the caller
+	_HESTIA_VERSION="$VERSION"
+	source /etc/os-release
+	VERSION="$_HESTIA_VERSION"
+	unset _HESTIA_VERSION
+fi
+
+# Set running OS
+IS_DEBIAN13=false
+IS_UBUNTU2604=false
+IS_DEBIAN13_OR_UBUNTU2604=false
+
+if [[ "$ID" == "debian" && "$VERSION_ID" == "13" ]]; then
+	IS_DEBIAN13=true
+fi
+
+if [[ "$ID" == "ubuntu" && "$VERSION_ID" == "26.04" ]]; then
+	IS_UBUNTU2604=true
+fi
+
+if $IS_DEBIAN13 || $IS_UBUNTU2604; then
+	IS_DEBIAN13_OR_UBUNTU2604=true
+fi
+
+# Start fix ProFTPD
+# In Debiand 13 and Ubuntu 26.04 we need to:
+#   Add modules.conf to proftpd.conf so tls mod is loaded.
+if $IS_DEBIAN13_OR_UBUNTU2604; then
+	if [[ -f /etc/proftpd/modules.conf ]] && grep -qF "Include /etc/proftpd/tls.conf" /etc/proftpd/proftpd.conf; then
+		if ! grep -qF "Include /etc/proftpd/modules.conf" /etc/proftpd/proftpd.conf; then
+			sed -i '\|Include /etc/proftpd/tls.conf|i Include /etc/proftpd/modules.conf' /etc/proftpd/proftpd.conf
+		fi
+	fi
+fi
+
+# In Ubuntu 26.04 we also need to:
+#   Add rules to AppArmor to allow ProFTPD to read the certificates and create the socket.
+if $IS_UBUNTU2604; then
+	# Add ruleset for AppArmor
+	mkdir -p /etc/apparmor.d/local
+	if [[ ! -f /etc/apparmor.d/local/proftpd ]]; then
+		cat > /etc/apparmor.d/local/proftpd << 'EOF'
+# Configuration added by Hestia
+/usr/local/hestia/ssl/certificate.crt r,
+/usr/local/hestia/ssl/certificate.key r,
+/run/proftpd.sock rw,
+EOF
+	elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
+		cat >> /etc/apparmor.d/local/proftpd << 'EOF'
+# Configuration added by Hestia
+/usr/local/hestia/ssl/certificate.crt r,
+/usr/local/hestia/ssl/certificate.key r,
+/run/proftpd.sock rw,
+EOF
+	fi
+fi
+# End fix ProFTPD
+
 # Load the phpMyAdmin tempdir configuration last, leaving lower-numbered
 # prefixes available for additional phpMyAdmin configuration files.
 pma_old_tempdir_conf="/etc/phpmyadmin/conf.d/02-tempdir.php"

--- a/install/upgrade/versions/1.10.5.sh
+++ b/install/upgrade/versions/1.10.5.sh
@@ -90,6 +90,7 @@ if $IS_UBUNTU2604; then
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
+		apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
 		restart_proftpd=true
 	elif ! grep -qF "# Configuration added by Hestia" /etc/apparmor.d/local/proftpd; then
 		echo "[ + ] Fixing ProFTPd rules for AppArmor"
@@ -99,6 +100,7 @@ EOF
 /usr/local/hestia/ssl/certificate.key r,
 /run/proftpd.sock rw,
 EOF
+		apparmor_parser -r /etc/apparmor.d/proftpd 2> /dev/null
 		restart_proftpd=true
 	fi
 fi


### PR DESCRIPTION
In Debiand 13 and Ubuntu 26.04 we need to:
- Add `modules.conf` to `proftpd.conf` so tls mod is loaded.

In Ubuntu 26.04 we also need to:
- Add rules to AppArmor to allow ProFTPD to read the certificates and create the socket.

Forum post: https://forum.hestiacp.com/t/ftp-issues-on-debian-13-with-hestiacp-1-10-4-with-proftpd/22179