### PR TITLE
feat(backup): Enhance backup detail pages by adding icons to item types

### DIFF
--- a/web/templates/pages/list_backup_detail.php
+++ b/web/templates/pages/list_backup_detail.php
@@ -73,7 +73,7 @@
 					</div>
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-					<?= tohtml( _("Web Domain")) ?>
+					<i class="fas fa-earth-americas u-mr5"></i><?= tohtml( _("Web Domain")) ?>
 				</div>
 				<div class="units-table-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -116,7 +116,7 @@
 					</div>
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-					<?= tohtml( _("Mail Domain")) ?>
+					<i class="fas fa-envelopes-bulk u-mr5"></i><?= tohtml( _("Mail Domain")) ?>
 				</div>
 				<div class="units-table-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -159,7 +159,7 @@
 					</div>
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-					<?= tohtml( _("DNS Zone")) ?>
+					<i class="fas fa-book-atlas u-mr5"></i><?= tohtml( _("DNS Zone")) ?>
 				</div>
 				<div class="units-table-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -202,7 +202,7 @@
 					</div>
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-					<?= tohtml( _("Database")) ?>
+					<i class="fas fa-database u-mr5"></i><?= tohtml( _("Database")) ?>
 				</div>
 				<div class="units-table-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -243,7 +243,7 @@
 					</div>
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-					<?= tohtml( _("Cron Jobs")) ?>
+					<i class="fas fa-clock u-mr5"></i><?= tohtml( _("Cron Jobs")) ?>
 				</div>
 				<div class="units-table-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -286,7 +286,7 @@
 					</div>
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-					<?= tohtml( _("User Directory")) ?>
+					<i class="fas fa-folder-open u-mr5"></i><?= tohtml( _("User Directory")) ?>
 				</div>
 				<div class="units-table-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>

--- a/web/templates/pages/list_backup_detail_incremental.php
+++ b/web/templates/pages/list_backup_detail_incremental.php
@@ -63,7 +63,7 @@
 			</div>
 			<div class="units-table-cell units-table-heading-cell">
 				<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-				<?= tohtml( _("Web Domain")) ?>
+				<i class="fas fa-earth-americas u-mr5"></i><?= tohtml( _("Web Domain")) ?>
 			</div>
 			<div class="units-table-cell u-text-bold">
 				<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -97,7 +97,7 @@
 			</div>
 			<div class="units-table-cell units-table-heading-cell">
 				<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-				<?= tohtml( _("Mail Domain")) ?>
+				<i class="fas fa-envelopes-bulk u-mr5"></i><?= tohtml( _("Mail Domain")) ?>
 			</div>
 			<div class="units-table-cell u-text-bold">
 				<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -131,7 +131,7 @@
 			</div>
 			<div class="units-table-cell units-table-heading-cell">
 				<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-				<?= tohtml( _("DNS Domain")) ?>
+				<i class="fas fa-book-atlas u-mr5"></i><?= tohtml( _("DNS Domain")) ?>
 			</div>
 			<div class="units-table-cell u-text-bold">
 				<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -165,7 +165,7 @@
 			</div>
 			<div class="units-table-cell units-table-heading-cell">
 				<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-				<?= tohtml( _("Database")) ?>
+				<i class="fas fa-database u-mr5"></i><?= tohtml( _("Database")) ?>
 			</div>
 			<div class="units-table-cell u-text-bold">
 				<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>
@@ -199,7 +199,7 @@
 		</div>
 		<div class="units-table-cell units-table-heading-cell">
 			<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Type")) ?>:</span>
-			<?= tohtml( _("Cronjob")) ?>
+			<i class="fas fa-clock u-mr5"></i><?= tohtml( _("Cronjob")) ?>
 		</div>
 		<div class="units-table-cell u-text-bold">
 			<span class="u-hide-desktop"><?= tohtml( _("Details")) ?>:</span>


### PR DESCRIPTION
## Description
This PR improves the user experience on the Backup Details pages (both standard and incremental) by adding corresponding Font Awesome icons to the "Type" column.

Currently, the items inside a backup are only differentiated by plain text, which can be hard to scan. By adding these icons, it becomes much easier and faster for users to visually identify what each item is when selecting things to restore.

## Changes

- Added matching icons to `web/templates/pages/list_backup_detail.php` and `web/templates/pages/list_backup_detail_incremental.php`.
- Icons used: `fa-earth-americas` (Web Domain), `fa-envelopes-bulk` (Mail Domain), `fa-book-atlas` (DNS Zone), `fa-database` (Database), `fa-clock` (Cron Jobs), and `fa-folder-open` (User Directory).
- Utilized the standard `.u-mr5` class to ensure consistent spacing between the icon and the label text (which correctly accommodates LTR/RTL layouts).

## Screenshot

<img width="1073" height="694" alt="image" src="https://github.com/user-attachments/assets/fe8f81c5-104d-402d-96d5-1fff766d4705" />

