### PR TITLE
fix(ui): action button icons overlapping text on mobile view

### DIFF
--- a/web/css/src/themes/default.css
+++ b/web/css/src/themes/default.css
@@ -1111,7 +1111,8 @@
 	}
 
 	& .fas {
-		padding: 5px 5px 5px 10px;
+		padding: 5px 0;
+		margin: 0 5px 0 10px;
 		font-size: 0.9rem;
 	}
 
@@ -1122,6 +1123,7 @@
 		& .fas {
 			color: silver;
 			padding: 4px;
+			margin: 0;
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes a visual bug on mobile devices where the icons inside table action buttons (e.g., Visit, Edit Domain, Suspend, Restore) were overlapping the first letter of the button text. 

<img width="500" height="667" alt="SCR-20260902-midu" src="https://github.com/user-attachments/assets/02f935ec-c4c9-4149-b444-02f23165f1f4" />

The issue was caused by `padding` being used for horizontal spacing on the `.fas` icon elements. Because of `box-sizing: border-box` and FontAwesome's inherent glyph widths, the horizontal padding squished the icon's content box, forcing the glyph to physically overflow its container to the right and cover the adjacent `<span>` text.

## Changes Made
- **`web/css/src/themes/default.css`**: Migrated horizontal spacing on `.units-table-row-action .fas` from `padding` to `margin` for mobile viewports. This properly separates the icon from the text without triggering content box overflow.
- Ensured that `margin: 0` is reset on desktop viewports (`--viewport-large`), preserving the intended square button layout.
- Ran `npm run build` to successfully recompile the minified CSS assets (`web/css/themes/default.css` and `dark.css`).

## How to Test
1. Access the control panel from a mobile device (or simulate mobile view via browser DevTools).
2. Navigate to the **Web**, **Backups**, or any other page with table action buttons.
3. Verify that the text inside the action buttons (e.g., "Edit Domain", "Restore") is properly spaced and no longer sits underneath the icons.

<img width="502" height="676" alt="SCR-20260902-mizk" src="https://github.com/user-attachments/assets/76f4d9b4-8a67-46ad-b463-6563b7ff7551" />
