### PR TITLE
feat(cron): Auto-select appropriate Cron Generator tab based on current cron values

### DIFF
--- a/web/js/src/cronGenerator.js
+++ b/web/js/src/cronGenerator.js
@@ -1,5 +1,7 @@
 // Copies values from cron generator fields to main cron fields when "Generate" is clicked
 export default function handleCronGenerator() {
+	setTimeout(initCronGenerator, 0);
+
 	document.querySelectorAll('.js-generate-cron').forEach((button) => {
 		button.addEventListener('click', () => {
 			const fieldset = button.closest('fieldset');
@@ -22,4 +24,94 @@ export default function handleCronGenerator() {
 			});
 		});
 	});
+}
+
+function initCronGenerator() {
+	const mainForm = document.getElementById('main-form');
+	if (!mainForm) return;
+
+	const vMin = mainForm.querySelector('input[name="v_min"]')?.value;
+	const vHour = mainForm.querySelector('input[name="v_hour"]')?.value;
+	const vDay = mainForm.querySelector('input[name="v_day"]')?.value;
+	const vMonth = mainForm.querySelector('input[name="v_month"]')?.value;
+	const vWday = mainForm.querySelector('input[name="v_wday"]')?.value;
+
+	if (!vMin) return;
+
+	const tabs = [
+		{
+			id: 'tab-one',
+			condition: vHour === '*' && vDay === '*' && vMonth === '*' && vWday === '*',
+			fields: { h_min: vMin },
+		},
+		{
+			id: 'tab-two',
+			condition: vDay === '*' && vMonth === '*' && vWday === '*',
+			fields: { h_hour: vHour, h_min: vMin },
+		},
+		{
+			id: 'tab-three',
+			condition: vMonth === '*' && vWday === '*',
+			fields: { h_day: vDay, h_hour: vHour, h_min: vMin },
+		},
+		{
+			id: 'tab-four',
+			condition: vDay === '*' && vMonth === '*',
+			fields: { h_wday: vWday, h_hour: vHour, h_min: vMin },
+		},
+		{
+			id: 'tab-five',
+			condition: vWday === '*',
+			fields: { h_month: vMonth, h_day: vDay, h_hour: vHour, h_min: vMin },
+		},
+	];
+
+	// Find the most appropriate tab
+	let selectedTab = null;
+	let selectedFields = null;
+
+	for (const tab of tabs) {
+		if (!tab.condition) continue;
+
+		const panel = document.querySelector(`[aria-labelledby="${tab.id}"]`);
+		if (!panel) continue;
+
+		let allFieldsMatch = true;
+		for (const [name, value] of Object.entries(tab.fields)) {
+			const select = panel.querySelector(`select[name="${name}"]`);
+			if (select) {
+				const optionExists = Array.from(select.options).some((opt) => opt.value === value);
+				if (!optionExists) {
+					allFieldsMatch = false;
+					break;
+				}
+			} else {
+				allFieldsMatch = false;
+				break;
+			}
+		}
+
+		if (allFieldsMatch) {
+			selectedTab = tab.id;
+			selectedFields = tab.fields;
+			break;
+		}
+	}
+
+	if (selectedTab) {
+		const tabElement = document.getElementById(selectedTab);
+		if (tabElement) {
+			tabElement.click(); // Activate the tab
+			tabElement.blur(); // Remove the blue focus ring caused by programmatic clicking
+
+			// Set the select values
+			const panel = document.querySelector(`[aria-labelledby="${selectedTab}"]`);
+			for (const [name, value] of Object.entries(selectedFields)) {
+				const select = panel.querySelector(`select[name="${name}"]`);
+				if (select) {
+					select.value = value;
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Description
This PR enhances the "Edit Cron Job" page by automatically selecting the most appropriate tab in the Cron Generator based on the job's current configuration. 

Previously, the page always defaulted to the first tab ("Minutes"), even if the cron job was set to run Daily, Weekly, or Monthly. This PR adds logic to inspect the current cron parameters (`v_min`, `v_hour`, `v_day`, `v_month`, `v_wday`) on page load, identify the most specific tab that can accommodate those exact values, and automatically switch to it.

## Changes
- Added `initCronGenerator()` to `web/js/src/cronGenerator.js` which parses the current cron input fields upon page load.
- Implemented a priority-based matching system (Minutes -> Hourly -> Daily -> Weekly -> Monthly) that verifies if the current cron expression exactly matches the `<select>` options available in each tab.
- Simulated a tab click to activate the matched tab and auto-populate its dropdown menus with the current values.
- Deferred the execution of `initCronGenerator` via `setTimeout` to ensure it fires after `tabPanels.js` has finished attaching its click event listeners.
- Called `.blur()` on the activated tab to prevent the browser from displaying a programmatic focus ring (blue border).

## How to Test
1. Open an existing cron job configured to run daily (e.g., `0 2 * * *`).
2. Verify that the Cron Generator automatically opens the **Daily** tab.
3. Verify that the Run Command, Hour, and Minute dropdowns are populated correctly.
4. Verify that no blue focus ring is left around the selected tab.
5. Edit a cron job with a custom/unsupported expression (e.g. `14 15 12 * *`) and verify it gracefully ignores it and stays on the default tab.