### PR TITLE
Improves read-only mode enforcement

### DIFF
--- a/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
+++ b/install/deb/filemanager/filegator/backend/Services/Auth/Adapters/HestiaAuth.php
@@ -35,7 +35,7 @@ class HestiaAuth implements Service, AuthInterface {
 				$v_user = $_SESSION["look"];
 			}
 			if (
-				$_SESSION["look"] == "admin" &&
+				$_SESSION["look"] == $_SESSION["root"] &&
 				$_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] == "yes"
 			) {
 				// Go away do not login

--- a/install/deb/filemanager/filegator/configuration.php
+++ b/install/deb/filemanager/filegator/configuration.php
@@ -178,7 +178,7 @@ $dist_config["services"]["Filegator\Services\Storage\Filesystem"]["config"][
 		}
 		if (
 			isset($_SESSION["look"]) &&
-			$_SESSION["look"] == "admin" &&
+			$_SESSION["look"] == $_SESSION["ROOT_USER"] &&
 			$_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] == "yes"
 		) {
 			header("Location: /");

--- a/web/add/cron/index.php
+++ b/web/add/cron/index.php
@@ -8,7 +8,7 @@ $TAB = "CRON";
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
 // Check POST request
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only != true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/cron/index.php
+++ b/web/add/cron/index.php
@@ -8,7 +8,7 @@ $TAB = "CRON";
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
 // Check POST request
-if (!empty($_POST["ok"]) && $read_only != true) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/cron/reports/index.php
+++ b/web/add/cron/reports/index.php
@@ -5,8 +5,9 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
-exec(HESTIA_CMD . "v-add-cron-reports " . $user, $output, $return_var);
-unset($output);
-
+if ($read_only !== true) {
+	exec(HESTIA_CMD . "v-add-cron-reports " . $user, $output, $return_var);
+	unset($output);
+}
 header("Location: /list/cron/");
 exit();

--- a/web/add/db/index.php
+++ b/web/add/db/index.php
@@ -8,7 +8,7 @@ $TAB = "DB";
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
 // Check POST request
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -13,7 +13,7 @@ $v_ips = json_decode(implode("", $output), true);
 unset($output);
 
 // Check POST request for dns domain
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/key/index.php
+++ b/web/add/key/index.php
@@ -8,7 +8,7 @@ $TAB = "USER";
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
 // Check POST request
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/mail/index.php
+++ b/web/add/mail/index.php
@@ -30,7 +30,7 @@ if (!empty($v_domain)) {
 }
 
 // Check POST request for mail domain
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 
@@ -201,7 +201,7 @@ if (!empty($_POST["ok"])) {
 }
 
 // Check POST request for mail account
-if (!empty($_POST["ok_acc"])) {
+if (!empty($_POST["ok_acc"]) && $read_only !== true) {
 	// Check token
 	if (!isset($_POST["token"]) || $_SESSION["token"] != $_POST["token"]) {
 		header("location: /login/");

--- a/web/add/user/index.php
+++ b/web/add/user/index.php
@@ -14,7 +14,7 @@ if ($_SESSION["userContext"] != "admin") {
 }
 
 // Check POST request
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 
@@ -26,7 +26,7 @@ if (!empty($_POST["ok"])) {
 		$errors[] = _("Password");
 	}
 	if (empty($_POST["v_package"])) {
-		$errrors[] = _("Package");
+		$errors[] = _("Package");
 	}
 	if (empty($_POST["v_email"])) {
 		$errors[] = _("Email");

--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -8,7 +8,7 @@ $TAB = "WEB";
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
 // Check POST request
-if (!empty($_POST["ok"])) {
+if (!empty($_POST["ok"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -65,7 +65,7 @@ if (!empty($_GET["app"])) {
 }
 
 // Check POST request
-if (!empty($_POST["ok"]) && !empty($app)) {
+if (!empty($_POST["ok"]) && !empty($app) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -14,11 +14,6 @@ if (empty($_GET["domain"])) {
 	exit();
 }
 
-// Edit as someone else?
-if ($_SESSION["user"] == $_SESSION["ROOT_USER"] && !empty($_GET["user"])) {
-	$user = quoteshellarg($_GET["user"]);
-}
-
 // Check if domain belongs to the user
 $v_domain = $_GET["domain"];
 $user = isset($user) ? $user : quoteshellarg($_SESSION["user"]);

--- a/web/add/webapp/index.php
+++ b/web/add/webapp/index.php
@@ -15,12 +15,13 @@ if (empty($_GET["domain"])) {
 }
 
 // Edit as someone else?
-if ($_SESSION["user"] == "admin" && !empty($_GET["user"])) {
+if ($_SESSION["user"] == $_SESSION["ROOT_USER"] && !empty($_GET["user"])) {
 	$user = quoteshellarg($_GET["user"]);
 }
 
 // Check if domain belongs to the user
 $v_domain = $_GET["domain"];
+$user = isset($user) ? $user : quoteshellarg($_SESSION["user"]);
 exec(
 	HESTIA_CMD . "v-list-web-domain " . $user . " " . quoteshellarg($v_domain) . " json",
 	$output,

--- a/web/bulk/access-key/index.php
+++ b/web/bulk/access-key/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/access-key/");
+	exit();
+}
+
 if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 	$user = quoteshellarg($_GET["user"]);
 	$user_plain = $_GET["user"];

--- a/web/bulk/backup/incremental/index.php
+++ b/web/bulk/backup/incremental/index.php
@@ -4,6 +4,11 @@ use function Hestiacp\quoteshellarg\quoteshellarg;
 ob_start();
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
+if ($read_only === true) {
+	header("Location: /list/backup/incremental/");
+	exit();
+}
+
 if (empty($_POST["backup"])) {
 	header("Location: /list/backup/incremental/");
 	exit();

--- a/web/bulk/backup/index.php
+++ b/web/bulk/backup/index.php
@@ -4,6 +4,11 @@ use function Hestiacp\quoteshellarg\quoteshellarg;
 ob_start();
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
+if ($read_only === true) {
+	header("Location: /list/backup/");
+	exit();
+}
+
 if (empty($_POST["backup"])) {
 	header("Location: /list/backup/");
 	exit();

--- a/web/bulk/cron/index.php
+++ b/web/bulk/cron/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/cron/");
+	exit();
+}
+
 if (empty($_POST["job"])) {
 	header("Location: /list/cron/");
 	exit();

--- a/web/bulk/db/index.php
+++ b/web/bulk/db/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/db/");
+	exit();
+}
+
 if (empty($_POST["database"])) {
 	header("Location: /list/db/");
 	exit();

--- a/web/bulk/dns/index.php
+++ b/web/bulk/dns/index.php
@@ -8,6 +8,16 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/dns/");
+	exit();
+}
+
+if ($read_only === true) {
+	header("Location: /list/access-key/");
+	exit();
+}
+
 if (empty($_POST["domain"])) {
 	header("Location: /list/dns/");
 	exit();

--- a/web/bulk/dns/index.php
+++ b/web/bulk/dns/index.php
@@ -14,7 +14,7 @@ if ($read_only === true) {
 }
 
 if ($read_only === true) {
-	header("Location: /list/access-key/");
+	header("Location: /list/dns/");
 	exit();
 }
 

--- a/web/bulk/dns/index.php
+++ b/web/bulk/dns/index.php
@@ -13,11 +13,6 @@ if ($read_only === true) {
 	exit();
 }
 
-if ($read_only === true) {
-	header("Location: /list/dns/");
-	exit();
-}
-
 if (empty($_POST["domain"])) {
 	header("Location: /list/dns/");
 	exit();

--- a/web/bulk/mail/index.php
+++ b/web/bulk/mail/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/mail/");
+	exit();
+}
+
 if (empty($_POST["domain"])) {
 	header("Location: /list/mail");
 	exit();

--- a/web/bulk/restore/incremental/index.php
+++ b/web/bulk/restore/incremental/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/backup/incremental/");
+	exit();
+}
+
 $action = $_POST["action"];
 $snapshot = quoteshellarg($_POST["snapshot"]);
 
@@ -128,6 +133,4 @@ if ($return_var == 0) {
 } else {
 	$_SESSION["error_msg"] = implode("<br>", $output);
 }
-var_dump($_POST);
-var_dump($output);
 header("Location: /list/backup/incremental/?snapshot=" . $_POST["snapshot"]);

--- a/web/bulk/restore/index.php
+++ b/web/bulk/restore/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/backup/");
+	exit();
+}
+
 if (empty($_POST["backup"])) {
 	header("Location: /list/backup/");
 	exit();

--- a/web/bulk/web/index.php
+++ b/web/bulk/web/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_POST);
 
+if ($read_only === true) {
+	header("Location: /list/web/");
+	exit();
+}
+
 if (empty($_POST["domain"])) {
 	header("Location: /list/web/");
 	exit();

--- a/web/delete/access-key/index.php
+++ b/web/delete/access-key/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/access-key/");
+	exit();
+}
+
 if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 	$user = quoteshellarg($_GET["user"]);
 	$user_plain = $_GET["user"];

--- a/web/delete/backup/index.php
+++ b/web/delete/backup/index.php
@@ -11,6 +11,11 @@ if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/backup/");
+	exit();
+}
+
 if (!empty($_GET["backup"])) {
 	$v_backup = quoteshellarg($_GET["backup"]);
 	exec(HESTIA_CMD . "v-delete-user-backup " . $user . " " . $v_backup, $output, $return_var);

--- a/web/delete/cron/index.php
+++ b/web/delete/cron/index.php
@@ -11,6 +11,11 @@ if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/cron/");
+	exit();
+}
+
 if (!empty($_GET["job"])) {
 	$v_username = quoteshellarg($user);
 	$v_job = quoteshellarg($_GET["job"]);

--- a/web/delete/db/index.php
+++ b/web/delete/db/index.php
@@ -11,6 +11,11 @@ if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/db/");
+	exit();
+}
+
 if (!empty($_GET["database"])) {
 	$v_database = quoteshellarg($_GET["database"]);
 	exec(HESTIA_CMD . "v-delete-database " . $user . " " . $v_database, $output, $return_var);

--- a/web/delete/dns/index.php
+++ b/web/delete/dns/index.php
@@ -12,6 +12,11 @@ if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/dns/");
+	exit();
+}
+
 // DNS domain
 if (!empty($_GET["domain"]) && empty($_GET["record_id"])) {
 	$v_domain = quoteshellarg($_GET["domain"]);

--- a/web/delete/firewall/index.php
+++ b/web/delete/firewall/index.php
@@ -14,6 +14,11 @@ if ($_SESSION["userContext"] != "admin") {
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/firewall/");
+	exit();
+}
+
 if (!empty($_GET["rule"])) {
 	$v_rule = quoteshellarg($_GET["rule"]);
 	exec(HESTIA_CMD . "v-delete-firewall-rule " . $v_rule, $output, $return_var);

--- a/web/delete/firewall/index.php
+++ b/web/delete/firewall/index.php
@@ -14,11 +14,6 @@ if ($_SESSION["userContext"] != "admin") {
 // Check token
 verify_csrf($_GET);
 
-if ($read_only === true) {
-	header("Location: /list/firewall/");
-	exit();
-}
-
 if (!empty($_GET["rule"])) {
 	$v_rule = quoteshellarg($_GET["rule"]);
 	exec(HESTIA_CMD . "v-delete-firewall-rule " . $v_rule, $output, $return_var);

--- a/web/delete/ip/index.php
+++ b/web/delete/ip/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/ip/");
+	exit();
+}
+
 if ($_SESSION["userContext"] === "admin") {
 	if (!empty($_GET["ip"])) {
 		$v_ip = quoteshellarg($_GET["ip"]);

--- a/web/delete/key/index.php
+++ b/web/delete/key/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/key/");
+	exit();
+}
+
 if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 	$user = quoteshellarg($_GET["user"]);
 }

--- a/web/delete/log/index.php
+++ b/web/delete/log/index.php
@@ -6,6 +6,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/log/");
+	exit();
+}
+
 // Check if administrator is viewing system log (currently 'admin' user)
 if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 	$user = quoteshellarg($_GET["user"]);

--- a/web/delete/mail/index.php
+++ b/web/delete/mail/index.php
@@ -12,6 +12,11 @@ if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/mail/");
+	exit();
+}
+
 // Mail domain
 if (!empty($_GET["domain"]) && empty($_GET["account"])) {
 	$v_username = quoteshellarg($user);

--- a/web/delete/notification/index.php
+++ b/web/delete/notification/index.php
@@ -6,6 +6,10 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	exit();
+}
+
 if ($_GET["delete"] == 1) {
 	if (empty($_GET["notification_id"])) {
 		exec(HESTIA_CMD . "v-delete-user-notification " . $user . " all", $output, $return_var);

--- a/web/delete/package/index.php
+++ b/web/delete/package/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/package/");
+	exit();
+}
+
 // Prevent editing of default package
 if ($_GET["package"] === "default") {
 	header("Location: /list/package/");

--- a/web/delete/user/index.php
+++ b/web/delete/user/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/user/");
+	exit();
+}
+
 if ($_SESSION["userContext"] === "admin") {
 	if (!empty($_GET["user"])) {
 		$v_username = quoteshellarg($_GET["user"]);

--- a/web/delete/web/index.php
+++ b/web/delete/web/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/web/");
+	exit();
+}
+
 // Delete as someone else?
 if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
 	$user = quoteshellarg($user);

--- a/web/edit/backup/exclusions/index.php
+++ b/web/edit/backup/exclusions/index.php
@@ -56,7 +56,7 @@ foreach ($data["USER"] as $key => $value) {
 }
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/cron/index.php
+++ b/web/edit/cron/index.php
@@ -44,7 +44,7 @@ if ($v_suspended == "yes") {
 }
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/db/index.php
+++ b/web/edit/db/index.php
@@ -47,7 +47,7 @@ if ($v_suspended == "yes") {
 }
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	$v_username = $user;
 
 	// Check token

--- a/web/edit/dns/index.php
+++ b/web/edit/dns/index.php
@@ -92,7 +92,12 @@ if (!empty($_GET["domain"]) && !empty($_GET["record_id"])) {
 }
 
 // Check POST request for dns domain
-if (!empty($_POST["save"]) && !empty($_GET["domain"]) && empty($_GET["record_id"])) {
+if (
+	!empty($_POST["save"]) &&
+	!empty($_GET["domain"]) &&
+	empty($_GET["record_id"]) &&
+	$read_only !== true
+) {
 	$v_domain = quoteshellarg($_POST["v_domain"]);
 
 	// Check token
@@ -247,7 +252,12 @@ if (!empty($_POST["save"]) && !empty($_GET["domain"]) && empty($_GET["record_id"
 }
 
 // Check POST request for dns record
-if (!empty($_POST["save"]) && !empty($_GET["domain"]) && !empty($_GET["record_id"])) {
+if (
+	!empty($_POST["save"]) &&
+	!empty($_GET["domain"]) &&
+	!empty($_GET["record_id"]) &&
+	$read_only !== true
+) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/firewall/index.php
+++ b/web/edit/firewall/index.php
@@ -61,7 +61,7 @@ foreach ($data as $key => $value) {
 $ipset_lists_json = json_encode($ipset_lists);
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/ip/index.php
+++ b/web/edit/ip/index.php
@@ -47,7 +47,7 @@ $users = json_decode(implode("", $output), true);
 unset($output);
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/mail/index.php
+++ b/web/edit/mail/index.php
@@ -167,7 +167,12 @@ if (!empty($_GET["domain"]) && !empty($_GET["account"])) {
 }
 
 // Check POST request for mail domain
-if (!empty($_POST["save"]) && !empty($_GET["domain"]) && empty($_GET["account"])) {
+if (
+	!empty($_POST["save"]) &&
+	!empty($_GET["domain"]) &&
+	empty($_GET["account"]) &&
+	$read_only !== true
+) {
 	// Check token
 	verify_csrf($_POST);
 
@@ -742,7 +747,12 @@ if (!empty($_POST["save"]) && !empty($_GET["domain"]) && empty($_GET["account"])
 }
 
 // Check POST request for mail account
-if (!empty($_POST["save"]) && !empty($_GET["domain"]) && !empty($_GET["account"])) {
+if (
+	!empty($_POST["save"]) &&
+	!empty($_GET["domain"]) &&
+	!empty($_GET["account"]) &&
+	$read_only !== true
+) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -148,7 +148,7 @@ $php_versions = json_decode(implode("", $output), true);
 unset($output);
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	// Check token
 	verify_csrf($_POST);
 

--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -12,8 +12,13 @@ if (empty($_SESSION["user"])) {
 	exit();
 }
 
-$user = $_SESSION["user"];
-$v_username = $_SESSION["user"];
+if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] !== "") {
+	$user = $_SESSION["look"];
+} else {
+	$user = $_SESSION["user"];
+}
+
+$v_username = $user;
 
 // Prevent other users with admin privileges from editing properties of the ROOT_USER account.
 // Only a session whose real logged-in user IS the ROOT_USER may edit it,

--- a/web/edit/user/index.php
+++ b/web/edit/user/index.php
@@ -7,20 +7,13 @@ $TAB = "USER";
 // Main include
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
-// Check user argument
-if (empty($_GET["user"])) {
-	header("Location: /list/user/");
+if (empty($_SESSION["user"])) {
+	header("Location: /login/");
 	exit();
 }
 
-// Edit as someone else?
-if ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) {
-	$user = $_GET["user"];
-	$v_username = $_GET["user"];
-} else {
-	$user = $_SESSION["user"];
-	$v_username = $_SESSION["user"];
-}
+$user = $_SESSION["user"];
+$v_username = $_SESSION["user"];
 
 // Prevent other users with admin privileges from editing properties of the ROOT_USER account.
 // Only a session whose real logged-in user IS the ROOT_USER may edit it,

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -185,7 +185,7 @@ $stats = json_decode(implode("", $output), true);
 unset($output);
 
 // Check POST request
-if (!empty($_POST["save"])) {
+if (!empty($_POST["save"]) && $read_only !== true) {
 	$v_domain = $_POST["v_domain"];
 	if (!in_array($v_domain, $user_domains)) {
 		check_return_code(3, ["Unknown domain"]);

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -142,6 +142,9 @@ if (!isset($_SESSION["look"])) {
 }
 
 require_once dirname(__FILE__) . "/i18n.php";
+if (isset($_SESSION["userContext"])) {
+	require_once dirname(__FILE__) . "/policies.php";
+}
 
 function check_error($return_var) {
 	if ($return_var > 0) {
@@ -188,9 +191,6 @@ function render_page($user, $TAB, $page) {
 
 	// Panel
 	$panel = top_panel(empty($_SESSION["look"]) ? $_SESSION["user"] : $_SESSION["look"], $TAB);
-
-	// Policies controller
-	@include_once dirname(__DIR__) . "/inc/policies.php";
 
 	// Body
 	include $__template_dir . "pages/" . $page . ".php";

--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -142,6 +142,9 @@ if (!isset($_SESSION["look"])) {
 }
 
 require_once dirname(__FILE__) . "/i18n.php";
+
+$read_only = false;
+//accessing main.php via CLI doesn't set $_SESSION["userContext"], so we need to check if it's set before including policies.php
 if (isset($_SESSION["userContext"])) {
 	require_once dirname(__FILE__) . "/policies.php";
 }

--- a/web/inc/policies.php
+++ b/web/inc/policies.php
@@ -8,12 +8,12 @@ if (
 		$_SESSION["look"] === "admin" &&
 		$_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes")
 ) {
-	$read_only = "true";
+	$read_only = true;
 } else {
-	$read_only = "";
+	$read_only = false;
 }
 
-if ($read_only === "true") {
+if ($read_only === true) {
 	$display_mode = "disabled";
 } else {
 	$display_mode = "";

--- a/web/inc/policies.php
+++ b/web/inc/policies.php
@@ -5,7 +5,7 @@ if (
 		$panel[$user]["SUSPENDED"] === "yes" &&
 		$_SESSION["POLICY_USER_VIEW_SUSPENDED"] === "yes") ||
 	($_SESSION["userContext"] === "admin" &&
-		$_SESSION["look"] === "admin" &&
+		$_SESSION["look"] === $_SESSION["ROOT_USER"] &&
 		$_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes")
 ) {
 	$read_only = true;

--- a/web/list/access-key/index.php
+++ b/web/list/access-key/index.php
@@ -38,14 +38,14 @@ if (!empty($_GET["key"])) {
 	exec(HESTIA_CMD . "v-list-apis json", $output, $return_var);
 	$apis = json_decode(implode("", $output), true);
 	$apis = array_filter($apis, function ($api) use ($user_plain) {
-		return $user_plain == "admin" || $api["ROLE"] == "user";
+		return $user_plain == $_SESSION["ROOT_USER"] || $api["ROLE"] == "user";
 	});
 	ksort($apis);
 	unset($output);
 
 	render_page($user, $TAB, "list_access_key");
 } else {
-	exec(HESTIA_CMD . "v-list-access-keys $user json", $output, $return_var);
+	exec(HESTIA_CMD . "v-list-access-keys " . $user . " json", $output, $return_var);
 	$data = json_decode(implode("", $output), true);
 
 	uasort($data, function ($a, $b) {

--- a/web/list/log/auth/index.php
+++ b/web/list/log/auth/index.php
@@ -7,6 +7,15 @@ $TAB = "LOG";
 // Main include
 include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 
+if (
+	$_SESSION["userContext"] === "admin" &&
+	$_SESSION["look"] === $_SESSION["ROOT_USER"] &&
+	$_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes"
+) {
+	header("Location: /");
+	exit();
+}
+
 // Edit as someone else?
 if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] != "") {
 	$user = quoteshellarg($_SESSION["look"]);

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -49,9 +49,12 @@ if (isset($_SESSION["user"])) {
 				unset($_SESSION["_sf2_meta"]);
 				if (!empty($_GET["edit_link"])) {
 					$edit_link = urldecode($_GET["edit_link"]);
-					$url = $edit_link . "?token=" . $_SESSION["token"];
-					header("Location: " . $url);
-					die();
+					// Prevent open redirect by allowing only internal links
+					if (preg_match("/^\//", $edit_link)) {
+						$url = $edit_link . "?token=" . $_SESSION["token"];
+						header("Location: " . $url);
+						die();
+					}
 				}
 				header("Location: /login/");
 			} else {

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -49,7 +49,7 @@ if (isset($_SESSION["user"])) {
 				unset($_SESSION["_sf2_meta"]);
 				if (!empty($_GET["edit_link"])) {
 					$edit_link = urldecode($_GET["edit_link"]);
-					$url = $edit_link . "&token=" . $_SESSION["token"];
+					$url = $edit_link . "?token=" . $_SESSION["token"];
 					header("Location: " . $url);
 					die();
 				}

--- a/web/schedule/backup/incremental/index.php
+++ b/web/schedule/backup/incremental/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/backup/incremental/");
+	exit();
+}
+
 if (empty($_GET["object"])) {
 	$_GET["object"] = "";
 }

--- a/web/schedule/backup/index.php
+++ b/web/schedule/backup/index.php
@@ -6,6 +6,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/backup/");
+	exit();
+}
+
 exec(HESTIA_CMD . "v-schedule-user-backup " . $user, $output, $return_var);
 if ($return_var == 0) {
 	$_SESSION["error_msg"] = _(

--- a/web/schedule/restore/incremental/index.php
+++ b/web/schedule/restore/incremental/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/backup/incremental/");
+	exit();
+}
+
 $snapshot = quoteshellarg($_GET["snapshot"]);
 
 if (empty($_GET["object"])) {

--- a/web/schedule/restore/index.php
+++ b/web/schedule/restore/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/backup/");
+	exit();
+}
+
 $backup = quoteshellarg($_GET["backup"]);
 
 $web = "no";

--- a/web/suspend/cron/index.php
+++ b/web/suspend/cron/index.php
@@ -6,6 +6,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/cron/");
+	exit();
+}
+
 if (!empty($_GET["job"])) {
 	$v_job = quoteshellarg($_GET["job"]);
 	exec(HESTIA_CMD . "v-suspend-cron-job " . $user . " " . $v_job, $output, $return_var);

--- a/web/suspend/db/index.php
+++ b/web/suspend/db/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/db/");
+	exit();
+}
+
 if (!empty($_GET["database"])) {
 	$v_database = quoteshellarg($_GET["database"]);
 	exec(HESTIA_CMD . "v-suspend-database " . $user . " " . $v_database, $output, $return_var);

--- a/web/suspend/dns/index.php
+++ b/web/suspend/dns/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/dns/");
+	exit();
+}
+
 // DNS domain
 if (!empty($_GET["domain"]) && empty($_GET["record_id"])) {
 	$v_domain = quoteshellarg($_GET["domain"]);

--- a/web/suspend/mail/index.php
+++ b/web/suspend/mail/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/mail/");
+	exit();
+}
+
 // Mail domain
 if (!empty($_GET["domain"]) && empty($_GET["account"])) {
 	$v_domain = quoteshellarg($_GET["domain"]);

--- a/web/suspend/user/index.php
+++ b/web/suspend/user/index.php
@@ -14,6 +14,11 @@ if ($_SESSION["userContext"] != "admin") {
 	exit();
 }
 
+if ($read_only === true) {
+	header("Location: /list/user/");
+	exit();
+}
+
 if (!empty($_GET["user"])) {
 	$v_username = quoteshellarg($_GET["user"]);
 	exec(HESTIA_CMD . "v-suspend-user " . $v_username, $output, $return_var);

--- a/web/suspend/web/index.php
+++ b/web/suspend/web/index.php
@@ -7,6 +7,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/web/");
+	exit();
+}
+
 if (!empty($_GET["domain"])) {
 	$v_username = quoteshellarg($user);
 	$v_domain = quoteshellarg($_GET["domain"]);

--- a/web/templates/includes/panel.php
+++ b/web/templates/includes/panel.php
@@ -63,7 +63,7 @@
 
 				<!-- Notifications -->
 				<?php
-    $impersonatingAdmin = $_SESSION["userContext"] === "admin" && ($_SESSION["look"] !== "" && $user == "admin");
+    $impersonatingAdmin = $_SESSION["userContext"] === "admin" && ($_SESSION["look"] !== "" && $user == $_SESSION["ROOT_USER"]) && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes";
     // Do not show notifications panel when impersonating 'admin' user
     if (!$impersonatingAdmin) { ?>
 					<div x-data="notifications" class="top-bar-notifications">

--- a/web/templates/includes/panel.php
+++ b/web/templates/includes/panel.php
@@ -170,7 +170,7 @@
 
 							<!-- File Manager -->
 							<?php if (isset($_SESSION["FILE_MANAGER"]) && !empty($_SESSION["FILE_MANAGER"]) && $_SESSION["FILE_MANAGER"] == "true") { ?>
-								<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] == "yes") { ?>
+								<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION["ROOT_USER"] && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] == "yes") { ?>
 									<!-- Hide file manager when impersonating admin-->
 								<?php } else { ?>
 									<li class="top-bar-menu-item">
@@ -186,7 +186,7 @@
 
 							<!-- Web Terminal -->
 							<?php if (isset($_SESSION["WEB_TERMINAL"]) && !empty($_SESSION["WEB_TERMINAL"]) && $_SESSION["WEB_TERMINAL"] == "true") { ?>
-								<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] == "yes") { ?>
+								<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION["ROOT_USER"] && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] == "yes") { ?>
 									<!-- Hide web terminal when impersonating admin -->
 								<?php } elseif ($_SESSION["login_shell"] != "nologin") { ?>
 									<li class="top-bar-menu-item">
@@ -217,7 +217,7 @@
 							<?php } ?>
 
 							<!-- Edit User -->
-							<?php if ($_SESSION["userContext"] === "admin" && ($_SESSION["look"] !== "" && $user == "admin")) { ?>
+							<?php if ($_SESSION["userContext"] === "admin" && ($_SESSION["look"] !== "" && $user == $_SESSION["ROOT_USER"]) && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes") { ?>
 								<!-- Hide 'edit user' entry point from other administrators for default 'admin' account-->
 								<li class="top-bar-menu-item">
 									<a title="<?= _("Logs") ?>" class="top-bar-menu-link <?php if ($TAB == "LOG") {
@@ -297,7 +297,7 @@
 
 				<!-- Users tab -->
 				<?php if ($_SESSION["userContext"] == "admin" && $_SESSION["look"] === "") { ?>
-					<?php if ($_SESSION["user"] !== "admin" && $_SESSION["POLICY_SYSTEM_HIDE_ADMIN"] === "yes") {
+					<?php if ($_SESSION["user"] !== $_SESSION["ROOT_USER"] && $_SESSION["POLICY_SYSTEM_HIDE_ADMIN"] === "yes") {
      	$user_count = $panel[$user]["U_USERS"] - 1;
      } else {
      	$user_count = $panel[$user]["U_USERS"];

--- a/web/templates/pages/add_key.php
+++ b/web/templates/pages/add_key.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && $_GET["user"] !== "admin") { ?>
+			<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && $_GET["user"] !== $_SESSION['ROOT_USER']) { ?>
 				<a class="button button-secondary button-back js-button-back" href="/list/key/?<?= tohtml(http_build_query(["user" => $_GET["user"]])) ?>">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>

--- a/web/templates/pages/add_mail.php
+++ b/web/templates/pages/add_mail.php
@@ -7,7 +7,7 @@
 			</a>
 		</div>
 		<div class="toolbar-buttons">
-			<?php if (($_SESSION["role"] == "admin" && $accept === "true") || $user_plain !== "admin") { ?>
+			<?php if (($_SESSION["role"] == "admin" && $accept === "true") || $_SESSION["role"] !== "admin") { ?>
 				<button type="submit" class="button" form="main-form">
 					<i class="fas fa-floppy-disk icon-purple"></i><?= tohtml( _("Save")) ?>
 				</button>

--- a/web/templates/pages/edit_user.php
+++ b/web/templates/pages/edit_user.php
@@ -148,7 +148,7 @@
 					?>
 				</select>
 			</div>
-			<?php if ($v_username != "admin" && $_SESSION["userContext"] === "admin" && $_SESSION["user"] != $v_username): ?>
+			<?php if ($v_username != $_SESSION["ROOT_USER"] && $_SESSION["userContext"] === "admin" && $_SESSION["user"] != $v_username): ?>
 				<div class="u-mb10">
 					<label for="v_role" class="form-label"><?= tohtml( _("Role")) ?></label>
 					<select class="form-select" name="v_role" id="v_role" required>

--- a/web/templates/pages/list_access_keys.php
+++ b/web/templates/pages/list_access_keys.php
@@ -73,7 +73,7 @@
 		<?php
 			foreach ($data as $key => $value) {
 				++$i;
-				$key_user = !empty($value['USER']) ? $value['USER'] : 'admin';
+				$key_user = !empty($value['USER']) ? $value['USER'] : $_SESSION["ROOT_USER"];
 				$key_comment = !empty($value['COMMENT']) ? $value['COMMENT'] : '-';
 				//$key_permissions = !empty($value['PERMISSIONS']) ? $value['PERMISSIONS'] : '-';
 				//$key_permissions = implode(' ', $key_permissions);

--- a/web/templates/pages/list_access_keys.php
+++ b/web/templates/pages/list_access_keys.php
@@ -2,11 +2,11 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '' && $_GET["user"] !== "admin") { ?>
+			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '' && $_GET["user"] !== $_SESSION["ROOT_USER"]) { ?>
 				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
-			<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) { ?>
+			<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"]) && $_GET["user"] !== $_SESSION["ROOT_USER"]) { ?>
 				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>

--- a/web/templates/pages/list_access_keys.php
+++ b/web/templates/pages/list_access_keys.php
@@ -2,19 +2,9 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '' && $_GET["user"] !== $_SESSION["ROOT_USER"]) { ?>
-				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"]) && $_GET["user"] !== $_SESSION["ROOT_USER"]) { ?>
-				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } else { ?>
-				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } ?>
+			<a href="/edit/user/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
+				<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
+			</a>
 			<a href="/add/access-key/" class="button button-secondary js-button-create">
 				<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Access Key")) ?>
 			</a>

--- a/web/templates/pages/list_backup.php
+++ b/web/templates/pages/list_backup.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/schedule/backup/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" class="button button-secondary"><i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Create Backup")) ?></a>
 				<a href="/list/backup/exclusions/" class="button button-secondary"><i class="fas fa-folder-minus icon-orange"></i><?= tohtml( _("Backup Exclusions")) ?></a>
 			<?php } ?>
@@ -11,7 +11,7 @@
 			<?php } ?>
 		</div>
 		<div class="toolbar-right">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<form x-data x-bind="BulkEdit" action="/bulk/backup/" method="post">
 					<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 					<select class="form-select" name="action">
@@ -81,7 +81,7 @@
 				</div>
 				<div class="units-table-cell units-table-heading-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("File Name")) ?>:</span>
-					<?php if ($read_only === "true") { ?>
+					<?php if ($read_only === true) { ?>
 						<?= tohtml($key) ?>
 					<?php } else { ?>
 						<a href="/list/backup/?<?= tohtml(http_build_query(["backup" => $key, "token" => $_SESSION["token"]])) ?>" title="<?= tohtml( _("Restore")) ?>">
@@ -90,7 +90,7 @@
 					<?php } ?>
 				</div>
 				<div class="units-table-cell">
-					<?php if (!($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $read_only === "true")) { ?>
+					<?php if (!($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $read_only === true)) { ?>
 						<ul class="units-table-row-actions">
 							<li class="units-table-row-action shortcut-d" data-key-action="href">
 								<a
@@ -102,7 +102,7 @@
 									<span class="u-hide-desktop"><?= tohtml( _("Download")) ?></span>
 								</a>
 							</li>
-							<?php if ($read_only !== "true") { ?>
+							<?php if ($read_only !== true) { ?>
 								<li class="units-table-row-action shortcut-enter" data-key-action="href">
 									<a
 										class="units-table-row-action-link data-controls"

--- a/web/templates/pages/list_backup.php
+++ b/web/templates/pages/list_backup.php
@@ -90,7 +90,7 @@
 					<?php } ?>
 				</div>
 				<div class="units-table-cell">
-					<?php if (!($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $read_only === true)) { ?>
+					<?php if (!($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION['ROOT_USER'] && $read_only === true)) { ?>
 						<ul class="units-table-row-actions">
 							<li class="units-table-row-action shortcut-d" data-key-action="href">
 								<a

--- a/web/templates/pages/list_backup_detail.php
+++ b/web/templates/pages/list_backup_detail.php
@@ -5,14 +5,14 @@
 				<a class="button button-secondary button-back js-button-back" href="/list/backup/">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<a href="/schedule/restore/?<?= tohtml(http_build_query(array("token" => $_SESSION["token"], "backup" => $_GET["backup"]))) ?>" class="button button-secondary">
 						<i class="fas fa-arrow-rotate-left icon-green"></i><?= tohtml( _("Restore All")) ?>
 					</a>
 				<?php } ?>
 			</div>
 			<div class="toolbar-right">
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/restore/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<input type="hidden" name="backup" value="<?= tohtml($_GET["backup"]) ?>">

--- a/web/templates/pages/list_backup_detail_incremental.php
+++ b/web/templates/pages/list_backup_detail_incremental.php
@@ -3,12 +3,12 @@
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
 			<a class="button button-secondary button-back js-button-back" href="/list/backup/incremental/"><i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?></a>
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 			<a href="/schedule/restore/incremental/?<?= tohtml(http_build_query(array("token" => $_SESSION["token"], "snapshot" => $_GET["snapshot"]))) ?>" class="button button-secondary"><i class="fas fa-arrow-rotate-left icon-green"></i><?= tohtml( _("Restore All")) ?></a>
 			<?php } ?>
 		</div>
 		<div class="toolbar-right">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<form x-data x-bind="BulkEdit" action="/bulk/restore/incremental/" method="post">
 					<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 					<input type="hidden" name="snapshot" value="<?= tohtml($_GET["snapshot"]) ?>">

--- a/web/templates/pages/list_backup_incremental.php
+++ b/web/templates/pages/list_backup_incremental.php
@@ -2,14 +2,14 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-		<?php if ($read_only !== "true") { ?>
+		<?php if ($read_only !== true) { ?>
 			<a href="/schedule/backup/incremental/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" class="button button-secondary js-button-create">
 				<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Create Snapshot")) ?>
 			</a>
 		<?php } ?>
 		</div>
 		<div class="toolbar-right">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<form x-data x-bind="BulkEdit" action="/bulk/backup/incremental/" method="post">
 					<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 					<select class="form-select" name="action">
@@ -64,7 +64,7 @@
 			</div>
 			<div class="units-table-cell units-table-heading-cell u-text-bold">
 				<b>
-					<?php if ($read_only === "true") { ?>
+					<?php if ($read_only === true) { ?>
 							<span class="u-hide-desktop"><?= tohtml( _("Snapshot")) ?>:</span>
 							<?= tohtml($value['short_id']) ?>
 					<?php } else { ?>

--- a/web/templates/pages/list_cron.php
+++ b/web/templates/pages/list_cron.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/cron/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Cron Job")) ?>
 				</a>
@@ -34,7 +34,7 @@
 						<span class="name <?php if ($_SESSION['userSortOrder'] === 'date') { echo 'active'; } ?>"><?= tohtml( _("Date")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/cron/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<select class="form-select" name="action">
@@ -114,7 +114,7 @@
 				</div>
 				<div class="units-table-cell units-table-heading-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Command")) ?>:</span>
-					<?php if ($read_only === "true" || $data[$key]["SUSPENDED"] == "yes") { ?>
+					<?php if ($read_only === true || $data[$key]["SUSPENDED"] == "yes") { ?>
 						<?= tohtml($data[$key]["CMD"]) ?>
 					<?php } else { ?>
 						<a href="/edit/cron/?<?= tohtml(http_build_query(["job" => $data[$key]["JOB"], "token" => $_SESSION["token"]])) ?>" title="<?= tohtml( _("Edit Cron Job")) ?>: <?= tohtml($data[$key]["CMD"]) ?>">

--- a/web/templates/pages/list_db.php
+++ b/web/templates/pages/list_db.php
@@ -15,7 +15,7 @@ if (!empty($_SESSION["DB_PGA_ALIAS"])) {
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/db/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Database")) ?>
 				</a>
@@ -65,7 +65,7 @@ if (!empty($_SESSION["DB_PGA_ALIAS"])) {
 						<span class="name"><?= tohtml( _("Username")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/db/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<select class="form-select" name="action">
@@ -158,7 +158,7 @@ if (!empty($_SESSION["DB_PGA_ALIAS"])) {
 				</div>
 				<div class="units-table-cell units-table-heading-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Name")) ?>:</span>
-					<?php if ($read_only === "true" || $data[$key]["SUSPENDED"] == "yes") { ?>
+					<?php if ($read_only === true || $data[$key]["SUSPENDED"] == "yes") { ?>
 						<?= tohtml($key) ?>
 					<?php } else { ?>
 						<a href="/edit/db/?<?= tohtml(http_build_query(["database" => $key, "token" => $_SESSION["token"]])) ?>" title="<?= tohtml( _("Edit Database")) ?>: <?= tohtml($key) ?>">

--- a/web/templates/pages/list_dns.php
+++ b/web/templates/pages/list_dns.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/dns/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add DNS Domain")) ?>
 				</a>
@@ -34,7 +34,7 @@
 						<span class="name"><?= tohtml( _("Records")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/dns/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<select class="form-select" name="action">

--- a/web/templates/pages/list_dns_public.php
+++ b/web/templates/pages/list_dns_public.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/dns/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add DNS Domain")) ?>
 				</a>

--- a/web/templates/pages/list_dns_rec.php
+++ b/web/templates/pages/list_dns_rec.php
@@ -5,7 +5,7 @@
 				<a class="button button-secondary button-back js-button-back" href="/list/dns/">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<a href="/add/dns/?<?= tohtml(http_build_query(array("domain" => $_GET["domain"]))) ?>" class="button button-secondary js-button-create">
 						<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Record")) ?>
 					</a>
@@ -40,7 +40,7 @@
 						<span class="name"><?= tohtml( _("Type")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/dns/" method="post">
 						<input type="hidden" name="domain" value="<?= tohtml($_GET["domain"]) ?>">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
@@ -120,9 +120,9 @@
 							<?php } ?>
 						</div>
 					<div class="units-table-cell">
-						<?php if ($read_only !== "true") { ?>
+						<?php if ($read_only !== true) { ?>
 						<ul class="units-table-row-actions">
-							<?php if ($read_only !== "true") { ?>
+							<?php if ($read_only !== true) { ?>
 									<?php if ($data[$key]["SUSPENDED"] == "no") { ?>
 										<li class="units-table-row-action shortcut-enter" data-key-action="href">
 											<a

--- a/web/templates/pages/list_dns_rec.php
+++ b/web/templates/pages/list_dns_rec.php
@@ -111,7 +111,7 @@
 					</div>
 					<div class="units-table-cell units-table-heading-cell u-text-bold">
 						<span class="u-hide-desktop"><?= tohtml( _("Record")) ?>:</span>
-							<?php if (($read_only === 'true') || ($data[$key]['SUSPENDED'] == 'yes')) { ?>
+							<?php if (($read_only === true) || ($data[$key]['SUSPENDED'] == 'yes')) { ?>
 								<?= tohtml(substr($data[$key]['RECORD'], 0, 12)) ?><?php if (strlen($data[$key]['RECORD']) > 12 ) echo '...'; ?>
 							<?php } else { ?>
 								<a href="/edit/dns/?<?= tohtml(http_build_query(array("domain" => $_GET['domain'], "record_id" => $data[$key]['ID'], "token" => $_SESSION['token']))) ?>" title="<?= tohtml(_("Edit DNS Record") . ': '.$data[$key]['RECORD']) ?>">

--- a/web/templates/pages/list_files_incremental.php
+++ b/web/templates/pages/list_files_incremental.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 			<?php if(str_starts_with($files[0]['path'],'/home/'.$user_plain) && $files[0]['path'] != '/home/'.$user_plain ){
 			?>
 			<a class="button button-secondary" id="btn-back" href="/list/backup/incremental/?<?= tohtml(http_build_query(["snapshot" => $_GET["snapshot"], "browse" => "yes", "folder" => $files[0]["path"] . "/../", "token" => $_SESSION["token"]])) ?>"><i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?></a>
@@ -15,7 +15,7 @@
 			<?php } ?>
 		</div>
 		<div class="toolbar-right">
-					<?php if ($read_only !== "true") { ?>
+					<?php if ($read_only !== true) { ?>
 						<form x-data x-bind="BulkEdit" action="/bulk/restore/" method="post">
 							<input type="hidden" name="backup" value="<?= tohtml($_GET["snapshot"]) ?>">
 							<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">

--- a/web/templates/pages/list_key.php
+++ b/web/templates/pages/list_key.php
@@ -59,7 +59,7 @@
 						<li class="units-table-row-action shortcut-delete" data-key-action="js">
 							<a
 								class="units-table-row-action-link data-controls js-confirm-action"
-								<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && $_GET["user"] !== "admin") { ?>
+								<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && $_GET["user"] !== $_SESSION['ROOT_USER']) { ?>
 									href="/delete/key/?<?= tohtml(http_build_query(["user" => $_GET["user"], "key" => $key, "token" => $_SESSION["token"]])) ?>"
 								<?php } else { ?>
 									href="/delete/key/?<?= tohtml(http_build_query(["key" => $key, "token" => $_SESSION["token"]])) ?>"

--- a/web/templates/pages/list_key.php
+++ b/web/templates/pages/list_key.php
@@ -5,7 +5,7 @@
 			<a href="/edit/user/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 			</a>
-			<?php if($readonly) { ?>
+			<?php if($read_only !== true) { ?>
 				<a href="/add/key/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add SSH Key")) ?>
 				</a>

--- a/web/templates/pages/list_key.php
+++ b/web/templates/pages/list_key.php
@@ -2,25 +2,10 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '' && $_GET["user"] !== $_SESSION['ROOT_USER']) { ?>
-				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
+			<a href="/edit/user/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) { ?>
-				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } else { ?>
-				<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } ?>
-
-			<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && $_GET["user"] !== "admin") { ?>
-				<a href="/add/key/?<?= tohtml(http_build_query(["user" => $_GET["user"]])) ?>" class="button button-secondary js-button-create">
-					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add SSH Key")) ?>
-				</a>
-			<?php } else { ?>
+			</a>
+			<?php if($readonly) { ?>
 				<a href="/add/key/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add SSH Key")) ?>
 				</a>

--- a/web/templates/pages/list_key.php
+++ b/web/templates/pages/list_key.php
@@ -44,11 +44,7 @@
 						<li class="units-table-row-action shortcut-delete" data-key-action="js">
 							<a
 								class="units-table-row-action-link data-controls js-confirm-action"
-								<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && $_GET["user"] !== $_SESSION['ROOT_USER']) { ?>
-									href="/delete/key/?<?= tohtml(http_build_query(["user" => $_GET["user"], "key" => $key, "token" => $_SESSION["token"]])) ?>"
-								<?php } else { ?>
-									href="/delete/key/?<?= tohtml(http_build_query(["key" => $key, "token" => $_SESSION["token"]])) ?>"
-								<?php } ?>
+								href="/delete/key/?<?= tohtml(http_build_query(["key" => $key, "token" => $_SESSION["token"]])) ?>"
 								title="<?= tohtml( _("Delete")) ?>"
 								data-confirm-title="<?= tohtml( _("Delete")) ?>"
 								data-confirm-message="<?= tohtml(sprintf(_("Are you sure you want to delete SSH key %s?"), tohtml($key))) ?>"

--- a/web/templates/pages/list_log.php
+++ b/web/templates/pages/list_log.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION["ROOT_USER"]) { ?>
+			<?php if ($_SESSION["userContext"] === "admin") { ?>
 				<a href="/list/user/" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
@@ -11,33 +11,15 @@
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
 			<?php } else { ?>
-				<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '') { ?>
-					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
+					<a href="/edit/user/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 					</a>
-				<?php } elseif ($_SESSION["userContext"] === "admin" && !empty($_GET["user"])) { ?>
-					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-					</a>
-				<?php } else { ?>
-					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-					</a>
-				<?php } ?>
 			<?php } ?>
 			<?php if ($_SESSION['DEMO_MODE'] != "yes"){
 			if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) !== $_SESSION['ROOT_USER'])) { ?>
-					<?php if (($_SESSION['userContext'] === 'admin') && ($_GET['user'] != '') && (htmlentities($_GET['user']) !== $_SESSION['ROOT_USER'])) { ?>
-						<?php if (htmlentities($_GET['user']) !== 'system') { ?>
-							<a href="/list/log/auth/?<?= tohtml(http_build_query(["user" => $_GET['user'], "token" => $_SESSION['token']])) ?>" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
-								<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
-							</a>
-						<?php } ?>
-					<?php } else { ?>
-					<a href="/list/log/auth/" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
-						<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
-					</a>
-				<?php } ?>
+				<a href="/list/log/auth/" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
+					<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
+				</a>
 			<?php } ?>
 			<?php if ($_SESSION["userContext"] === "user") { ?>
 				<a href="/list/log/auth/" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">

--- a/web/templates/pages/list_log.php
+++ b/web/templates/pages/list_log.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin") { ?>
+			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION["ROOT_USER"]) { ?>
 				<a href="/list/user/" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
@@ -11,7 +11,7 @@
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
 			<?php } else { ?>
-				<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '' && $_GET["user"] !== "admin") { ?>
+				<?php if ($_SESSION["userContext"] === "admin" && $_SESSION['look'] !== '') { ?>
 					<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $_SESSION["look"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 					</a>
@@ -48,7 +48,7 @@
 		</div>
 		<div class="toolbar-buttons">
 			<a href="javascript:location.reload();" class="button button-secondary"><i class="fas fa-arrow-rotate-right icon-green"></i><?= tohtml( _("Refresh")) ?></a>
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes") { ?>
+			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION["ROOT_USER"] && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes") { ?>
 				<!-- Hide delete buttons-->
 			<?php } else { ?>
 				<?php if ($_SESSION["userContext"] === "admin" || ($_SESSION["userContext"] === "user" && $_SESSION["POLICY_USER_DELETE_LOGS"] !== "no")) { ?>

--- a/web/templates/pages/list_log.php
+++ b/web/templates/pages/list_log.php
@@ -26,14 +26,14 @@
 				<?php } ?>
 			<?php } ?>
 			<?php if ($_SESSION['DEMO_MODE'] != "yes"){
-			if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) !== 'admin')) { ?>
-				<?php if (($_SESSION['userContext'] === 'admin') && ($_GET['user'] != '') && (htmlentities($_GET['user']) !== 'admin')) { ?>
-					<?php if (htmlentities($_GET['user']) !== 'system') { ?>
-						<a href="/list/log/auth/?<?= tohtml(http_build_query(["user" => $_GET['user'], "token" => $_SESSION['token']])) ?>" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
-							<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
-						</a>
-					<?php } ?>
-				<?php } else { ?>
+			if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) !== $_SESSION['ROOT_USER'])) { ?>
+					<?php if (($_SESSION['userContext'] === 'admin') && ($_GET['user'] != '') && (htmlentities($_GET['user']) !== $_SESSION['ROOT_USER'])) { ?>
+						<?php if (htmlentities($_GET['user']) !== 'system') { ?>
+							<a href="/list/log/auth/?<?= tohtml(http_build_query(["user" => $_GET['user'], "token" => $_SESSION['token']])) ?>" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
+								<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
+							</a>
+						<?php } ?>
+					<?php } else { ?>
 					<a href="/list/log/auth/" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
 						<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
 					</a>

--- a/web/templates/pages/list_log.php
+++ b/web/templates/pages/list_log.php
@@ -15,18 +15,11 @@
 						<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 					</a>
 			<?php } ?>
-			<?php if ($_SESSION['DEMO_MODE'] != "yes"){
-			if (($_SESSION['userContext'] === 'admin') && (htmlentities($_GET['user']) !== $_SESSION['ROOT_USER'])) { ?>
+			<?php if ($_SESSION['DEMO_MODE'] != "yes") { ?>
 				<a href="/list/log/auth/" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
 					<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
 				</a>
 			<?php } ?>
-			<?php if ($_SESSION["userContext"] === "user") { ?>
-				<a href="/list/log/auth/" class="button button-secondary button-back js-button-back" title="<?= tohtml( _("Login History")) ?>">
-					<i class="fas fa-binoculars icon-green"></i><?= tohtml( _("Login History")) ?>
-				</a>
-			<?php }
-			} ?>
 		</div>
 		<div class="toolbar-buttons">
 			<a href="javascript:location.reload();" class="button button-secondary"><i class="fas fa-arrow-rotate-right icon-green"></i><?= tohtml( _("Refresh")) ?></a>
@@ -36,11 +29,7 @@
 				<?php if ($_SESSION["userContext"] === "admin" || ($_SESSION["userContext"] === "user" && $_SESSION["POLICY_USER_DELETE_LOGS"] !== "no")) { ?>
 					<a
 						class="button button-secondary button-danger data-controls js-confirm-action"
-						<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"])) { ?>
-							href="/delete/log/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>"
-						<?php } else { ?>
-							href="/delete/log/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>"
-						<?php } ?>
+						href="/delete/log/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>"
 						data-confirm-title="<?= tohtml( _("Delete")) ?>"
 						data-confirm-message="<?= tohtml( _("Are you sure you want to delete the logs?")) ?>"
 					>

--- a/web/templates/pages/list_log_auth.php
+++ b/web/templates/pages/list_log_auth.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"]) && htmlentities($_GET["user"]) !== "admin") { ?>
+			<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"])) { ?>
 				<a href="/list/log/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
 					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 				</a>
@@ -14,7 +14,7 @@
 		</div>
 		<div class="toolbar-buttons">
 			<a href="javascript:location.reload();" class="button button-secondary"><i class="fas fa-arrow-rotate-right icon-green"></i><?= tohtml( _("Refresh")) ?></a>
-			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === "admin" && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes") { ?>
+			<?php if ($_SESSION["userContext"] === "admin" && $_SESSION["look"] === $_SESSION["ROOT_USER"] && $_SESSION["POLICY_SYSTEM_PROTECTED_ADMIN"] === "yes") { ?>
 				<!-- Hide delete buttons-->
 			<?php } else { ?>
 				<?php if ($_SESSION["userContext"] === "admin" || ($_SESSION["userContext"] === "user" && $_SESSION["POLICY_USER_DELETE_LOGS"] !== "no")) { ?>

--- a/web/templates/pages/list_log_auth.php
+++ b/web/templates/pages/list_log_auth.php
@@ -2,15 +2,9 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"])) { ?>
-				<a href="/list/log/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } else { ?>
-				<a href="/list/log/" class="button button-secondary button-back js-button-back">
-					<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
-				</a>
-			<?php } ?>
+			<a href="/list/log/" class="button button-secondary button-back js-button-back">
+				<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
+			</a>
 		</div>
 		<div class="toolbar-buttons">
 			<a href="javascript:location.reload();" class="button button-secondary"><i class="fas fa-arrow-rotate-right icon-green"></i><?= tohtml( _("Refresh")) ?></a>
@@ -20,11 +14,7 @@
 				<?php if ($_SESSION["userContext"] === "admin" || ($_SESSION["userContext"] === "user" && $_SESSION["POLICY_USER_DELETE_LOGS"] !== "no")) { ?>
 					<a
 						class="button button-secondary button-danger data-controls js-confirm-action"
-						<?php if ($_SESSION["userContext"] === "admin" && isset($_GET["user"])) { ?>
-							href="/delete/log/auth/?<?= tohtml(http_build_query(["user" => $_GET["user"], "token" => $_SESSION["token"]])) ?>"
-						<?php } else { ?>
-							href="/delete/log/auth/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>"
-						<?php } ?>
+						href="/delete/log/auth/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>"
 						data-confirm-title="<?= tohtml( _("Delete")) ?>"
 						data-confirm-message="<?= tohtml( _("Are you sure you want to delete the logs?")) ?>"
 					>

--- a/web/templates/pages/list_mail.php
+++ b/web/templates/pages/list_mail.php
@@ -11,7 +11,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/mail/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Mail Domain")) ?>
 				</a>
@@ -40,7 +40,7 @@
 						<span class="name <?php if ($_SESSION['userSortOrder'] === 'name') { echo 'active'; } ?>"><?= tohtml( _("Name")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/mail/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<select class="form-select" name="action">
@@ -192,7 +192,7 @@
 				</div>
 				<div class="units-table-cell">
 					<ul class="units-table-row-actions">
-						<?php if ($read_only === "true") { ?>
+						<?php if ($read_only === true) { ?>
 							<li class="units-table-row-action shortcut-l" data-key-action="href">
 								<a
 									class="units-table-row-action-link"

--- a/web/templates/pages/list_mail_acc.php
+++ b/web/templates/pages/list_mail_acc.php
@@ -11,7 +11,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 			<a class="button button-secondary button-back js-button-back" href="/list/mail/">
 				<i class="fas fa-arrow-left icon-blue"></i><?= tohtml( _("Back")) ?>
 			</a>
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/mail/?<?= tohtml(http_build_query(["domain" => $_GET["domain"]])) ?>" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Mail Account")) ?>
 				</a>
@@ -43,7 +43,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 						<span class="name"><?= tohtml( _("Quota")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/mail/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<input type="hidden" value="<?= tohtml($_GET["domain"]) ?>" name="domain">
@@ -166,7 +166,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 				</div>
 				<div class="units-table-cell units-table-heading-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Name")) ?>:</span>
-					<?php if ($read_only === "true" || $data[$key]["SUSPENDED"] == "yes") { ?>
+					<?php if ($read_only === true || $data[$key]["SUSPENDED"] == "yes") { ?>
 						<?= tohtml($key . "@" . $_GET["domain"]) ?>
 					<?php } else { ?>
 						<a href="/edit/mail/?<?= tohtml(http_build_query(["domain" => $_GET['domain'], "account" => $key, "token" => $_SESSION['token']])) ?>" title="<?= tohtml( _("Edit Mail Account")) ?>: <?= tohtml($key) ?>@<?= tohtml($_GET['domain']) ?>">
@@ -176,7 +176,7 @@ if (!empty($_SESSION["WEBMAIL_ALIAS"])) {
 				</div>
 				<div class="units-table-cell">
 					<ul class="units-table-row-actions">
-						<?php if ($read_only === "true") { ?>
+						<?php if ($read_only === true) { ?>
 							<!-- Restrict the ability to edit, delete, or suspend domain items when impersonating 'admin' account -->
 							<?php if ($data[$key]["SUSPENDED"] != "yes") { ?>
 								<li class="units-table-row-action" data-key-action="href">

--- a/web/templates/pages/list_search.php
+++ b/web/templates/pages/list_search.php
@@ -86,7 +86,7 @@
 				data-sort-type="<?= tohtml( _($object)) ?>"
 				data-sort-owner="<?= tohtml($value["USER"]) ?>"
 				data-sort-status="<?= tohtml($status) ?>"
-				style="<?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value['USER']) === 'admin') { echo 'display: none;'; } ?>">
+				style="<?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value['USER']) === $_SESSION['ROOT_USER']) { echo 'display: none;'; } ?>">
 				<div class="units-table-cell u-text-center-desktop">
 					<?php
 						if ($object === 'web domain') {
@@ -146,7 +146,7 @@
 						$edit_lnk = "/edit/" . rawurlencode($value["TYPE"]) . "/?" . http_build_query($edit_query);
 					?>
 					<?php
-						if (($_SESSION['userContext'] === 'admin') && ($_SESSION['user'] !== 'admin') && ($value['USER'] === 'admin') && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {
+						if (($_SESSION['userContext'] === 'admin') && ($_SESSION['user'] !== $_SESSION['ROOT_USER']) && ($value['USER'] === $_SESSION['ROOT_USER']) && ($_SESSION['POLICY_SYSTEM_PROTECTED_ADMIN'] === 'yes')) {
 							echo tohtml($value["RESULT"]);
 						} else {
 							if ($value["USER"] == $_SESSION["user"]) {
@@ -173,7 +173,7 @@
 					<a href="/search/?<?= tohtml(http_build_query(["q" => $_GET["q"], "u" => $value["USER"], "token" => $_SESSION["token"]])) ?>">
 						<?= tohtml($value["USER"]) ?>
 					</a>
-					<?php if (!($_SESSION["POLICY_SYSTEM_HIDE_ADMIN"] === "yes" && $value["USER"] !== "admin") && $_SESSION["userContext"] === "admin") { ?>
+					<?php if (!($_SESSION["POLICY_SYSTEM_HIDE_ADMIN"] === "yes" && $value["USER"] === $_SESSION["ROOT_USER"]) && $_SESSION["userContext"] === "admin") { ?>
 						<a href="/login/?<?= tohtml(http_build_query(["loginas" => $value["USER"], "token" => $_SESSION["token"]])) ?>" title="<?= tohtml( _("Log in as")) ?> <?= tohtml($value["USER"]) ?>" class="u-ml5">
 							<i class="fas fa-right-to-bracket icon-green icon-dim"></i>
 							<span class="u-hidden-visually"><?= tohtml( _("Log in as")) ?> <?= tohtml($value["USER"]) ?></span>

--- a/web/templates/pages/list_stats.php
+++ b/web/templates/pages/list_stats.php
@@ -14,7 +14,7 @@
 						<option value=""><?= tohtml( _("Show Per User")) ?></option>
 						<?php
 							foreach ($users as $key => $value) {
-								if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value === 'admin')) {
+								if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($value === $_SESSION['ROOT_USER'])) {
 									// Hide admin user from statistics list
 								} else {
 								echo "\t\t\t\t<option value=\"".$value."\"";

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -190,7 +190,7 @@
 							<li class="units-table-row-action shortcut-enter" data-key-action="href">
 								<a
 									class="units-table-row-action-link"
-									href="/login/?<?= tohtml(http_build_query(["loginas" => $key, "token" => $_SESSION["token"], "edit_link" => "/edit/user/"])) ?>"
+									href="/login/?<?= tohtml(http_build_query(["loginas" => $key, "token" => $_SESSION["token"], "edit_link" => "/edit/user"])) ?>"
 									title="<?= tohtml( _("Edit User")) ?>"
 								>
 									<i class="fas fa-pencil icon-orange"></i>

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -190,7 +190,7 @@
 							<li class="units-table-row-action shortcut-enter" data-key-action="href">
 								<a
 									class="units-table-row-action-link"
-									href="/login/?<?= tohtml(http_build_query(["loginas" => $key, "token" => $_SESSION["token"], "edit_link" => "/edit/user"])) ?>"
+									href="/login/?<?= tohtml(http_build_query(["loginas" => $key, "token" => $_SESSION["token"], "edit_link" => "/edit/user/"])) ?>"
 									title="<?= tohtml( _("Edit User")) ?>"
 								>
 									<i class="fas fa-pencil icon-orange"></i>

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -133,7 +133,7 @@
 					$spnd_confirmation = _('Are you sure you want to suspend user %s?');
 				}
 			?>
-			<div class="units-table-row <?php if ($status == 'suspended') echo 'disabled'; ?> js-unit <?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($_SESSION['user'] !== $_SESSION['ROOT_USER']) && ($key === 'admin')) { echo 'u-hidden'; } ?>"
+			<div class="units-table-row <?php if ($status == 'suspended') echo 'disabled'; ?> js-unit <?php if (($_SESSION['POLICY_SYSTEM_HIDE_ADMIN'] === 'yes') && ($_SESSION['user'] !== $_SESSION['ROOT_USER']) && ($key === $_SESSION['ROOT_USER'])) { echo 'u-hidden'; } ?>"
 				data-sort-date="<?= tohtml(strtotime($data[$key]['DATE'].' '.$data[$key]['TIME'])) ?>"
 				data-sort-name="<?= tohtml(strtolower($key)) ?>"
 				data-sort-package="<?= tohtml(strtolower($data[$key]['PACKAGE'])) ?>"

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -190,7 +190,7 @@
 							<li class="units-table-row-action shortcut-enter" data-key-action="href">
 								<a
 									class="units-table-row-action-link"
-									href="/edit/user/?<?= tohtml(http_build_query(["user" => $key, "token" => $_SESSION["token"]])) ?>"
+									href="/login/?<?= tohtml(http_build_query(["loginas" => $key, "token" => $_SESSION["token"], "edit_link" => "/edit/user/"])) ?>"
 									title="<?= tohtml( _("Edit User")) ?>"
 								>
 									<i class="fas fa-pencil icon-orange"></i>

--- a/web/templates/pages/list_user.php
+++ b/web/templates/pages/list_user.php
@@ -148,7 +148,7 @@
 				<div class="units-table-cell units-table-heading-cell">
 					<span class="u-hide-desktop u-text-bold"><?= tohtml( _("Name")) ?>:</span>
 					<?php if ($key == $user_plain) { ?>
-						<a href="/edit/user/?<?= tohtml(http_build_query(["user" => $key, "token" => $_SESSION["token"]])) ?>" title="<?= tohtml( _("Edit User")) ?>">
+						<a href="/edit/user/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>" title="<?= tohtml( _("Edit User")) ?>">
 							<span class="u-text-bold">
 								<?= tohtml($key) ?>
 							</span>
@@ -187,7 +187,19 @@
 							</li>
 						<?php } ?>
 						<?php if (!($_SESSION["userContext"] === "admin" && $key == $_SESSION['ROOT_USER'] && $_SESSION["user"] != $_SESSION['ROOT_USER'])) { ?>
+							<?php if ($key == $user_plain) { ?>
 							<li class="units-table-row-action shortcut-enter" data-key-action="href">
+								<a
+									class="units-table-row-action-link"
+									href="/edit/user/?<?= tohtml(http_build_query(["token" => $_SESSION["token"]])) ?>"
+									title="<?= tohtml( _("Edit User")) ?>"
+								>
+									<i class="fas fa-pencil icon-orange"></i>
+									<span class="u-hide-desktop"><?= tohtml( _("Edit User")) ?></span>
+								</a>
+							</li>
+							<?php } else { ?>
+<li class="units-table-row-action shortcut-enter" data-key-action="href">
 								<a
 									class="units-table-row-action-link"
 									href="/login/?<?= tohtml(http_build_query(["loginas" => $key, "token" => $_SESSION["token"], "edit_link" => "/edit/user/"])) ?>"
@@ -197,6 +209,7 @@
 									<span class="u-hide-desktop"><?= tohtml( _("Edit User")) ?></span>
 								</a>
 							</li>
+							<?php } ?>
 						<?php } ?>
 						<?php if (!($key == $_SESSION['ROOT_USER'] || $key == $user_plain)) { ?>
 							<li class="units-table-row-action shortcut-s" data-key-action="js">

--- a/web/templates/pages/list_web.php
+++ b/web/templates/pages/list_web.php
@@ -2,7 +2,7 @@
 <div class="toolbar">
 	<div class="toolbar-inner">
 		<div class="toolbar-buttons">
-			<?php if ($read_only !== "true") { ?>
+			<?php if ($read_only !== true) { ?>
 				<a href="/add/web/" class="button button-secondary js-button-create">
 					<i class="fas fa-circle-plus icon-green"></i><?= tohtml( _("Add Web Domain")) ?>
 				</a>
@@ -34,7 +34,7 @@
 						<span class="name"><?= tohtml( _("IP Address")) ?> <i class="fas fa-arrow-down-a-z"></i></span><span class="up"><i class="fas fa-arrow-up-a-z"></i></span>
 					</li>
 				</ul>
-				<?php if ($read_only !== "true") { ?>
+				<?php if ($read_only !== true) { ?>
 					<form x-data x-bind="BulkEdit" action="/bulk/web/" method="post">
 						<input type="hidden" name="token" value="<?= tohtml($_SESSION["token"]) ?>">
 						<select class="form-select" name="action">
@@ -202,7 +202,7 @@
 				</div>
 				<div class="units-table-cell units-table-heading-cell u-text-bold">
 					<span class="u-hide-desktop"><?= tohtml( _("Name")) ?>:</span>
-					<?php if ($read_only === "true") { ?>
+					<?php if ($read_only === true) { ?>
 						<?= tohtml($key) ?>
 					<?php } else {
 						$aliases = explode(',', $data[$key]['ALIAS']);
@@ -252,7 +252,7 @@
 								<span class="u-hide-desktop"><?= tohtml( _("Visit")) ?></span>
 							</a>
 						</li>
-						<?php if ($read_only !== "true") { ?>
+						<?php if ($read_only !== true) { ?>
 							<?php if ($data[$key]["SUSPENDED"] == "no") { ?>
 								<li class="units-table-row-action shortcut-enter" data-key-action="href">
 									<a

--- a/web/unsuspend/cron/index.php
+++ b/web/unsuspend/cron/index.php
@@ -9,6 +9,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/cron/");
+	exit();
+}
+
 if (!empty($_GET["job"])) {
 	$v_job = quoteshellarg($_GET["job"]);
 	exec(HESTIA_CMD . "v-unsuspend-cron-job " . $user . " " . $v_job, $output, $return_var);

--- a/web/unsuspend/db/index.php
+++ b/web/unsuspend/db/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/db/");
+	exit();
+}
+
 if (!empty($_GET["database"])) {
 	$v_database = quoteshellarg($_GET["database"]);
 	exec(HESTIA_CMD . "v-unsuspend-database " . $user . " " . $v_database, $output, $return_var);

--- a/web/unsuspend/dns/index.php
+++ b/web/unsuspend/dns/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/dns/");
+	exit();
+}
+
 // DNS domain
 if (!empty($_GET["domain"]) && empty($_GET["record_id"])) {
 	$v_domain = quoteshellarg($_GET["domain"]);

--- a/web/unsuspend/mail/index.php
+++ b/web/unsuspend/mail/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/mail/");
+	exit();
+}
+
 // Mail domain
 if (!empty($_GET["domain"]) && empty($_GET["account"])) {
 	$v_domain = quoteshellarg($_GET["domain"]);

--- a/web/unsuspend/user/index.php
+++ b/web/unsuspend/user/index.php
@@ -15,6 +15,11 @@ if ($_SESSION["userContext"] != "admin") {
 	exit();
 }
 
+if ($read_only === true) {
+	header("Location: /list/user/");
+	exit();
+}
+
 if (!empty($_GET["user"])) {
 	$v_username = quoteshellarg($_GET["user"]);
 	exec(HESTIA_CMD . "v-unsuspend-user " . $v_username, $output, $return_var);

--- a/web/unsuspend/web/index.php
+++ b/web/unsuspend/web/index.php
@@ -8,6 +8,11 @@ include $_SERVER["DOCUMENT_ROOT"] . "/inc/main.php";
 // Check token
 verify_csrf($_GET);
 
+if ($read_only === true) {
+	header("Location: /list/web/");
+	exit();
+}
+
 if (!empty($_GET["domain"])) {
 	$v_domain = quoteshellarg($_GET["domain"]);
 	exec(HESTIA_CMD . "v-unsuspend-domain " . $user . " " . $v_domain, $output, $return_var);


### PR DESCRIPTION
### Summary
Enhances the read-only mode across the control panel to consistently prevent write operations when active. This addresses previous bypass opportunities and standardizes its application.

### Changes
*   Adds explicit `$read_only !== true` conditions to all 'add' and 'edit' form submissions, ensuring no data modification is possible when in read-only mode.
*   Implements early redirects for 'bulk', 'delete', 'suspend', 'unsuspend', and 'schedule' actions, blocking them entirely if read-only mode is enabled.
*   Standardizes the `$read_only` variable to a boolean type (`true`/`false`) for improved consistency and type safety.
*   Adjusts template logic in various list pages to correctly reflect the read-only state and disable or hide relevant action buttons.
*   Refines policy file inclusion in `main.php` to only load when a user context exists, and removes redundant policy loading in `render_page`.
*   Includes a minor typo fix in the user addition process (`errors[]` instead of `errrors[]`).
