### PR TITLE
docs: add index.php fix for /phpmyadmin/ 404 on IP access

### DIFF
--- a/docs/docs/server-administration/databases.md
+++ b/docs/docs/server-administration/databases.md
@@ -83,9 +83,9 @@ Add `index index.php;` after the `alias` line inside the `location /phpmyadmin {
 
 ```nginx
 location /phpmyadmin {
-    alias /usr/share/phpmyadmin/;
-    index index.php;
-    ...
+	alias /usr/share/phpmyadmin/;
+	index index.php;
+	...
 }
 ```
 

--- a/docs/docs/server-administration/databases.md
+++ b/docs/docs/server-administration/databases.md
@@ -71,6 +71,30 @@ include     /etc/nginx/conf.d/phpmyadmin.inc*;
 include     /etc/nginx/conf.d/phppgadmin.inc*;
 ```
 
+### Note: If /phpmyadmin/ shows "Page Not Found" (404)
+
+If accessing `http://ip/phpmyadmin/` (without `index.php`) returns a 404 after applying the fix above, add an `index` directive to the phpmyadmin include:
+
+```bash
+nano /etc/nginx/conf.d/phpmyadmin.inc
+```
+
+Add `index index.php;` after the `alias` line inside the `location /phpmyadmin { ... }` block:
+
+```nginx
+location /phpmyadmin {
+    alias /usr/share/phpmyadmin/;
+    index index.php;
+    ...
+}
+```
+
+Then test and reload:
+
+```bash
+nginx -t && systemctl reload nginx
+```
+
 ## How can I connect from a remote location to the database
 
 By default, connections to port 3306 are disabled in the firewall. Open


### PR DESCRIPTION
Context: Followed the existing "How can I enable access to http://ip/phpmyadmin/" doc section to fix an Access Denied (403) issue. After applying the documented Nginx include fix, http://ip/phpmyadmin/index.php worked correctly, but the bare http://ip/phpmyadmin/ (without index.php) still returned a 404, since the include's location /phpmyadmin block has no index directive.

This PR adds a short note + the index index.php; fix so others hitting the same follow-up 404 don't get stuck after following the existing steps.

Tested on: Ubuntu 24.04, HestiaCP (Nginx-only, multiphp), confirmed /phpmyadmin/ loads correctly after the fix.