### PR TITLE
fix: restore all objects on full restic restore and correct cron binary name

### DIFF
--- a/bin/v-restore-user-restic
+++ b/bin/v-restore-user-restic
@@ -13,13 +13,13 @@
 # Argument definition
 user=$1
 snapshot=$2
-web=$3
-dns=$4
-mail=$5
-db=$6
-cron=$7
-udir=${8-yes}
-notify=${9-no}
+web=${3:-*}
+dns=${4:-*}
+mail=${5:-*}
+db=${6:-*}
+cron=${7:-yes}
+udir=${8:-yes}
+notify=${9:-no}
 
 # Includes
 # shellcheck source=/etc/hestiacp/hestia.conf
@@ -41,8 +41,8 @@ source_conf "$HESTIA/conf/hestia.conf"
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-args_usage='USER SNAPSHOT KEY [NOTIFY]'
-check_args '3' "$#" "$args_usage"
+args_usage='USER SNAPSHOT [WEB] [DNS] [MAIL] [DB] [CRON] [UDIR] [NOTIFY]'
+check_args '2' "$#" "$args_usage"
 is_format_valid 'user'
 is_object_valid 'user' 'USER' "$user"
 

--- a/bin/v-schedule-user-restore-restic
+++ b/bin/v-schedule-user-restore-restic
@@ -54,7 +54,7 @@ fi
 rm -fr "$tmpdir"
 
 if [ -z "$object" ]; then
-	echo "$BIN/v-restore-user-restic '$user' '$snapshot' '' '' '' '' '' '' 'yes' >> $log 2>&1" >> $HESTIA/data/queue/backup.pipe
+	echo "$BIN/v-restore-user-restic '$user' '$snapshot' '*' '*' '*' '*' 'yes' 'yes' 'yes' >> $log 2>&1" >> $HESTIA/data/queue/backup.pipe
 else
 	if [ "$object" = "web" ]; then
 		echo "$BIN/v-restore-web-domain-restic '$user' '$snapshot' '$value' 'yes' >> $log 2>&1" >> $HESTIA/data/queue/backup.pipe
@@ -65,7 +65,7 @@ else
 	elif [ "$object" = "db" ]; then
 		echo "$BIN/v-restore-database-restic '$user' '$snapshot' '$value' 'yes' >> $log 2>&1" >> $HESTIA/data/queue/backup.pipe
 	elif [ "$object" = "cron" ]; then
-		echo "$BIN/v-restore-cron-restic '$user' '$snapshot' 'yes' >> $log 2>&1" >> $HESTIA/data/queue/backup.pipe
+		echo "$BIN/v-restore-cron-job-restic '$user' '$snapshot' 'yes' >> $log 2>&1" >> $HESTIA/data/queue/backup.pipe
 	else
 		check_result "$E_INVALID" "Not supported"
 	fi


### PR DESCRIPTION
## What

1. In `bin/v-schedule-user-restore-restic`, when scheduling a full user restore (`$object` is empty), pass `'*'` for `web`, `dns`, `mail`, `db` and `'yes'` for `cron` and `udir`, instead of empty strings `''`.
2. In `bin/v-schedule-user-restore-restic`, fix the binary name for restoring cron jobs from `v-restore-cron-restic` to `v-restore-cron-job-restic`.
3. In `bin/v-restore-user-restic`, add fallback parameter expansions (`web=${3:-*}`, `dns=${4:-*}`, `mail=${5:-*}`, `db=${6:-*}`, `cron=${7:-yes}`, `udir=${8:-yes}`) so that omitted or empty arguments safely default to restoring all objects.
4. In `bin/v-restore-user-restic`, update `check_args '2'` (was `'3'`) and `args_usage` to match the documented CLI example (`v-restore-user-restic user snapshot`).

## Why

### 1. Full user restore via restic was a silent no-op
When a full user restore is scheduled from the Web UI ("Restore All") or via `v-schedule-user-restore-restic $user $snapshot`, line 57 queued:
```bash
$BIN/v-restore-user-restic '$user' '$snapshot' '' '' '' '' '' '' 'yes'
```
- In child restore scripts (`v-restore-web-domain-restic`, `v-restore-mail-domain-restic`, `v-restore-database-restic`, `v-restore-dns-domain-restic`), domain/db matching is checked with:
  `if [[ ",$web," == *",$domain,"* || "$web" = '*' ]]`
  Passing `''` matches zero items, so web, dns, mail, and database restores do nothing.
- In `v-restore-user-restic`:
  - `udir=${8-yes}`: passing `''` assigns `udir=""` (because the 8th argument is set, though empty). The condition `if [ "$udir" = "yes" ]` evaluates to false, completely skipping user files.
  - `cron`: `if [ -n "$cron" ]` evaluates to false, skipping cron jobs.

Passing `'*' '*' '*' '*' 'yes' 'yes' 'yes'` ensures that all web domains, DNS zones, mail domains, databases, cron jobs, and user directories are restored.

### 2. Typo in cron restore binary name
Line 68 calls `$BIN/v-restore-cron-restic '$user' '$snapshot' 'yes'`, which does not exist in HestiaCP (404). The implemented binary is `v-restore-cron-job-restic`.

### 3. CLI usage failed on its own documentation example
Line 5 of `bin/v-restore-user-restic` documents:
```bash
# example: v-restore-user-restic user snapshot
```
However, line 45 required 3 arguments (`check_args '3'`), failing when invoked as documented. Lowering the minimum argument check to 2 and setting default parameter expansions (`${3:-*}`) allows `v-restore-user-restic user snapshot` to work directly from the CLI.

Closes #4905.

## How to test

1. Create a restic snapshot for a user with web domains, databases, and mail domains.
2. In HestiaCP Web UI, navigate to Backups -> select snapshot -> click "Restore All".
3. Verify `/usr/local/hestia/log/restore.log`: all web domains, databases, mail domains, cron jobs, and home directory files are restored instead of being silently skipped.
4. Test single cron restore: trigger a cron restoration job and verify it invokes `v-restore-cron-job-restic`.
5. Test CLI: `v-restore-user-restic <user> <snapshot>` restores all components.

`bash -n` passes for both scripts.
