### PR TITLE
Fix v-unsuspend-user

### DIFF
--- a/bin/v-unsuspend-user
+++ b/bin/v-unsuspend-user
@@ -41,7 +41,7 @@ check_hestia_demo_mode
 #----------------------------------------------------------#
 
 # Do not restrict access to SFTP/FTP/SSH if POLICY_USER_VIEW_SUSPENDED is set to yes
-if [ -z "$POLICY_USER_VIEW_SUSPENDED" ] || [ "$POLICY_USER_VIEW_SUSPENDED" = 'no' ]; then
+if [ -z "$POLICY_USER_VIEW_SUSPENDED" ] || [ "$POLICY_USER_VIEW_SUSPENDED" != 'yes' ]; then
 	# Deleting '!' in front of the password
 	/usr/sbin/usermod --unlock $user
 


### PR DESCRIPTION
The script is not unlocking the user because it checks whether `POLICY_USER_VIEW_SUSPENDED` is set to `no`, but for some reason it is set to `false` instead (I haven't found the reason yet).

The `v-suspend-user` script, instead of checking whether `POLICY_USER_VIEW_SUSPENDED` is set to `no`, checks whether it is not set to `yes`. This commit adds the same comparison.

This PR must be merged before PR #5710 or the bats test will fail.